### PR TITLE
feat(#7): list_pull_requests + load_pull_request

### DIFF
--- a/crates/core/src/application/mod.rs
+++ b/crates/core/src/application/mod.rs
@@ -1,1 +1,2 @@
+pub mod pull_requests;
 pub mod repo_selection;

--- a/crates/core/src/application/pull_requests/list.rs
+++ b/crates/core/src/application/pull_requests/list.rs
@@ -1,0 +1,11 @@
+use crate::domain::PullRequestSummary;
+use crate::AppResult;
+
+use super::PullRequests;
+
+pub async fn list_pull_requests(
+    svc: &PullRequests,
+    repo_path: &str,
+) -> AppResult<Vec<PullRequestSummary>> {
+    svc.gh.list_pull_requests(repo_path).await
+}

--- a/crates/core/src/application/pull_requests/load.rs
+++ b/crates/core/src/application/pull_requests/load.rs
@@ -1,0 +1,12 @@
+use crate::domain::PullRequestDetail;
+use crate::AppResult;
+
+use super::PullRequests;
+
+pub async fn load_pull_request(
+    svc: &PullRequests,
+    repo_path: &str,
+    number: u64,
+) -> AppResult<PullRequestDetail> {
+    svc.gh.load_pull_request(repo_path, number).await
+}

--- a/crates/core/src/application/pull_requests/mod.rs
+++ b/crates/core/src/application/pull_requests/mod.rs
@@ -1,0 +1,12 @@
+pub mod list;
+pub mod load;
+
+use std::sync::Arc;
+
+use crate::ports::GhClient;
+
+/// Bundles ports needed by the pull-requests use cases.
+#[derive(Clone)]
+pub struct PullRequests {
+    pub gh: Arc<dyn GhClient>,
+}

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -1,5 +1,7 @@
+pub mod pull_request;
 pub mod repository;
 pub mod tool_status;
 
+pub use pull_request::{PullRequestDetail, PullRequestState, PullRequestSummary};
 pub use repository::{RemoteUrl, Repository};
 pub use tool_status::{ToolCheck, ToolStatus};

--- a/crates/core/src/domain/pull_request.rs
+++ b/crates/core/src/domain/pull_request.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PullRequestState {
+    Open,
+    Closed,
+    Merged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestSummary {
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub base_ref: String,
+    pub head_ref: String,
+    pub state: PullRequestState,
+    pub is_draft: bool,
+    pub updated_at: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PullRequestDetail {
+    pub summary: PullRequestSummary,
+    pub body: Option<String>,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub additions: u32,
+    pub deletions: u32,
+    pub changed_files: u32,
+}

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+use crate::domain::{PullRequestDetail, PullRequestSummary};
 use crate::AppResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -16,4 +17,7 @@ pub struct GhAuthReport {
 pub trait GhClient: Send + Sync {
     async fn version(&self) -> AppResult<String>;
     async fn auth_status(&self) -> AppResult<GhAuthReport>;
+    async fn list_pull_requests(&self, repo_path: &str) -> AppResult<Vec<PullRequestSummary>>;
+    async fn load_pull_request(&self, repo_path: &str, number: u64)
+        -> AppResult<PullRequestDetail>;
 }

--- a/crates/core/tests/pull_requests.rs
+++ b/crates/core/tests/pull_requests.rs
@@ -1,0 +1,127 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::pull_requests::{
+    list::list_pull_requests, load::load_pull_request, PullRequests,
+};
+use markdown_reviewer_core::domain::{PullRequestDetail, PullRequestState, PullRequestSummary};
+use markdown_reviewer_core::ports::{GhAuthReport, GhClient};
+use markdown_reviewer_core::{AppError, AppResult};
+
+struct FakeGh {
+    summaries: Vec<PullRequestSummary>,
+    detail: Option<PullRequestDetail>,
+    auth_error: Option<AppError>,
+}
+
+impl FakeGh {
+    fn new(summaries: Vec<PullRequestSummary>, detail: Option<PullRequestDetail>) -> Self {
+        Self {
+            summaries,
+            detail,
+            auth_error: None,
+        }
+    }
+}
+
+#[async_trait]
+impl GhClient for FakeGh {
+    async fn version(&self) -> AppResult<String> {
+        Ok("gh 2.50.0".into())
+    }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> {
+        Ok(GhAuthReport {
+            authenticated: true,
+            username: Some("octocat".into()),
+            detail: String::new(),
+        })
+    }
+    async fn list_pull_requests(&self, _repo_path: &str) -> AppResult<Vec<PullRequestSummary>> {
+        if let Some(err) = &self.auth_error {
+            return Err(err.clone());
+        }
+        Ok(self.summaries.clone())
+    }
+    async fn load_pull_request(
+        &self,
+        _repo_path: &str,
+        number: u64,
+    ) -> AppResult<PullRequestDetail> {
+        if let Some(err) = &self.auth_error {
+            return Err(err.clone());
+        }
+        match &self.detail {
+            Some(d) if d.summary.number == number => Ok(d.clone()),
+            _ => Err(AppError::PrNotFound { number }),
+        }
+    }
+}
+
+fn summary(number: u64, title: &str) -> PullRequestSummary {
+    PullRequestSummary {
+        number,
+        title: title.into(),
+        author: "octocat".into(),
+        base_ref: "main".into(),
+        head_ref: format!("feature/{number}"),
+        state: PullRequestState::Open,
+        is_draft: false,
+        updated_at: "2026-04-24T10:00:00Z".into(),
+        url: format!("https://github.com/o/r/pull/{number}"),
+    }
+}
+
+fn svc_with(gh: FakeGh) -> PullRequests {
+    PullRequests { gh: Arc::new(gh) }
+}
+
+#[tokio::test]
+async fn list_returns_empty_vec() {
+    let svc = svc_with(FakeGh::new(vec![], None));
+    let prs = list_pull_requests(&svc, "/repo").await.unwrap();
+    assert!(prs.is_empty());
+}
+
+#[tokio::test]
+async fn list_preserves_order() {
+    let svc = svc_with(FakeGh::new(
+        vec![summary(7, "first"), summary(3, "second")],
+        None,
+    ));
+    let prs = list_pull_requests(&svc, "/repo").await.unwrap();
+    assert_eq!(prs.len(), 2);
+    assert_eq!(prs[0].number, 7);
+    assert_eq!(prs[1].number, 3);
+}
+
+#[tokio::test]
+async fn list_propagates_auth_error() {
+    let mut gh = FakeGh::new(vec![], None);
+    gh.auth_error = Some(AppError::GhNotAuthenticated);
+    let svc = svc_with(gh);
+    let err = list_pull_requests(&svc, "/repo").await.unwrap_err();
+    assert!(matches!(err, AppError::GhNotAuthenticated));
+}
+
+#[tokio::test]
+async fn load_returns_detail() {
+    let detail = PullRequestDetail {
+        summary: summary(42, "the answer"),
+        body: Some("hello".into()),
+        head_sha: "deadbeef".into(),
+        base_sha: "cafebabe".into(),
+        additions: 10,
+        deletions: 2,
+        changed_files: 3,
+    };
+    let svc = svc_with(FakeGh::new(vec![], Some(detail.clone())));
+    let got = load_pull_request(&svc, "/repo", 42).await.unwrap();
+    assert_eq!(got, detail);
+}
+
+#[tokio::test]
+async fn load_missing_returns_pr_not_found() {
+    let svc = svc_with(FakeGh::new(vec![], None));
+    let err = load_pull_request(&svc, "/repo", 99).await.unwrap_err();
+    assert!(matches!(err, AppError::PrNotFound { number: 99 }));
+}

--- a/crates/core/tests/repo_selection.rs
+++ b/crates/core/tests/repo_selection.rs
@@ -64,6 +64,20 @@ impl GhClient for FakeGh {
             detail: String::new(),
         })
     }
+    async fn list_pull_requests(
+        &self,
+        _repo_path: &str,
+    ) -> markdown_reviewer_core::AppResult<Vec<markdown_reviewer_core::domain::PullRequestSummary>>
+    {
+        Ok(Vec::new())
+    }
+    async fn load_pull_request(
+        &self,
+        _repo_path: &str,
+        number: u64,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::PullRequestDetail> {
+        Err(AppError::PrNotFound { number })
+    }
 }
 
 #[derive(Default)]

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -1,13 +1,98 @@
 use async_trait::async_trait;
+use markdown_reviewer_core::domain::{PullRequestDetail, PullRequestState, PullRequestSummary};
 use markdown_reviewer_core::ports::{GhAuthReport, GhClient};
 use markdown_reviewer_core::{AppError, AppResult};
+use serde::Deserialize;
 
 use crate::process::{run, run_ok};
 
 const TIMEOUT_MS: u64 = 7_000;
+const PR_TIMEOUT_MS: u64 = 15_000;
+const PR_LIST_LIMIT: &str = "50";
+
+const SUMMARY_FIELDS: &str =
+    "number,title,author,baseRefName,headRefName,state,isDraft,updatedAt,url";
+const DETAIL_FIELDS: &str = "number,title,author,baseRefName,headRefName,state,isDraft,updatedAt,url,body,headRefOid,baseRefOid,additions,deletions,changedFiles";
 
 #[derive(Debug, Default, Clone)]
 pub struct GhCli;
+
+#[derive(Debug, Deserialize)]
+struct GhAuthor {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhSummary {
+    number: u64,
+    title: String,
+    #[serde(default)]
+    author: Option<GhAuthor>,
+    base_ref_name: String,
+    head_ref_name: String,
+    state: String,
+    #[serde(default)]
+    is_draft: bool,
+    updated_at: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhDetail {
+    #[serde(flatten)]
+    summary: GhSummary,
+    #[serde(default)]
+    body: Option<String>,
+    head_ref_oid: String,
+    base_ref_oid: String,
+    additions: u32,
+    deletions: u32,
+    changed_files: u32,
+}
+
+fn parse_state(raw: &str) -> PullRequestState {
+    match raw.to_ascii_uppercase().as_str() {
+        "MERGED" => PullRequestState::Merged,
+        "CLOSED" => PullRequestState::Closed,
+        _ => PullRequestState::Open,
+    }
+}
+
+fn into_summary(g: GhSummary) -> PullRequestSummary {
+    PullRequestSummary {
+        number: g.number,
+        title: g.title,
+        author: g
+            .author
+            .and_then(|a| a.login)
+            .unwrap_or_else(|| "ghost".into()),
+        base_ref: g.base_ref_name,
+        head_ref: g.head_ref_name,
+        state: parse_state(&g.state),
+        is_draft: g.is_draft,
+        updated_at: g.updated_at,
+        url: g.url,
+    }
+}
+
+fn map_gh_error(stderr: &str, number: Option<u64>) -> AppError {
+    let lower = stderr.to_ascii_lowercase();
+    if let Some(n) = number {
+        if lower.contains("could not resolve to a pullrequest")
+            || lower.contains("no pull requests found")
+            || lower.contains("not found")
+        {
+            return AppError::PrNotFound { number: n };
+        }
+    }
+    if lower.contains("authentication required") || lower.contains("gh auth login") {
+        return AppError::GhNotAuthenticated;
+    }
+    AppError::process(stderr.trim().to_string())
+}
 
 #[async_trait]
 impl GhClient for GhCli {
@@ -43,6 +128,64 @@ impl GhClient for GhCli {
             authenticated,
             username,
             detail: text.trim().to_string(),
+        })
+    }
+
+    async fn list_pull_requests(&self, repo_path: &str) -> AppResult<Vec<PullRequestSummary>> {
+        let out = run(
+            "gh",
+            &[
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                PR_LIST_LIMIT,
+                "--json",
+                SUMMARY_FIELDS,
+            ],
+            Some(repo_path),
+            PR_TIMEOUT_MS,
+        )
+        .await?;
+
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, None));
+        }
+
+        let parsed: Vec<GhSummary> = serde_json::from_str(out.stdout.trim())
+            .map_err(|e| AppError::process(format!("gh pr list: invalid JSON: {e}")))?;
+        Ok(parsed.into_iter().map(into_summary).collect())
+    }
+
+    async fn load_pull_request(
+        &self,
+        repo_path: &str,
+        number: u64,
+    ) -> AppResult<PullRequestDetail> {
+        let number_str = number.to_string();
+        let out = run(
+            "gh",
+            &["pr", "view", &number_str, "--json", DETAIL_FIELDS],
+            Some(repo_path),
+            PR_TIMEOUT_MS,
+        )
+        .await?;
+
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, Some(number)));
+        }
+
+        let detail: GhDetail = serde_json::from_str(out.stdout.trim())
+            .map_err(|e| AppError::process(format!("gh pr view: invalid JSON: {e}")))?;
+        Ok(PullRequestDetail {
+            head_sha: detail.head_ref_oid.clone(),
+            base_sha: detail.base_ref_oid.clone(),
+            additions: detail.additions,
+            deletions: detail.deletions,
+            changed_files: detail.changed_files,
+            body: detail.body.clone(),
+            summary: into_summary(detail.summary),
         })
     }
 }

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -8,7 +8,9 @@ use crate::process::{run, run_ok};
 
 const TIMEOUT_MS: u64 = 7_000;
 const PR_TIMEOUT_MS: u64 = 15_000;
-const PR_LIST_LIMIT: &str = "50";
+// `gh pr list` defaults to 30; bump to a value high enough to cover the
+// largest realistic open-PR backlog without paginating ourselves.
+const PR_LIST_LIMIT: &str = "200";
 
 const SUMMARY_FIELDS: &str =
     "number,title,author,baseRefName,headRefName,state,isDraft,updatedAt,url";
@@ -54,10 +56,12 @@ struct GhDetail {
 }
 
 fn parse_state(raw: &str) -> PullRequestState {
-    match raw.to_ascii_uppercase().as_str() {
-        "MERGED" => PullRequestState::Merged,
-        "CLOSED" => PullRequestState::Closed,
-        _ => PullRequestState::Open,
+    if raw.eq_ignore_ascii_case("MERGED") {
+        PullRequestState::Merged
+    } else if raw.eq_ignore_ascii_case("CLOSED") {
+        PullRequestState::Closed
+    } else {
+        PullRequestState::Open
     }
 }
 
@@ -78,13 +82,17 @@ fn into_summary(g: GhSummary) -> PullRequestSummary {
     }
 }
 
+fn is_pr_not_found(stderr_lower: &str) -> bool {
+    stderr_lower.contains("could not resolve to a pullrequest")
+        || stderr_lower.contains("could not resolve to pullrequest")
+        || stderr_lower.contains("no pull requests found")
+        || stderr_lower.contains("no pull request found")
+}
+
 fn map_gh_error(stderr: &str, number: Option<u64>) -> AppError {
     let lower = stderr.to_ascii_lowercase();
     if let Some(n) = number {
-        if lower.contains("could not resolve to a pullrequest")
-            || lower.contains("no pull requests found")
-            || lower.contains("not found")
-        {
+        if is_pr_not_found(&lower) {
             return AppError::PrNotFound { number: n };
         }
     }
@@ -178,14 +186,23 @@ impl GhClient for GhCli {
 
         let detail: GhDetail = serde_json::from_str(out.stdout.trim())
             .map_err(|e| AppError::process(format!("gh pr view: invalid JSON: {e}")))?;
+        let GhDetail {
+            summary,
+            body,
+            head_ref_oid,
+            base_ref_oid,
+            additions,
+            deletions,
+            changed_files,
+        } = detail;
         Ok(PullRequestDetail {
-            head_sha: detail.head_ref_oid.clone(),
-            base_sha: detail.base_ref_oid.clone(),
-            additions: detail.additions,
-            deletions: detail.deletions,
-            changed_files: detail.changed_files,
-            body: detail.body.clone(),
-            summary: into_summary(detail.summary),
+            head_sha: head_ref_oid,
+            base_sha: base_ref_oid,
+            additions,
+            deletions,
+            changed_files,
+            body,
+            summary: into_summary(summary),
         })
     }
 }

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -4,7 +4,7 @@ use markdown_reviewer_core::ports::{GhAuthReport, GhClient};
 use markdown_reviewer_core::{AppError, AppResult};
 use serde::Deserialize;
 
-use crate::process::{run, run_ok};
+use crate::process::{redact, run, run_ok};
 
 const TIMEOUT_MS: u64 = 7_000;
 const PR_TIMEOUT_MS: u64 = 15_000;
@@ -99,7 +99,7 @@ fn map_gh_error(stderr: &str, number: Option<u64>) -> AppError {
     if lower.contains("authentication required") || lower.contains("gh auth login") {
         return AppError::GhNotAuthenticated;
     }
-    AppError::process(stderr.trim().to_string())
+    AppError::process(redact(stderr.trim()))
 }
 
 #[async_trait]

--- a/crates/infra/tests/phase1_e2e.rs
+++ b/crates/infra/tests/phase1_e2e.rs
@@ -34,6 +34,20 @@ impl GhClient for StubGh {
             detail: String::new(),
         })
     }
+    async fn list_pull_requests(
+        &self,
+        _repo_path: &str,
+    ) -> markdown_reviewer_core::AppResult<Vec<markdown_reviewer_core::domain::PullRequestSummary>>
+    {
+        Ok(Vec::new())
+    }
+    async fn load_pull_request(
+        &self,
+        _repo_path: &str,
+        number: u64,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::PullRequestDetail> {
+        Err(AppError::PrNotFound { number })
+    }
 }
 
 fn svc(db_dir: &std::path::Path, authed: bool) -> RepoSelection {

--- a/crates/ipc/src/commands/mod.rs
+++ b/crates/ipc/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod pull_requests;
 pub mod recents;
 pub mod repo;
 pub mod tools;

--- a/crates/ipc/src/commands/pull_requests.rs
+++ b/crates/ipc/src/commands/pull_requests.rs
@@ -1,0 +1,25 @@
+use markdown_reviewer_core::application::pull_requests::{
+    list::list_pull_requests as list_uc, load::load_pull_request as load_uc,
+};
+use markdown_reviewer_core::domain::{PullRequestDetail, PullRequestSummary};
+use markdown_reviewer_core::AppError;
+use tauri::State;
+
+use crate::state::AppState;
+
+#[tauri::command]
+pub async fn list_pull_requests(
+    state: State<'_, AppState>,
+    repo_path: String,
+) -> Result<Vec<PullRequestSummary>, AppError> {
+    list_uc(&state.pull_requests, &repo_path).await
+}
+
+#[tauri::command]
+pub async fn load_pull_request(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+) -> Result<PullRequestDetail, AppError> {
+    load_uc(&state.pull_requests, &repo_path, pr_number).await
+}

--- a/crates/ipc/src/commands/pull_requests.rs
+++ b/crates/ipc/src/commands/pull_requests.rs
@@ -7,7 +7,7 @@ use tauri::State;
 
 use crate::state::AppState;
 
-#[tauri::command]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn list_pull_requests(
     state: State<'_, AppState>,
     repo_path: String,
@@ -15,7 +15,7 @@ pub async fn list_pull_requests(
     list_uc(&state.pull_requests, &repo_path).await
 }
 
-#[tauri::command]
+#[tauri::command(rename_all = "camelCase")]
 pub async fn load_pull_request(
     state: State<'_, AppState>,
     repo_path: String,

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -6,7 +6,7 @@ pub use state::AppState;
 
 use tauri::{generate_handler, Runtime};
 
-/// Registers every Phase 1 command handler.
+/// Registers every command handler exposed to the `WebView`.
 pub fn register<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
     builder.invoke_handler(generate_handler![
         commands::tools::check_tools,
@@ -15,5 +15,7 @@ pub fn register<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
         commands::recents::list_recent_repositories,
         commands::recents::add_recent_repository,
         commands::recents::remove_recent_repository,
+        commands::pull_requests::list_pull_requests,
+        commands::pull_requests::load_pull_request,
     ])
 }

--- a/crates/ipc/src/state.rs
+++ b/crates/ipc/src/state.rs
@@ -1,8 +1,10 @@
+use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
 
-/// Tauri managed state. Clone-on-access: all members are `Arc`-wrapped inside
-/// `RepoSelection`, so cloning is cheap.
+/// Tauri managed state. Clone-on-access: every member is `Arc`-wrapped inside
+/// the use-case bundles, so cloning is cheap.
 #[derive(Clone)]
 pub struct AppState {
     pub repo_selection: RepoSelection,
+    pub pull_requests: PullRequests,
 }

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
 use markdown_reviewer_infra::{
     logging,
@@ -27,13 +28,16 @@ pub(crate) fn run() {
 
             let db = open_and_migrate(&paths.db_path)?;
 
+            let git = Arc::new(GitCli);
+            let gh = Arc::new(GhCli);
             let state = AppState {
                 repo_selection: RepoSelection {
-                    git: Arc::new(GitCli),
-                    gh: Arc::new(GhCli),
+                    git: git.clone(),
+                    gh: gh.clone(),
                     recents: Arc::new(SqliteRecentsStore::new(db)),
                     clock: Arc::new(SystemClock),
                 },
+                pull_requests: PullRequests { gh: gh.clone() },
             };
             app.manage(state);
             Ok(())

--- a/src/shared/ipc/client.ts
+++ b/src/shared/ipc/client.ts
@@ -36,4 +36,8 @@ export const ipc = {
     add: (repo: Repository) => call("add_recent_repository", { repo }),
     remove: (path: string) => call("remove_recent_repository", { path }),
   },
+  pullRequests: {
+    list: (repoPath: string) => call("list_pull_requests", { repoPath }),
+    load: (repoPath: string, prNumber: number) => call("load_pull_request", { repoPath, prNumber }),
+  },
 };

--- a/src/shared/ipc/contract.ts
+++ b/src/shared/ipc/contract.ts
@@ -37,6 +37,30 @@ export interface RecentRepository {
   lastOpenedAt: number;
 }
 
+export type PullRequestState = "open" | "closed" | "merged";
+
+export interface PullRequestSummary {
+  number: number;
+  title: string;
+  author: string;
+  baseRef: string;
+  headRef: string;
+  state: PullRequestState;
+  isDraft: boolean;
+  updatedAt: string;
+  url: string;
+}
+
+export interface PullRequestDetail {
+  summary: PullRequestSummary;
+  body: string | null;
+  headSha: string;
+  baseSha: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+}
+
 export type AppError =
   | { kind: "invalidPath"; data: { path: string } }
   | { kind: "notAGitRepo"; data: { path: string } }
@@ -56,6 +80,11 @@ export interface Commands {
   list_recent_repositories: { args: undefined; result: RecentRepository[] };
   add_recent_repository: { args: { repo: Repository }; result: RecentRepository };
   remove_recent_repository: { args: { path: string }; result: null };
+  list_pull_requests: { args: { repoPath: string }; result: PullRequestSummary[] };
+  load_pull_request: {
+    args: { repoPath: string; prNumber: number };
+    result: PullRequestDetail;
+  };
 }
 
 export type CommandName = keyof Commands;


### PR DESCRIPTION
## Summary
- Adds Phase 2 backend slice for pull requests: `PullRequestSummary` / `PullRequestDetail` domain types, `GhClient::list_pull_requests` + `load_pull_request`, and a new `PullRequests` use-case bundle.
- Wires two Tauri commands (`list_pull_requests`, `load_pull_request`) and mirrors the contract in `src/shared/ipc/contract.ts` + a new `ipc.pullRequests` helper.
- Maps `gh` CLI errors back to `AppError::PrNotFound` / `GhNotAuthenticated` where applicable.

Refs #7. No UI changes — that lands with #6 / #8.

## Test plan
- [x] `cargo test --workspace` (5 new core tests for list/load)
- [x] `cargo clippy --workspace --all-targets -D warnings`
- [x] `cargo fmt --check`
- [x] `bun run typecheck` + `bun run check`
- [ ] Manual smoke from devtools on a real repo:
  ```js
  await window.__TAURI__.core.invoke("list_pull_requests", { repoPath: "/path/to/repo" })
  await window.__TAURI__.core.invoke("load_pull_request", { repoPath: "/path/to/repo", prNumber: 1 })
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)