### PR TITLE
chore: add CODEOWNERS (global @jaovito)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for this repository.
+# Combined with the `main` branch ruleset ("Require review from Code Owners"),
+# this ensures every PR needs an approval from one of the listed owners
+# before it can be merged.
+
+* @jaovito


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with global cover (`* @jaovito`).
- Pairs with the main-branch ruleset's "Require review from Code Owners" so PRs need a maintainer approval before merge.

## Next steps (manual, on GitHub)
- In the `main` ruleset, enable: Require a PR before merging → Require review from Code Owners (≥ 1 approval), Dismiss stale approvals on new commits, Require approval of the most recent reviewable push.
- Keep the bypass list empty (or only @jaovito for hotfixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)