### PR TITLE
feat(phase-3): local-first comments (#13–#20)

### DIFF
--- a/crates/core/src/application/comments/crud.rs
+++ b/crates/core/src/application/comments/crud.rs
@@ -20,11 +20,7 @@ pub async fn create(svc: &Comments, payload: NewComment) -> AppResult<ReviewComm
     svc.store.create(payload, svc.clock.now_unix_ms()).await
 }
 
-pub async fn update(
-    svc: &Comments,
-    id: i64,
-    patch: CommentUpdate,
-) -> AppResult<ReviewComment> {
+pub async fn update(svc: &Comments, id: i64, patch: CommentUpdate) -> AppResult<ReviewComment> {
     svc.store.update(id, patch, svc.clock.now_unix_ms()).await
 }
 

--- a/crates/core/src/application/comments/crud.rs
+++ b/crates/core/src/application/comments/crud.rs
@@ -1,0 +1,33 @@
+use crate::domain::{CommentUpdate, ReviewComment};
+use crate::ports::NewComment;
+use crate::AppResult;
+
+use super::Comments;
+
+pub async fn list_for_pr(svc: &Comments, pr_number: u64) -> AppResult<Vec<ReviewComment>> {
+    svc.store.list_for_pr(pr_number).await
+}
+
+pub async fn list_for_file(
+    svc: &Comments,
+    pr_number: u64,
+    file_path: &str,
+) -> AppResult<Vec<ReviewComment>> {
+    svc.store.list_for_file(pr_number, file_path).await
+}
+
+pub async fn create(svc: &Comments, payload: NewComment) -> AppResult<ReviewComment> {
+    svc.store.create(payload, svc.clock.now_unix_ms()).await
+}
+
+pub async fn update(
+    svc: &Comments,
+    id: i64,
+    patch: CommentUpdate,
+) -> AppResult<ReviewComment> {
+    svc.store.update(id, patch, svc.clock.now_unix_ms()).await
+}
+
+pub async fn delete(svc: &Comments, id: i64) -> AppResult<()> {
+    svc.store.delete(id, svc.clock.now_unix_ms()).await
+}

--- a/crates/core/src/application/comments/mod.rs
+++ b/crates/core/src/application/comments/mod.rs
@@ -1,0 +1,17 @@
+pub mod crud;
+pub mod submit;
+
+use std::sync::Arc;
+
+use crate::ports::{Clock, CommentsStore, GhClient};
+
+/// Bundles the ports needed by every comment use case.
+///
+/// `gh` lives here so #19's `submit_review` use case can publish drafts;
+/// the local CRUD operations only touch `store` and `clock`.
+#[derive(Clone)]
+pub struct Comments {
+    pub store: Arc<dyn CommentsStore>,
+    pub clock: Arc<dyn Clock>,
+    pub gh: Arc<dyn GhClient>,
+}

--- a/crates/core/src/application/comments/submit.rs
+++ b/crates/core/src/application/comments/submit.rs
@@ -1,0 +1,251 @@
+use crate::domain::{CommentState, ReviewComment};
+use crate::ports::{
+    ReviewCommentInput, ReviewSubmissionResult, SubmitOutcome, SubmittedReviewComment,
+};
+use crate::AppResult;
+
+use super::Comments;
+
+/// Outcome we hold per requested id while assembling the response. Keeps the
+/// original input order regardless of which path (idempotent / batch /
+/// fallback) produced the result.
+enum Slot {
+    /// Already published in a previous submit. Skipped without hitting `gh`.
+    AlreadySubmitted { github_id: i64 },
+    /// Soft-deleted or missing — reported as a no-op failure so the UI can
+    /// surface it instead of silently dropping the request.
+    Skipped { reason: String },
+    /// Mismatched `head_sha` against the batch — fall back to per-comment.
+    MixedHead,
+    /// Eligible for submission. Holds the input the gh layer needs.
+    Pending { input: ReviewCommentInput },
+}
+
+pub async fn run(
+    svc: &Comments,
+    repo_path: &str,
+    pr_number: u64,
+    comment_ids: &[i64],
+) -> AppResult<ReviewSubmissionResult> {
+    // 1. Fetch every requested comment, classify, and collect the head_sha
+    //    candidates so we can decide whether a single batch is safe.
+    let mut slots: Vec<(i64, Slot)> = Vec::with_capacity(comment_ids.len());
+    let mut head_shas: Vec<String> = Vec::new();
+
+    for &id in comment_ids {
+        let fetched = svc.store.get(id).await?;
+        let slot = classify(id, fetched, &mut head_shas);
+        slots.push((id, slot));
+    }
+
+    // 2. Decide whether the whole pending set shares one head_sha. If not,
+    //    flip every Pending into MixedHead so we go straight to per-comment.
+    let unique_heads: std::collections::BTreeSet<&String> = head_shas.iter().collect();
+    let single_head: Option<String> = if unique_heads.len() == 1 {
+        head_shas.first().cloned()
+    } else {
+        None
+    };
+    if single_head.is_none() {
+        for (_, slot) in &mut slots {
+            if matches!(slot, Slot::Pending { .. }) {
+                *slot = Slot::MixedHead;
+            }
+        }
+    }
+
+    // 3. Try the batch endpoint when we have a homogeneous, non-empty pending
+    //    set. Failure here just means we fall back per comment; we never
+    //    bubble the batch error up to the caller.
+    let pending_inputs: Vec<ReviewCommentInput> = slots
+        .iter()
+        .filter_map(|(_, s)| match s {
+            Slot::Pending { input } => Some(input.clone()),
+            _ => None,
+        })
+        .collect();
+
+    let mut batch_ids: Option<Vec<i64>> = None;
+    if let (Some(head), false) = (single_head.as_ref(), pending_inputs.is_empty()) {
+        // Either an Err or an unexpected-length Ok falls through to the
+        // per-comment fallback path; the only success case worth taking is a
+        // length-matching list of ids we can zip in input order.
+        if let Ok(ids) = svc
+            .gh
+            .submit_review_batch(repo_path, pr_number, head, &pending_inputs)
+            .await
+        {
+            if ids.len() == pending_inputs.len() {
+                batch_ids = Some(ids);
+            }
+        }
+    }
+
+    // 4. Walk the slots in input order, dispatching to whichever publication
+    //    path applies to each.
+    let mut results: Vec<SubmittedReviewComment> = Vec::with_capacity(slots.len());
+    let now = svc.clock.now_unix_ms();
+    let mut batch_iter = batch_ids.into_iter().flatten();
+
+    for (id, slot) in slots {
+        let entry = match slot {
+            Slot::AlreadySubmitted { github_id } => SubmittedReviewComment {
+                local_id: id,
+                github_id: Some(github_id),
+                submitted: true,
+                error: None,
+            },
+            Slot::Skipped { reason } => SubmittedReviewComment {
+                local_id: id,
+                github_id: None,
+                submitted: false,
+                error: Some(reason),
+            },
+            Slot::Pending { input } => {
+                if let Some(github_id) = batch_iter.next() {
+                    svc.store
+                        .record_submit(
+                            id,
+                            SubmitOutcome {
+                                github_id: Some(github_id),
+                                submit_error: None,
+                            },
+                            now,
+                        )
+                        .await?;
+                    SubmittedReviewComment {
+                        local_id: id,
+                        github_id: Some(github_id),
+                        submitted: true,
+                        error: None,
+                    }
+                } else {
+                    // Batch failed (or never ran for a single-head set that
+                    // tripped a length mismatch). The head must exist if we
+                    // reached Pending classification.
+                    let head = single_head
+                        .as_deref()
+                        .expect("Pending slot implies a resolved head_sha");
+                    submit_single(svc, repo_path, pr_number, head, &input, id, now).await?
+                }
+            }
+            Slot::MixedHead => {
+                // Re-fetch so we have the latest head_sha for this comment;
+                // the classify pass already held one but burying it in the
+                // enum would couple unrelated branches.
+                match svc.store.get(id).await? {
+                    Some(comment) => {
+                        let input = ReviewCommentInput {
+                            local_id: id,
+                            path: comment.file_path.clone(),
+                            line: comment.anchor.end_line(),
+                            body: comment.body.clone(),
+                        };
+                        submit_single(
+                            svc,
+                            repo_path,
+                            pr_number,
+                            &comment.head_sha,
+                            &input,
+                            id,
+                            now,
+                        )
+                        .await?
+                    }
+                    None => SubmittedReviewComment {
+                        local_id: id,
+                        github_id: None,
+                        submitted: false,
+                        error: Some(format!("local comment {id} not found")),
+                    },
+                }
+            }
+        };
+        results.push(entry);
+    }
+
+    let all_submitted = results.iter().all(|r| r.submitted);
+    Ok(ReviewSubmissionResult {
+        comments: results,
+        all_submitted,
+    })
+}
+
+fn classify(id: i64, fetched: Option<ReviewComment>, head_shas: &mut Vec<String>) -> Slot {
+    let Some(comment) = fetched else {
+        return Slot::Skipped {
+            reason: format!("local comment {id} not found"),
+        };
+    };
+    if matches!(comment.state, CommentState::Deleted) {
+        return Slot::Skipped {
+            reason: format!("local comment {id} is deleted"),
+        };
+    }
+    if let Some(github_id) = comment.github_id {
+        return Slot::AlreadySubmitted { github_id };
+    }
+    head_shas.push(comment.head_sha.clone());
+    Slot::Pending {
+        input: ReviewCommentInput {
+            local_id: id,
+            path: comment.file_path,
+            line: comment.anchor.end_line(),
+            body: comment.body,
+        },
+    }
+}
+
+async fn submit_single(
+    svc: &Comments,
+    repo_path: &str,
+    pr_number: u64,
+    head_sha: &str,
+    input: &ReviewCommentInput,
+    id: i64,
+    now: i64,
+) -> AppResult<SubmittedReviewComment> {
+    match svc
+        .gh
+        .submit_review_comment(repo_path, pr_number, head_sha, input)
+        .await
+    {
+        Ok(github_id) => {
+            svc.store
+                .record_submit(
+                    id,
+                    SubmitOutcome {
+                        github_id: Some(github_id),
+                        submit_error: None,
+                    },
+                    now,
+                )
+                .await?;
+            Ok(SubmittedReviewComment {
+                local_id: id,
+                github_id: Some(github_id),
+                submitted: true,
+                error: None,
+            })
+        }
+        Err(err) => {
+            let message = err.to_string();
+            svc.store
+                .record_submit(
+                    id,
+                    SubmitOutcome {
+                        github_id: None,
+                        submit_error: Some(message.clone()),
+                    },
+                    now,
+                )
+                .await?;
+            Ok(SubmittedReviewComment {
+                local_id: id,
+                github_id: None,
+                submitted: false,
+                error: Some(message),
+            })
+        }
+    }
+}

--- a/crates/core/src/application/comments/submit.rs
+++ b/crates/core/src/application/comments/submit.rs
@@ -135,12 +135,7 @@ pub async fn run(
                 // enum would couple unrelated branches.
                 match svc.store.get(id).await? {
                     Some(comment) => {
-                        let input = ReviewCommentInput {
-                            local_id: id,
-                            path: comment.file_path.clone(),
-                            line: comment.anchor.end_line(),
-                            body: comment.body.clone(),
-                        };
+                        let input = build_input(id, &comment);
                         submit_single(
                             svc,
                             repo_path,
@@ -177,22 +172,35 @@ fn classify(id: i64, fetched: Option<ReviewComment>, head_shas: &mut Vec<String>
             reason: format!("local comment {id} not found"),
         };
     };
-    if matches!(comment.state, CommentState::Deleted) {
-        return Slot::Skipped {
-            reason: format!("local comment {id} is deleted"),
-        };
-    }
+    // Already-published comments are reported as success (idempotent retry).
     if let Some(github_id) = comment.github_id {
         return Slot::AlreadySubmitted { github_id };
     }
+    // Only drafts are submitted. Anything else is reported back so the UI
+    // doesn't silently turn `hidden`/`resolved` rows into remote comments.
+    if !matches!(comment.state, CommentState::Draft) {
+        return Slot::Skipped {
+            reason: format!(
+                "local comment {id} is {} (only drafts are submitted)",
+                comment.state.as_str()
+            ),
+        };
+    }
     head_shas.push(comment.head_sha.clone());
     Slot::Pending {
-        input: ReviewCommentInput {
-            local_id: id,
-            path: comment.file_path,
-            line: comment.anchor.end_line(),
-            body: comment.body,
-        },
+        input: build_input(id, &comment),
+    }
+}
+
+fn build_input(id: i64, comment: &ReviewComment) -> ReviewCommentInput {
+    let start = comment.anchor.start_line();
+    let end = comment.anchor.end_line();
+    ReviewCommentInput {
+        local_id: id,
+        path: comment.file_path.clone(),
+        line: end,
+        start_line: if start < end { Some(start) } else { None },
+        body: comment.body.clone(),
     }
 }
 

--- a/crates/core/src/application/comments/submit.rs
+++ b/crates/core/src/application/comments/submit.rs
@@ -34,7 +34,7 @@ pub async fn run(
 
     for &id in comment_ids {
         let fetched = svc.store.get(id).await?;
-        let slot = classify(id, fetched, &mut head_shas);
+        let slot = classify(pr_number, id, fetched, &mut head_shas);
         slots.push((id, slot));
     }
 
@@ -134,7 +134,7 @@ pub async fn run(
                 // the classify pass already held one but burying it in the
                 // enum would couple unrelated branches.
                 match svc.store.get(id).await? {
-                    Some(comment) => {
+                    Some(comment) if comment.pr_number == pr_number => {
                         let input = build_input(id, &comment);
                         submit_single(
                             svc,
@@ -147,6 +147,15 @@ pub async fn run(
                         )
                         .await?
                     }
+                    Some(comment) => SubmittedReviewComment {
+                        local_id: id,
+                        github_id: None,
+                        submitted: false,
+                        error: Some(format!(
+                            "local comment {id} belongs to PR #{} (expected PR #{pr_number})",
+                            comment.pr_number
+                        )),
+                    },
                     None => SubmittedReviewComment {
                         local_id: id,
                         github_id: None,
@@ -166,12 +175,27 @@ pub async fn run(
     })
 }
 
-fn classify(id: i64, fetched: Option<ReviewComment>, head_shas: &mut Vec<String>) -> Slot {
+fn classify(
+    pr_number: u64,
+    id: i64,
+    fetched: Option<ReviewComment>,
+    head_shas: &mut Vec<String>,
+) -> Slot {
     let Some(comment) = fetched else {
         return Slot::Skipped {
             reason: format!("local comment {id} not found"),
         };
     };
+    // Guard against stale UI state — a comment id that belongs to a
+    // different PR must never be posted under this PR's review.
+    if comment.pr_number != pr_number {
+        return Slot::Skipped {
+            reason: format!(
+                "local comment {id} belongs to PR #{} (expected PR #{pr_number})",
+                comment.pr_number
+            ),
+        };
+    }
     // Already-published comments are reported as success (idempotent retry).
     if let Some(github_id) = comment.github_id {
         return Slot::AlreadySubmitted { github_id };

--- a/crates/core/src/application/mod.rs
+++ b/crates/core/src/application/mod.rs
@@ -1,3 +1,4 @@
+pub mod comments;
 pub mod files;
 pub mod pull_requests;
 pub mod repo_selection;

--- a/crates/core/src/domain/comment.rs
+++ b/crates/core/src/domain/comment.rs
@@ -63,7 +63,11 @@ impl CommentState {
 /// The `kind` discriminator is rendered as `lineRange`, `singleLine`,
 /// `codeBlock` to match the frontend contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum CommentAnchor {
     SingleLine {
         line: u32,

--- a/crates/core/src/domain/comment.rs
+++ b/crates/core/src/domain/comment.rs
@@ -42,7 +42,8 @@ impl CommentState {
 
     /// Returns whether `next` is reachable from `self`. Used to guard updates
     /// in `application::comments::update`. `Deleted` is terminal — every
-    /// other transition is enumerated here.
+    /// other transition is enumerated here. Drafts can be discarded as
+    /// resolved before they're ever submitted.
     pub fn can_transition_to(self, next: Self) -> bool {
         use CommentState::{Deleted, Draft, Hidden, Resolved, Submitted};
         if self == next {
@@ -50,9 +51,10 @@ impl CommentState {
         }
         matches!(
             (self, next),
-            (Draft | Resolved, Submitted | Hidden | Deleted)
+            (Draft, Submitted | Hidden | Resolved | Deleted)
                 | (Submitted, Resolved | Hidden | Deleted)
                 | (Hidden, Draft | Submitted | Resolved | Deleted)
+                | (Resolved, Submitted | Hidden | Deleted)
         )
     }
 }
@@ -171,10 +173,11 @@ mod tests {
     }
 
     #[test]
-    fn draft_can_become_submitted() {
+    fn draft_can_become_submitted_or_resolved() {
         assert!(CommentState::Draft.can_transition_to(CommentState::Submitted));
         assert!(CommentState::Draft.can_transition_to(CommentState::Hidden));
-        assert!(!CommentState::Draft.can_transition_to(CommentState::Resolved));
+        // Drafts can be discarded as resolved before they're ever submitted.
+        assert!(CommentState::Draft.can_transition_to(CommentState::Resolved));
     }
 
     #[test]

--- a/crates/core/src/domain/comment.rs
+++ b/crates/core/src/domain/comment.rs
@@ -1,0 +1,189 @@
+use serde::{Deserialize, Serialize};
+
+/// Lifecycle of a review comment.
+///
+/// `Draft`     — local-only, not yet sent to GitHub.
+/// `Submitted` — published to GitHub (`github_id` is `Some`).
+/// `Hidden`    — kept locally but suppressed in default views.
+/// `Resolved`  — marked done by the reviewer.
+/// `Deleted`   — soft-deleted; rows remain so historical anchors can survive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CommentState {
+    Draft,
+    Submitted,
+    Hidden,
+    Resolved,
+    Deleted,
+}
+
+impl CommentState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Draft => "draft",
+            Self::Submitted => "submitted",
+            Self::Hidden => "hidden",
+            Self::Resolved => "resolved",
+            Self::Deleted => "deleted",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(raw: &str) -> Option<Self> {
+        match raw {
+            "draft" => Some(Self::Draft),
+            "submitted" => Some(Self::Submitted),
+            "hidden" => Some(Self::Hidden),
+            "resolved" => Some(Self::Resolved),
+            "deleted" => Some(Self::Deleted),
+            _ => None,
+        }
+    }
+
+    /// Returns whether `next` is reachable from `self`. Used to guard updates
+    /// in `application::comments::update`. `Deleted` is terminal — every
+    /// other transition is enumerated here.
+    pub fn can_transition_to(self, next: Self) -> bool {
+        use CommentState::{Deleted, Draft, Hidden, Resolved, Submitted};
+        if self == next {
+            return true;
+        }
+        matches!(
+            (self, next),
+            (Draft | Resolved, Submitted | Hidden | Deleted)
+                | (Submitted, Resolved | Hidden | Deleted)
+                | (Hidden, Draft | Submitted | Resolved | Deleted)
+        )
+    }
+}
+
+/// How a comment is anchored to source-document lines.
+///
+/// Lines are 1-indexed and refer to positions in the file at `head_sha`.
+/// The `kind` discriminator is rendered as `lineRange`, `singleLine`,
+/// `codeBlock` to match the frontend contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum CommentAnchor {
+    SingleLine {
+        line: u32,
+    },
+    LineRange {
+        start_line: u32,
+        end_line: u32,
+    },
+    /// Selection that lives entirely inside a code block. `code_start_line`
+    /// is the line where the fenced block begins; the start/end lines are
+    /// 1-indexed lines *within the source file* (not the block).
+    CodeBlock {
+        start_line: u32,
+        end_line: u32,
+        code_start_line: u32,
+    },
+}
+
+impl CommentAnchor {
+    pub fn start_line(&self) -> u32 {
+        match self {
+            Self::SingleLine { line } => *line,
+            Self::LineRange { start_line, .. } | Self::CodeBlock { start_line, .. } => *start_line,
+        }
+    }
+
+    pub fn end_line(&self) -> u32 {
+        match self {
+            Self::SingleLine { line } => *line,
+            Self::LineRange { end_line, .. } | Self::CodeBlock { end_line, .. } => *end_line,
+        }
+    }
+}
+
+/// A review comment in the local store. Persisted across restarts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewComment {
+    pub id: i64,
+    pub pr_number: u64,
+    pub file_path: String,
+    /// SHA the anchor lines are valid against. Used so a remote refresh can
+    /// detect stale anchors when the PR moves on.
+    pub head_sha: String,
+    pub body: String,
+    pub author: Option<String>,
+    pub state: CommentState,
+    pub anchor: CommentAnchor,
+    pub created_at: i64,
+    pub updated_at: i64,
+    /// GitHub review-comment id once published. Used as the idempotency key
+    /// when retrying a partial submit.
+    pub github_id: Option<i64>,
+    /// Last submit failure message; cleared on success.
+    pub submit_error: Option<String>,
+}
+
+/// Patch payload accepted by `update_local_comment`. Any field left `None`
+/// is preserved as-is.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommentUpdate {
+    pub body: Option<String>,
+    pub state: Option<CommentState>,
+    pub anchor: Option<CommentAnchor>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anchor_serializes_with_kind_discriminator() {
+        let json = serde_json::to_string(&CommentAnchor::LineRange {
+            start_line: 4,
+            end_line: 9,
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"lineRange\""));
+        assert!(json.contains("\"startLine\":4"));
+        assert!(json.contains("\"endLine\":9"));
+    }
+
+    #[test]
+    fn state_round_trips_via_str() {
+        for s in [
+            CommentState::Draft,
+            CommentState::Submitted,
+            CommentState::Hidden,
+            CommentState::Resolved,
+            CommentState::Deleted,
+        ] {
+            assert_eq!(CommentState::from_str(s.as_str()), Some(s));
+        }
+    }
+
+    #[test]
+    fn deleted_is_terminal() {
+        assert!(!CommentState::Deleted.can_transition_to(CommentState::Draft));
+        assert!(!CommentState::Deleted.can_transition_to(CommentState::Submitted));
+    }
+
+    #[test]
+    fn draft_can_become_submitted() {
+        assert!(CommentState::Draft.can_transition_to(CommentState::Submitted));
+        assert!(CommentState::Draft.can_transition_to(CommentState::Hidden));
+        assert!(!CommentState::Draft.can_transition_to(CommentState::Resolved));
+    }
+
+    #[test]
+    fn anchor_line_helpers() {
+        let a = CommentAnchor::SingleLine { line: 12 };
+        assert_eq!(a.start_line(), 12);
+        assert_eq!(a.end_line(), 12);
+        let b = CommentAnchor::CodeBlock {
+            start_line: 4,
+            end_line: 7,
+            code_start_line: 3,
+        };
+        assert_eq!(b.start_line(), 4);
+        assert_eq!(b.end_line(), 7);
+    }
+}

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -1,10 +1,12 @@
 pub mod changed_file;
+pub mod comment;
 pub mod file_diff;
 pub mod pull_request;
 pub mod repository;
 pub mod tool_status;
 
 pub use changed_file::{ChangeStatus, ChangedFile};
+pub use comment::{CommentAnchor, CommentState, CommentUpdate, ReviewComment};
 pub use file_diff::{DiffHunk, FileDiff, HunkKind};
 pub use pull_request::{PullRequestDetail, PullRequestState, PullRequestSummary};
 pub use repository::{RemoteUrl, Repository};

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -36,6 +36,12 @@ pub enum AppError {
     #[error("process error: {message}")]
     Process { message: String },
 
+    /// Application-level validation failure (e.g. an illegal state
+    /// transition). Distinct from `Db` so the UI / telemetry can route it
+    /// correctly.
+    #[error("validation error: {message}")]
+    Validation { message: String },
+
     #[error("unexpected error: {message}")]
     Unexpected { message: String },
 }
@@ -53,6 +59,11 @@ impl AppError {
     }
     pub fn process(err: impl std::fmt::Display) -> Self {
         Self::Process {
+            message: err.to_string(),
+        }
+    }
+    pub fn validation(err: impl std::fmt::Display) -> Self {
+        Self::Validation {
             message: err.to_string(),
         }
     }

--- a/crates/core/src/ports/comments_store.rs
+++ b/crates/core/src/ports/comments_store.rs
@@ -1,0 +1,69 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{CommentAnchor, CommentUpdate, ReviewComment};
+use crate::AppResult;
+
+/// Payload accepted by `CommentsStore::create`. The store assigns `id`,
+/// `created_at`, and `updated_at`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewComment {
+    pub pr_number: u64,
+    pub file_path: String,
+    pub head_sha: String,
+    pub body: String,
+    pub author: Option<String>,
+    pub anchor: CommentAnchor,
+}
+
+/// Patch the store applies after a successful submit to a remote.
+/// Used by `submit_review` to flip drafts into `submitted` and stamp
+/// the GitHub id.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitOutcome {
+    pub github_id: Option<i64>,
+    pub submit_error: Option<String>,
+}
+
+#[async_trait]
+pub trait CommentsStore: Send + Sync {
+    /// Lists every comment for a PR ordered by `(file_path, start_line, id)`.
+    /// Used by app-boot hydration (issue #18).
+    async fn list_for_pr(&self, pr_number: u64) -> AppResult<Vec<ReviewComment>>;
+
+    /// Lists every comment anchored to a single file inside a PR.
+    async fn list_for_file(
+        &self,
+        pr_number: u64,
+        file_path: &str,
+    ) -> AppResult<Vec<ReviewComment>>;
+
+    /// Returns the comment with the given local id, or `None` if absent.
+    async fn get(&self, id: i64) -> AppResult<Option<ReviewComment>>;
+
+    /// Persists a fresh draft. Returns the inserted row including the
+    /// store-assigned id and timestamps.
+    async fn create(&self, new: NewComment, now_unix_ms: i64) -> AppResult<ReviewComment>;
+
+    /// Applies a patch. Returns the updated row.
+    async fn update(
+        &self,
+        id: i64,
+        patch: CommentUpdate,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment>;
+
+    /// Soft-deletes by transitioning state → `Deleted`. Idempotent.
+    async fn delete(&self, id: i64, now_unix_ms: i64) -> AppResult<()>;
+
+    /// Marks a comment as submitted (or records the failure note). Used by
+    /// `submit_review` after a remote round-trip.
+    async fn record_submit(
+        &self,
+        id: i64,
+        outcome: SubmitOutcome,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment>;
+}

--- a/crates/core/src/ports/comments_store.rs
+++ b/crates/core/src/ports/comments_store.rs
@@ -34,11 +34,8 @@ pub trait CommentsStore: Send + Sync {
     async fn list_for_pr(&self, pr_number: u64) -> AppResult<Vec<ReviewComment>>;
 
     /// Lists every comment anchored to a single file inside a PR.
-    async fn list_for_file(
-        &self,
-        pr_number: u64,
-        file_path: &str,
-    ) -> AppResult<Vec<ReviewComment>>;
+    async fn list_for_file(&self, pr_number: u64, file_path: &str)
+        -> AppResult<Vec<ReviewComment>>;
 
     /// Returns the comment with the given local id, or `None` if absent.
     async fn get(&self, id: i64) -> AppResult<Option<ReviewComment>>;

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -13,15 +13,20 @@ pub struct GhAuthReport {
 }
 
 /// One inline review comment to submit. Lines refer to positions in the file
-/// at `head_sha`; we always anchor to a single line on the RIGHT side because
-/// GitHub's per-comment endpoint requires it (range comments live on the
-/// review-batch endpoint via `start_line`).
+/// at `head_sha`. `line` is the final line of the anchor (single-line or end
+/// of a range); when `start_line` is present the comment becomes multi-line
+/// on the GitHub side (`POST /pulls/{n}/comments` and the review-batch
+/// `comments[i][start_line]` payload both honor it).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReviewCommentInput {
     pub local_id: i64,
     pub path: String,
     pub line: u32,
+    /// Set to `Some(start)` when the original anchor spans multiple lines.
+    /// Unused for single-line anchors.
+    #[serde(default)]
+    pub start_line: Option<u32>,
     pub body: String,
 }
 

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -12,6 +12,37 @@ pub struct GhAuthReport {
     pub detail: String,
 }
 
+/// One inline review comment to submit. Lines refer to positions in the file
+/// at `head_sha`; we always anchor to a single line on the RIGHT side because
+/// GitHub's per-comment endpoint requires it (range comments live on the
+/// review-batch endpoint via `start_line`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewCommentInput {
+    pub local_id: i64,
+    pub path: String,
+    pub line: u32,
+    pub body: String,
+}
+
+/// Per-comment status returned to the UI after a `submit_review` round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmittedReviewComment {
+    pub local_id: i64,
+    pub github_id: Option<i64>,
+    pub submitted: bool,
+    pub error: Option<String>,
+}
+
+/// Aggregate result of a `submit_review` round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewSubmissionResult {
+    pub comments: Vec<SubmittedReviewComment>,
+    pub all_submitted: bool,
+}
+
 /// Abstracts the GitHub CLI (`gh`).
 #[async_trait]
 pub trait GhClient: Send + Sync {
@@ -32,4 +63,28 @@ pub trait GhClient: Send + Sync {
         sha: &str,
         file_path: &str,
     ) -> AppResult<String>;
+
+    /// Posts a review with multiple inline comments via
+    /// `POST /repos/{owner}/{repo}/pulls/{number}/reviews` with
+    /// `event: COMMENT`. Returns the created GitHub comment ids in the same
+    /// order as `comments`, or `Err` if the entire batch failed (caller can
+    /// then fall back to per-comment submission).
+    async fn submit_review_batch(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        comments: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>>;
+
+    /// Posts a single review comment via
+    /// `POST /repos/{owner}/{repo}/pulls/{number}/comments`. Used as the
+    /// fallback when the batch endpoint rejects part or all of the request.
+    async fn submit_review_comment(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        comment: &ReviewCommentInput,
+    ) -> AppResult<i64>;
 }

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -1,9 +1,13 @@
 pub mod clock;
+pub mod comments_store;
 pub mod gh;
 pub mod git;
 pub mod recents_store;
 
 pub use clock::Clock;
-pub use gh::{GhAuthReport, GhClient};
+pub use comments_store::{CommentsStore, NewComment, SubmitOutcome};
+pub use gh::{
+    GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult, SubmittedReviewComment,
+};
 pub use git::GitClient;
 pub use recents_store::{RecentRepository, RecentsStore};

--- a/crates/core/tests/comments_submit.rs
+++ b/crates/core/tests/comments_submit.rs
@@ -59,13 +59,7 @@ impl CommentsStore for InMemoryCommentsStore {
     }
 
     async fn get(&self, id: i64) -> AppResult<Option<ReviewComment>> {
-        Ok(self
-            .rows
-            .lock()
-            .await
-            .iter()
-            .find(|c| c.id == id)
-            .cloned())
+        Ok(self.rows.lock().await.iter().find(|c| c.id == id).cloned())
     }
 
     async fn create(&self, new: NewComment, now_unix_ms: i64) -> AppResult<ReviewComment> {
@@ -311,7 +305,10 @@ async fn batch_success_marks_every_comment_submitted() {
     assert_eq!(result.comments[0].local_id, a.id);
     assert_eq!(result.comments[0].github_id, Some(1001));
     assert_eq!(result.comments[1].github_id, Some(1002));
-    assert!(result.comments.iter().all(|c| c.submitted && c.error.is_none()));
+    assert!(result
+        .comments
+        .iter()
+        .all(|c| c.submitted && c.error.is_none()));
 
     // Persisted state matches.
     let stored_a = store.get(a.id).await.unwrap().unwrap();
@@ -330,7 +327,8 @@ async fn batch_failure_falls_back_to_per_comment() {
     let a = seed_comment(&store, 9, "a.md", "sha1", "first").await;
     let b = seed_comment(&store, 9, "b.md", "sha1", "second").await;
 
-    gh.set_batch(Err(AppError::process("422 unprocessable"))).await;
+    gh.set_batch(Err(AppError::process("422 unprocessable")))
+        .await;
     gh.set_per_comment(a.id, Ok(2001)).await;
     gh.set_per_comment(b.id, Ok(2002)).await;
 
@@ -383,7 +381,11 @@ async fn mixed_fallback_keeps_failures_as_drafts_with_error() {
     let stored_bad = store.get(bad.id).await.unwrap().unwrap();
     assert_eq!(stored_bad.state, CommentState::Draft);
     assert!(stored_bad.github_id.is_none());
-    assert!(stored_bad.submit_error.as_deref().unwrap().contains("rate limited"));
+    assert!(stored_bad
+        .submit_error
+        .as_deref()
+        .unwrap()
+        .contains("rate limited"));
 
     // Successful comment is on disk as Submitted with no lingering error.
     let stored_ok = store.get(ok.id).await.unwrap().unwrap();

--- a/crates/core/tests/comments_submit.rs
+++ b/crates/core/tests/comments_submit.rs
@@ -1,0 +1,451 @@
+//! Use-case tests for `application::comments::submit::run`.
+//!
+//! Covers the three branches the issue calls out: batch success, batch
+//! failure with successful per-comment fallback, and a mixed fallback where
+//! one comment fails. Idempotency (already-submitted comments are skipped)
+//! and `head_sha` heterogeneity (forces per-comment) round things out.
+
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::comments::{submit, Comments};
+use markdown_reviewer_core::domain::{
+    ChangedFile, CommentAnchor, CommentState, CommentUpdate, PullRequestDetail, PullRequestSummary,
+    ReviewComment,
+};
+use markdown_reviewer_core::ports::{
+    Clock, CommentsStore, GhAuthReport, GhClient, NewComment, ReviewCommentInput, SubmitOutcome,
+};
+use markdown_reviewer_core::{AppError, AppResult};
+use tokio::sync::Mutex;
+
+// ---- in-memory comments store --------------------------------------------
+
+#[derive(Default)]
+struct InMemoryCommentsStore {
+    next_id: AtomicI64,
+    rows: Mutex<Vec<ReviewComment>>,
+}
+
+#[async_trait]
+impl CommentsStore for InMemoryCommentsStore {
+    async fn list_for_pr(&self, pr_number: u64) -> AppResult<Vec<ReviewComment>> {
+        Ok(self
+            .rows
+            .lock()
+            .await
+            .iter()
+            .filter(|c| c.pr_number == pr_number)
+            .cloned()
+            .collect())
+    }
+
+    async fn list_for_file(
+        &self,
+        pr_number: u64,
+        file_path: &str,
+    ) -> AppResult<Vec<ReviewComment>> {
+        Ok(self
+            .rows
+            .lock()
+            .await
+            .iter()
+            .filter(|c| c.pr_number == pr_number && c.file_path == file_path)
+            .cloned()
+            .collect())
+    }
+
+    async fn get(&self, id: i64) -> AppResult<Option<ReviewComment>> {
+        Ok(self
+            .rows
+            .lock()
+            .await
+            .iter()
+            .find(|c| c.id == id)
+            .cloned())
+    }
+
+    async fn create(&self, new: NewComment, now_unix_ms: i64) -> AppResult<ReviewComment> {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst) + 1;
+        let row = ReviewComment {
+            id,
+            pr_number: new.pr_number,
+            file_path: new.file_path,
+            head_sha: new.head_sha,
+            body: new.body,
+            author: new.author,
+            state: CommentState::Draft,
+            anchor: new.anchor,
+            created_at: now_unix_ms,
+            updated_at: now_unix_ms,
+            github_id: None,
+            submit_error: None,
+        };
+        self.rows.lock().await.push(row.clone());
+        Ok(row)
+    }
+
+    async fn update(
+        &self,
+        id: i64,
+        patch: CommentUpdate,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment> {
+        let mut rows = self.rows.lock().await;
+        let row = rows
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| AppError::db(format!("comment {id} not found")))?;
+        if let Some(b) = patch.body {
+            row.body = b;
+        }
+        if let Some(s) = patch.state {
+            row.state = s;
+        }
+        if let Some(a) = patch.anchor {
+            row.anchor = a;
+        }
+        row.updated_at = now_unix_ms;
+        Ok(row.clone())
+    }
+
+    async fn delete(&self, id: i64, now_unix_ms: i64) -> AppResult<()> {
+        let mut rows = self.rows.lock().await;
+        if let Some(row) = rows.iter_mut().find(|c| c.id == id) {
+            row.state = CommentState::Deleted;
+            row.updated_at = now_unix_ms;
+        }
+        Ok(())
+    }
+
+    async fn record_submit(
+        &self,
+        id: i64,
+        outcome: SubmitOutcome,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment> {
+        let mut rows = self.rows.lock().await;
+        let row = rows
+            .iter_mut()
+            .find(|c| c.id == id)
+            .ok_or_else(|| AppError::db(format!("comment {id} not found")))?;
+        if let Some(gh_id) = outcome.github_id {
+            row.github_id = Some(gh_id);
+            row.state = CommentState::Submitted;
+            row.submit_error = None;
+        } else {
+            row.submit_error = outcome.submit_error;
+        }
+        row.updated_at = now_unix_ms;
+        Ok(row.clone())
+    }
+}
+
+// ---- programmable gh fake ------------------------------------------------
+
+#[derive(Default)]
+struct GhScript {
+    /// Result of the next `submit_review_batch` call. `Some(Ok(ids))` returns
+    /// those ids; `Some(Err(_))` forces a fallback.
+    batch: Option<AppResult<Vec<i64>>>,
+    /// Per-`local_id` outcomes used by `submit_review_comment`. Anything not
+    /// in the map errors with a default "not scripted" message.
+    per_comment: std::collections::HashMap<i64, AppResult<i64>>,
+    /// Captured invocations for assertion.
+    batch_calls: Vec<Vec<ReviewCommentInput>>,
+    per_calls: Vec<ReviewCommentInput>,
+}
+
+#[derive(Default, Clone)]
+struct ScriptedGh {
+    inner: Arc<Mutex<GhScript>>,
+}
+
+impl ScriptedGh {
+    async fn set_batch(&self, result: AppResult<Vec<i64>>) {
+        self.inner.lock().await.batch = Some(result);
+    }
+    async fn set_per_comment(&self, local_id: i64, result: AppResult<i64>) {
+        self.inner.lock().await.per_comment.insert(local_id, result);
+    }
+    async fn batch_call_count(&self) -> usize {
+        self.inner.lock().await.batch_calls.len()
+    }
+    async fn per_call_count(&self) -> usize {
+        self.inner.lock().await.per_calls.len()
+    }
+}
+
+#[async_trait]
+impl GhClient for ScriptedGh {
+    async fn version(&self) -> AppResult<String> {
+        Ok("gh test".into())
+    }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> {
+        Ok(GhAuthReport {
+            authenticated: true,
+            username: Some("octocat".into()),
+            detail: String::new(),
+        })
+    }
+    async fn list_pull_requests(&self, _repo_path: &str) -> AppResult<Vec<PullRequestSummary>> {
+        Ok(Vec::new())
+    }
+    async fn load_pull_request(
+        &self,
+        _repo_path: &str,
+        number: u64,
+    ) -> AppResult<PullRequestDetail> {
+        Err(AppError::PrNotFound { number })
+    }
+    async fn list_changed_files(
+        &self,
+        _repo_path: &str,
+        _number: u64,
+    ) -> AppResult<Vec<ChangedFile>> {
+        Ok(Vec::new())
+    }
+    async fn get_file_content(
+        &self,
+        _repo_path: &str,
+        _sha: &str,
+        _file_path: &str,
+    ) -> AppResult<String> {
+        Ok(String::new())
+    }
+    async fn submit_review_batch(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        comments: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        let mut g = self.inner.lock().await;
+        g.batch_calls.push(comments.to_vec());
+        match g.batch.take() {
+            Some(result) => result,
+            None => Err(AppError::process("batch not scripted")),
+        }
+    }
+    async fn submit_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        comment: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        let mut g = self.inner.lock().await;
+        g.per_calls.push(comment.clone());
+        g.per_comment
+            .remove(&comment.local_id)
+            .unwrap_or_else(|| Err(AppError::process("comment not scripted")))
+    }
+}
+
+// ---- clock --------------------------------------------------------------
+
+struct FixedClock(i64);
+
+impl Clock for FixedClock {
+    fn now(&self) -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp(self.0 / 1_000).unwrap()
+    }
+    fn now_unix_ms(&self) -> i64 {
+        self.0
+    }
+}
+
+// ---- helpers ------------------------------------------------------------
+
+async fn seed_comment(
+    store: &InMemoryCommentsStore,
+    pr_number: u64,
+    file_path: &str,
+    head_sha: &str,
+    body: &str,
+) -> ReviewComment {
+    store
+        .create(
+            NewComment {
+                pr_number,
+                file_path: file_path.into(),
+                head_sha: head_sha.into(),
+                body: body.into(),
+                author: None,
+                anchor: CommentAnchor::SingleLine { line: 4 },
+            },
+            1_700_000_000_000,
+        )
+        .await
+        .unwrap()
+}
+
+fn build_comments(store: Arc<InMemoryCommentsStore>, gh: Arc<ScriptedGh>) -> Comments {
+    Comments {
+        store,
+        clock: Arc::new(FixedClock(1_700_000_500_000)),
+        gh,
+    }
+}
+
+// ---- tests --------------------------------------------------------------
+
+#[tokio::test]
+async fn batch_success_marks_every_comment_submitted() {
+    let store = Arc::new(InMemoryCommentsStore::default());
+    let gh = Arc::new(ScriptedGh::default());
+
+    let a = seed_comment(&store, 7, "README.md", "sha1", "lgtm").await;
+    let b = seed_comment(&store, 7, "docs/x.md", "sha1", "nit").await;
+
+    gh.set_batch(Ok(vec![1001, 1002])).await;
+
+    let svc = build_comments(store.clone(), gh.clone());
+    let result = submit::run(&svc, "/repo", 7, &[a.id, b.id]).await.unwrap();
+
+    assert!(result.all_submitted);
+    assert_eq!(result.comments.len(), 2);
+    assert_eq!(result.comments[0].local_id, a.id);
+    assert_eq!(result.comments[0].github_id, Some(1001));
+    assert_eq!(result.comments[1].github_id, Some(1002));
+    assert!(result.comments.iter().all(|c| c.submitted && c.error.is_none()));
+
+    // Persisted state matches.
+    let stored_a = store.get(a.id).await.unwrap().unwrap();
+    assert_eq!(stored_a.state, CommentState::Submitted);
+    assert_eq!(stored_a.github_id, Some(1001));
+
+    assert_eq!(gh.batch_call_count().await, 1);
+    assert_eq!(gh.per_call_count().await, 0);
+}
+
+#[tokio::test]
+async fn batch_failure_falls_back_to_per_comment() {
+    let store = Arc::new(InMemoryCommentsStore::default());
+    let gh = Arc::new(ScriptedGh::default());
+
+    let a = seed_comment(&store, 9, "a.md", "sha1", "first").await;
+    let b = seed_comment(&store, 9, "b.md", "sha1", "second").await;
+
+    gh.set_batch(Err(AppError::process("422 unprocessable"))).await;
+    gh.set_per_comment(a.id, Ok(2001)).await;
+    gh.set_per_comment(b.id, Ok(2002)).await;
+
+    let svc = build_comments(store.clone(), gh.clone());
+    let result = submit::run(&svc, "/repo", 9, &[a.id, b.id]).await.unwrap();
+
+    assert!(result.all_submitted);
+    assert_eq!(result.comments[0].github_id, Some(2001));
+    assert_eq!(result.comments[1].github_id, Some(2002));
+    assert_eq!(gh.batch_call_count().await, 1);
+    assert_eq!(gh.per_call_count().await, 2);
+
+    assert_eq!(
+        store.get(b.id).await.unwrap().unwrap().state,
+        CommentState::Submitted
+    );
+}
+
+#[tokio::test]
+async fn mixed_fallback_keeps_failures_as_drafts_with_error() {
+    let store = Arc::new(InMemoryCommentsStore::default());
+    let gh = Arc::new(ScriptedGh::default());
+
+    let ok = seed_comment(&store, 11, "README.md", "sha1", "good").await;
+    let bad = seed_comment(&store, 11, "README.md", "sha1", "bad").await;
+
+    gh.set_batch(Err(AppError::process("422"))).await;
+    gh.set_per_comment(ok.id, Ok(3001)).await;
+    gh.set_per_comment(bad.id, Err(AppError::process("rate limited")))
+        .await;
+
+    let svc = build_comments(store.clone(), gh.clone());
+    let result = submit::run(&svc, "/repo", 11, &[ok.id, bad.id])
+        .await
+        .unwrap();
+
+    assert!(!result.all_submitted);
+    assert!(result.comments[0].submitted);
+    assert_eq!(result.comments[0].github_id, Some(3001));
+    assert!(!result.comments[1].submitted);
+    assert!(result.comments[1].github_id.is_none());
+    assert!(result.comments[1]
+        .error
+        .as_deref()
+        .unwrap()
+        .contains("rate limited"));
+
+    // Failed comment is still a draft, with submit_error populated and
+    // github_id absent — so a retry is safe.
+    let stored_bad = store.get(bad.id).await.unwrap().unwrap();
+    assert_eq!(stored_bad.state, CommentState::Draft);
+    assert!(stored_bad.github_id.is_none());
+    assert!(stored_bad.submit_error.as_deref().unwrap().contains("rate limited"));
+
+    // Successful comment is on disk as Submitted with no lingering error.
+    let stored_ok = store.get(ok.id).await.unwrap().unwrap();
+    assert_eq!(stored_ok.state, CommentState::Submitted);
+    assert!(stored_ok.submit_error.is_none());
+}
+
+#[tokio::test]
+async fn already_submitted_comments_are_skipped() {
+    let store = Arc::new(InMemoryCommentsStore::default());
+    let gh = Arc::new(ScriptedGh::default());
+
+    let already = seed_comment(&store, 1, "x.md", "sha1", "old").await;
+    // Mark `already` as submitted with a github_id (idempotency).
+    store
+        .record_submit(
+            already.id,
+            SubmitOutcome {
+                github_id: Some(9999),
+                submit_error: None,
+            },
+            1_700_000_100_000,
+        )
+        .await
+        .unwrap();
+
+    let fresh = seed_comment(&store, 1, "y.md", "sha1", "new").await;
+    gh.set_batch(Ok(vec![4242])).await;
+
+    let svc = build_comments(store.clone(), gh.clone());
+    let result = submit::run(&svc, "/repo", 1, &[already.id, fresh.id])
+        .await
+        .unwrap();
+
+    assert!(result.all_submitted);
+    assert_eq!(result.comments[0].github_id, Some(9999));
+    assert!(result.comments[0].submitted);
+    assert_eq!(result.comments[1].github_id, Some(4242));
+
+    // Batch was called only with the fresh comment, not the already-published one.
+    let calls = gh.inner.lock().await.batch_calls.clone();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].len(), 1);
+    assert_eq!(calls[0][0].local_id, fresh.id);
+}
+
+#[tokio::test]
+async fn mixed_head_sha_routes_through_per_comment() {
+    let store = Arc::new(InMemoryCommentsStore::default());
+    let gh = Arc::new(ScriptedGh::default());
+
+    let a = seed_comment(&store, 5, "a.md", "sha1", "one").await;
+    let b = seed_comment(&store, 5, "b.md", "sha2", "two").await;
+
+    gh.set_per_comment(a.id, Ok(5001)).await;
+    gh.set_per_comment(b.id, Ok(5002)).await;
+
+    let svc = build_comments(store.clone(), gh.clone());
+    let result = submit::run(&svc, "/repo", 5, &[a.id, b.id]).await.unwrap();
+
+    assert!(result.all_submitted);
+    // No batch attempt when head_sha is heterogeneous.
+    assert_eq!(gh.batch_call_count().await, 0);
+    assert_eq!(gh.per_call_count().await, 2);
+}

--- a/crates/core/tests/files.rs
+++ b/crates/core/tests/files.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use markdown_reviewer_core::application::files::{read_markdown_file::read_markdown_file, Files};
-use markdown_reviewer_core::ports::{GhAuthReport, GhClient, GitClient};
+use markdown_reviewer_core::ports::{GhAuthReport, GhClient, GitClient, ReviewCommentInput};
 use markdown_reviewer_core::{AppError, AppResult};
 
 struct FakeGit {
@@ -85,6 +85,24 @@ impl GhClient for FakeGh {
         _file_path: &str,
     ) -> AppResult<String> {
         self.fallback.clone()
+    }
+    async fn submit_review_batch(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comments: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        Err(AppError::process("not implemented in test fake"))
+    }
+    async fn submit_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comment: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        Err(AppError::process("not implemented in test fake"))
     }
 }
 

--- a/crates/core/tests/pull_requests.rs
+++ b/crates/core/tests/pull_requests.rs
@@ -9,7 +9,7 @@ use markdown_reviewer_core::domain::{
     ChangeStatus, ChangedFile, DiffHunk, HunkKind, PullRequestDetail, PullRequestState,
     PullRequestSummary,
 };
-use markdown_reviewer_core::ports::{GhAuthReport, GhClient, GitClient};
+use markdown_reviewer_core::ports::{GhAuthReport, GhClient, GitClient, ReviewCommentInput};
 use markdown_reviewer_core::{AppError, AppResult};
 
 struct FakeGh {
@@ -78,6 +78,24 @@ impl GhClient for FakeGh {
         _file_path: &str,
     ) -> AppResult<String> {
         Ok(String::new())
+    }
+    async fn submit_review_batch(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comments: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        Err(AppError::process("not implemented in test fake"))
+    }
+    async fn submit_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comment: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        Err(AppError::process("not implemented in test fake"))
     }
 }
 

--- a/crates/core/tests/repo_selection.rs
+++ b/crates/core/tests/repo_selection.rs
@@ -5,7 +5,7 @@ use markdown_reviewer_core::application::repo_selection::{
     check_tools::check_tools, recents, validate_repository::validate_repository, RepoSelection,
 };
 use markdown_reviewer_core::ports::{
-    Clock, GhAuthReport, GhClient, GitClient, RecentRepository, RecentsStore,
+    Clock, GhAuthReport, GhClient, GitClient, RecentRepository, RecentsStore, ReviewCommentInput,
 };
 use markdown_reviewer_core::AppError;
 use time::OffsetDateTime;
@@ -110,6 +110,24 @@ impl GhClient for FakeGh {
         _file_path: &str,
     ) -> markdown_reviewer_core::AppResult<String> {
         Ok(String::new())
+    }
+    async fn submit_review_batch(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comments: &[ReviewCommentInput],
+    ) -> markdown_reviewer_core::AppResult<Vec<i64>> {
+        Err(AppError::process("not implemented in test fake"))
+    }
+    async fn submit_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comment: &ReviewCommentInput,
+    ) -> markdown_reviewer_core::AppResult<i64> {
+        Err(AppError::process("not implemented in test fake"))
     }
 }
 

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use markdown_reviewer_core::domain::{
     ChangeStatus, ChangedFile, PullRequestDetail, PullRequestState, PullRequestSummary,
 };
-use markdown_reviewer_core::ports::{GhAuthReport, GhClient};
+use markdown_reviewer_core::ports::{GhAuthReport, GhClient, ReviewCommentInput};
 use markdown_reviewer_core::{AppError, AppResult};
 use serde::Deserialize;
 
@@ -11,6 +11,8 @@ use crate::process::{redact, run, run_ok};
 const TIMEOUT_MS: u64 = 7_000;
 const PR_TIMEOUT_MS: u64 = 15_000;
 const PR_FILES_TIMEOUT_MS: u64 = 30_000;
+const REVIEW_SUBMIT_TIMEOUT_MS: u64 = 30_000;
+const REVIEW_COMMENT_TIMEOUT_MS: u64 = 15_000;
 // `gh pr list` defaults to 30; bump to a value high enough to cover the
 // largest realistic open-PR backlog without paginating ourselves.
 const PR_LIST_LIMIT: &str = "200";
@@ -320,6 +322,124 @@ impl GhClient for GhCli {
             .map_err(|e| AppError::process(format!("gh api contents: invalid base64: {e}")))?;
         String::from_utf8(bytes)
             .map_err(|e| AppError::process(format!("gh api contents: invalid UTF-8: {e}")))
+    }
+
+    async fn submit_review_batch(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        comments: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        if comments.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // We assemble the call as `gh api -X POST <endpoint> -f field=value`
+        // (string) and `-F field=value` (raw / numeric). gh CLI translates
+        // bracketed names like `comments[0][path]` into a nested JSON body.
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews");
+        let commit_arg = format!("commit_id={head_sha}");
+
+        // Pre-compute every -f / -F string with stable lifetimes so the &str
+        // slice we hand to `run` stays valid for the whole call.
+        let mut owned: Vec<String> = Vec::with_capacity(4 + comments.len() * 8);
+        for (idx, c) in comments.iter().enumerate() {
+            owned.push(format!("comments[{idx}][path]={}", c.path));
+            owned.push(format!("comments[{idx}][line]={}", c.line));
+            owned.push(format!("comments[{idx}][side]=RIGHT"));
+            owned.push(format!("comments[{idx}][body]={}", c.body));
+        }
+
+        let mut args: Vec<&str> = vec!["api", "-X", "POST", &endpoint];
+        args.push("-f");
+        args.push(&commit_arg);
+        args.push("-f");
+        args.push("event=COMMENT");
+
+        // Alternate flags: -f (string) for path/side/body, -F (typed) for
+        // line so it lands as a JSON number.
+        for (idx, c) in comments.iter().enumerate() {
+            let path_idx = idx * 4;
+            let line_idx = path_idx + 1;
+            let side_idx = path_idx + 2;
+            let body_idx = path_idx + 3;
+            args.push("-f");
+            args.push(&owned[path_idx]);
+            args.push("-F");
+            args.push(&owned[line_idx]);
+            args.push("-f");
+            args.push(&owned[side_idx]);
+            args.push("-f");
+            args.push(&owned[body_idx]);
+            let _ = c; // silence unused warning if any
+        }
+
+        // `--jq '.comments | map(.id)'` extracts the ids in submission order.
+        args.push("--jq");
+        args.push(".comments | map(.id)");
+
+        let out = run("gh", &args, Some(repo_path), REVIEW_SUBMIT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, Some(pr_number)));
+        }
+
+        let ids: Vec<i64> = serde_json::from_str(out.stdout.trim()).map_err(|e| {
+            AppError::process(format!("gh api pulls/{pr_number}/reviews: invalid JSON: {e}"))
+        })?;
+        if ids.len() != comments.len() {
+            return Err(AppError::process(format!(
+                "gh api pulls/{pr_number}/reviews: expected {} comment ids, got {}",
+                comments.len(),
+                ids.len()
+            )));
+        }
+        Ok(ids)
+    }
+
+    async fn submit_review_comment(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        comment: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments");
+        let commit_arg = format!("commit_id={head_sha}");
+        let path_arg = format!("path={}", comment.path);
+        let line_arg = format!("line={}", comment.line);
+        let body_arg = format!("body={}", comment.body);
+
+        let args: Vec<&str> = vec![
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-f",
+            &commit_arg,
+            "-f",
+            &path_arg,
+            "-F",
+            &line_arg,
+            "-f",
+            "side=RIGHT",
+            "-f",
+            &body_arg,
+            "--jq",
+            ".id",
+        ];
+
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, Some(pr_number)));
+        }
+
+        let id: i64 = out.stdout.trim().parse().map_err(|e| {
+            AppError::process(format!(
+                "gh api pulls/{pr_number}/comments: invalid id: {e}"
+            ))
+        })?;
+        Ok(id)
     }
 }
 

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -385,7 +385,9 @@ impl GhClient for GhCli {
         }
 
         let ids: Vec<i64> = serde_json::from_str(out.stdout.trim()).map_err(|e| {
-            AppError::process(format!("gh api pulls/{pr_number}/reviews: invalid JSON: {e}"))
+            AppError::process(format!(
+                "gh api pulls/{pr_number}/reviews: invalid JSON: {e}"
+            ))
         })?;
         if ids.len() != comments.len() {
             return Err(AppError::process(format!(

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -341,38 +341,52 @@ impl GhClient for GhCli {
         let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews");
         let commit_arg = format!("commit_id={head_sha}");
 
-        // Pre-compute every -f / -F string with stable lifetimes so the &str
-        // slice we hand to `run` stays valid for the whole call.
-        let mut owned: Vec<String> = Vec::with_capacity(4 + comments.len() * 8);
-        for (idx, c) in comments.iter().enumerate() {
-            owned.push(format!("comments[{idx}][path]={}", c.path));
-            owned.push(format!("comments[{idx}][line]={}", c.line));
-            owned.push(format!("comments[{idx}][side]=RIGHT"));
-            owned.push(format!("comments[{idx}][body]={}", c.body));
-        }
+        // Pre-compute owned strings with stable lifetimes for the &str args
+        // we hand to `run`. We use `--raw-field` for user-provided string
+        // values (path/body/side) so a body starting with `@` (or otherwise
+        // matching gh's "@file" sigil) is sent literally instead of being
+        // interpreted as a file reference. Numeric line/start_line use `-F`
+        // so they land as JSON numbers.
+        let owned: Vec<BatchCommentSlot> = comments
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| BatchCommentSlot {
+                path: format!("comments[{idx}][path]={}", c.path),
+                line: format!("comments[{idx}][line]={}", c.line),
+                side: format!("comments[{idx}][side]=RIGHT"),
+                body: format!("comments[{idx}][body]={}", c.body),
+                start_line: c
+                    .start_line
+                    .map(|s| format!("comments[{idx}][start_line]={s}")),
+                start_side: c
+                    .start_line
+                    .map(|_| format!("comments[{idx}][start_side]=RIGHT")),
+            })
+            .collect();
 
         let mut args: Vec<&str> = vec!["api", "-X", "POST", &endpoint];
-        args.push("-f");
+        args.push("--raw-field");
         args.push(&commit_arg);
-        args.push("-f");
+        args.push("--raw-field");
         args.push("event=COMMENT");
 
-        // Alternate flags: -f (string) for path/side/body, -F (typed) for
-        // line so it lands as a JSON number.
-        for (idx, c) in comments.iter().enumerate() {
-            let path_idx = idx * 4;
-            let line_idx = path_idx + 1;
-            let side_idx = path_idx + 2;
-            let body_idx = path_idx + 3;
-            args.push("-f");
-            args.push(&owned[path_idx]);
+        for slot in &owned {
+            args.push("--raw-field");
+            args.push(&slot.path);
             args.push("-F");
-            args.push(&owned[line_idx]);
-            args.push("-f");
-            args.push(&owned[side_idx]);
-            args.push("-f");
-            args.push(&owned[body_idx]);
-            let _ = c; // silence unused warning if any
+            args.push(&slot.line);
+            args.push("--raw-field");
+            args.push(&slot.side);
+            args.push("--raw-field");
+            args.push(&slot.body);
+            if let Some(start) = &slot.start_line {
+                args.push("-F");
+                args.push(start);
+            }
+            if let Some(start_side) = &slot.start_side {
+                args.push("--raw-field");
+                args.push(start_side);
+            }
         }
 
         // `--jq '.comments | map(.id)'` extracts the ids in submission order.
@@ -411,25 +425,35 @@ impl GhClient for GhCli {
         let path_arg = format!("path={}", comment.path);
         let line_arg = format!("line={}", comment.line);
         let body_arg = format!("body={}", comment.body);
+        let start_line_arg = comment.start_line.map(|s| format!("start_line={s}"));
 
-        let args: Vec<&str> = vec![
+        // `--raw-field` for user-provided strings (commit/path/body/side) so
+        // bodies starting with `@` are sent literally instead of being treated
+        // as file inputs by gh. `-F` keeps numeric `line`/`start_line` typed.
+        let mut args: Vec<&str> = vec![
             "api",
             "-X",
             "POST",
             &endpoint,
-            "-f",
+            "--raw-field",
             &commit_arg,
-            "-f",
+            "--raw-field",
             &path_arg,
             "-F",
             &line_arg,
-            "-f",
+            "--raw-field",
             "side=RIGHT",
-            "-f",
+            "--raw-field",
             &body_arg,
-            "--jq",
-            ".id",
         ];
+        if let Some(arg) = start_line_arg.as_deref() {
+            args.push("-F");
+            args.push(arg);
+            args.push("--raw-field");
+            args.push("start_side=RIGHT");
+        }
+        args.push("--jq");
+        args.push(".id");
 
         let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
         if !out.ok() {
@@ -443,6 +467,17 @@ impl GhClient for GhCli {
         })?;
         Ok(id)
     }
+}
+
+/// Stable-lifetime owned strings used to assemble each batch-comment entry's
+/// `--raw-field` / `-F` argv pair.
+struct BatchCommentSlot {
+    path: String,
+    line: String,
+    side: String,
+    body: String,
+    start_line: Option<String>,
+    start_side: Option<String>,
 }
 
 /// Minimal base64 decoder for the standard alphabet. Avoids pulling in a new

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -44,12 +44,15 @@ fn row_to_comment(row: &Row<'_>) -> rusqlite::Result<ReviewComment> {
         )
     })?;
 
-    let pr_number: i64 = row.get(1)?;
+    let pr_number_signed: i64 = row.get(1)?;
+    let pr_number = u64::try_from(pr_number_signed).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(1, rusqlite::types::Type::Integer, Box::new(e))
+    })?;
     let github_id: Option<i64> = row.get(13)?;
 
     Ok(ReviewComment {
         id: row.get(0)?,
-        pr_number: u64::try_from(pr_number).unwrap_or_default(),
+        pr_number,
         file_path: row.get(2)?,
         head_sha: row.get(3)?,
         body: row.get(4)?,
@@ -147,12 +150,9 @@ fn decode_anchor(
     start_line: i64,
     end_line: i64,
 ) -> Result<CommentAnchor, BadEnum> {
-    let payload: AnchorPayload = serde_json::from_str(data).unwrap_or(AnchorPayload {
-        line: None,
-        start_line: None,
-        end_line: None,
-        code_start_line: None,
-    });
+    // Surface JSON corruption rather than silently inventing a line number.
+    let payload: AnchorPayload = serde_json::from_str(data)
+        .map_err(|e| BadEnum(format!("anchor_data: invalid JSON: {e}")))?;
     let start = payload
         .start_line
         .or(payload.line)

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -138,7 +138,9 @@ fn encode_anchor(anchor: &CommentAnchor) -> (String, String, i64, i64) {
     };
     (
         kind.to_string(),
-        serde_json::to_string(&payload).unwrap_or_default(),
+        // Programming error if this fails — every variant of `AnchorPayload`
+        // is a plain struct of `Option<u32>` and serializes losslessly.
+        serde_json::to_string(&payload).expect("AnchorPayload always serializes"),
         i64::from(start),
         i64::from(end),
     )

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -1,0 +1,383 @@
+use async_trait::async_trait;
+use markdown_reviewer_core::domain::{
+    CommentAnchor, CommentState, CommentUpdate, ReviewComment,
+};
+use markdown_reviewer_core::ports::{CommentsStore, NewComment, SubmitOutcome};
+use markdown_reviewer_core::{AppError, AppResult};
+use rusqlite::{params, Connection, Row};
+
+use super::Db;
+
+pub struct SqliteCommentsStore {
+    db: Db,
+}
+
+impl SqliteCommentsStore {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+const SELECT_COLS: &str = "id, pr_number, file_path, head_sha, body, author, state, \
+    anchor_kind, anchor_data, anchor_start_line, anchor_end_line, \
+    created_at, updated_at, github_id, submit_error";
+
+fn row_to_comment(row: &Row<'_>) -> rusqlite::Result<ReviewComment> {
+    let anchor_kind: String = row.get(7)?;
+    let anchor_data: String = row.get(8)?;
+    let anchor_start_line: i64 = row.get(9)?;
+    let anchor_end_line: i64 = row.get(10)?;
+    let anchor = decode_anchor(&anchor_kind, &anchor_data, anchor_start_line, anchor_end_line)
+        .map_err(|e| {
+            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
+        })?;
+
+    let state_raw: String = row.get(6)?;
+    let state = CommentState::from_str(&state_raw).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            6,
+            rusqlite::types::Type::Text,
+            Box::new(BadEnum(state_raw.clone())),
+        )
+    })?;
+
+    let pr_number: i64 = row.get(1)?;
+    let github_id: Option<i64> = row.get(13)?;
+
+    Ok(ReviewComment {
+        id: row.get(0)?,
+        pr_number: u64::try_from(pr_number).unwrap_or_default(),
+        file_path: row.get(2)?,
+        head_sha: row.get(3)?,
+        body: row.get(4)?,
+        author: row.get(5)?,
+        state,
+        anchor,
+        created_at: row.get(11)?,
+        updated_at: row.get(12)?,
+        github_id,
+        submit_error: row.get(14)?,
+    })
+}
+
+#[derive(Debug)]
+struct BadEnum(String);
+
+impl std::fmt::Display for BadEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown enum value: {}", self.0)
+    }
+}
+
+impl std::error::Error for BadEnum {}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AnchorPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    line: Option<u32>,
+    #[serde(default, rename = "startLine", skip_serializing_if = "Option::is_none")]
+    start_line: Option<u32>,
+    #[serde(default, rename = "endLine", skip_serializing_if = "Option::is_none")]
+    end_line: Option<u32>,
+    #[serde(default, rename = "codeStartLine", skip_serializing_if = "Option::is_none")]
+    code_start_line: Option<u32>,
+}
+
+fn encode_anchor(anchor: &CommentAnchor) -> (String, String, i64, i64) {
+    let (kind, payload, start, end): (&str, AnchorPayload, u32, u32) = match anchor {
+        CommentAnchor::SingleLine { line } => (
+            "singleLine",
+            AnchorPayload {
+                line: Some(*line),
+                start_line: None,
+                end_line: None,
+                code_start_line: None,
+            },
+            *line,
+            *line,
+        ),
+        CommentAnchor::LineRange {
+            start_line,
+            end_line,
+        } => (
+            "lineRange",
+            AnchorPayload {
+                line: None,
+                start_line: Some(*start_line),
+                end_line: Some(*end_line),
+                code_start_line: None,
+            },
+            *start_line,
+            *end_line,
+        ),
+        CommentAnchor::CodeBlock {
+            start_line,
+            end_line,
+            code_start_line,
+        } => (
+            "codeBlock",
+            AnchorPayload {
+                line: None,
+                start_line: Some(*start_line),
+                end_line: Some(*end_line),
+                code_start_line: Some(*code_start_line),
+            },
+            *start_line,
+            *end_line,
+        ),
+    };
+    (
+        kind.to_string(),
+        serde_json::to_string(&payload).unwrap_or_default(),
+        i64::from(start),
+        i64::from(end),
+    )
+}
+
+fn decode_anchor(
+    kind: &str,
+    data: &str,
+    start_line: i64,
+    end_line: i64,
+) -> Result<CommentAnchor, BadEnum> {
+    let payload: AnchorPayload = serde_json::from_str(data).unwrap_or(AnchorPayload {
+        line: None,
+        start_line: None,
+        end_line: None,
+        code_start_line: None,
+    });
+    let start = payload
+        .start_line
+        .or(payload.line)
+        .unwrap_or_else(|| u32::try_from(start_line).unwrap_or(1));
+    let end = payload
+        .end_line
+        .or(payload.line)
+        .unwrap_or_else(|| u32::try_from(end_line).unwrap_or(start));
+    match kind {
+        "singleLine" => Ok(CommentAnchor::SingleLine {
+            line: payload.line.unwrap_or(start),
+        }),
+        "lineRange" => Ok(CommentAnchor::LineRange {
+            start_line: start,
+            end_line: end,
+        }),
+        "codeBlock" => Ok(CommentAnchor::CodeBlock {
+            start_line: start,
+            end_line: end,
+            code_start_line: payload.code_start_line.unwrap_or(start),
+        }),
+        other => Err(BadEnum(other.to_string())),
+    }
+}
+
+fn fetch_one(conn: &Connection, id: i64) -> AppResult<ReviewComment> {
+    let sql = format!("SELECT {SELECT_COLS} FROM local_comments WHERE id = ?1");
+    conn.query_row(&sql, params![id], row_to_comment)
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => AppError::db(format!("comment {id} not found")),
+            other => AppError::db(other),
+        })
+}
+
+#[async_trait]
+impl CommentsStore for SqliteCommentsStore {
+    async fn list_for_pr(&self, pr_number: u64) -> AppResult<Vec<ReviewComment>> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM local_comments \
+                 WHERE pr_number = ?1 \
+                 ORDER BY file_path ASC, anchor_start_line ASC, id ASC"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(AppError::db)?;
+            let rows = stmt
+                .query_map(params![pr_signed], row_to_comment)
+                .map_err(AppError::db)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(AppError::db)?);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn list_for_file(
+        &self,
+        pr_number: u64,
+        file_path: &str,
+    ) -> AppResult<Vec<ReviewComment>> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        let path_owned = file_path.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let sql = format!(
+                "SELECT {SELECT_COLS} FROM local_comments \
+                 WHERE pr_number = ?1 AND file_path = ?2 \
+                 ORDER BY anchor_start_line ASC, id ASC"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(AppError::db)?;
+            let rows = stmt
+                .query_map(params![pr_signed, path_owned], row_to_comment)
+                .map_err(AppError::db)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(AppError::db)?);
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn get(&self, id: i64) -> AppResult<Option<ReviewComment>> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let sql = format!("SELECT {SELECT_COLS} FROM local_comments WHERE id = ?1");
+            match conn.query_row(&sql, params![id], row_to_comment) {
+                Ok(c) => Ok(Some(c)),
+                Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                Err(e) => Err(AppError::db(e)),
+            }
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn create(&self, new: NewComment, now_unix_ms: i64) -> AppResult<ReviewComment> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let (kind, data, start, end) = encode_anchor(&new.anchor);
+            let pr_signed = i64::try_from(new.pr_number).unwrap_or(i64::MAX);
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            conn.execute(
+                "INSERT INTO local_comments(pr_number, file_path, head_sha, body, author, state, \
+                    anchor_kind, anchor_data, anchor_start_line, anchor_end_line, \
+                    created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'draft', ?6, ?7, ?8, ?9, ?10, ?10)",
+                params![
+                    pr_signed,
+                    new.file_path,
+                    new.head_sha,
+                    new.body,
+                    new.author,
+                    kind,
+                    data,
+                    start,
+                    end,
+                    now_unix_ms,
+                ],
+            )
+            .map_err(AppError::db)?;
+            let id = conn.last_insert_rowid();
+            fetch_one(&conn, id)
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn update(
+        &self,
+        id: i64,
+        patch: CommentUpdate,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let current = fetch_one(&conn, id)?;
+
+            let new_state = patch.state.unwrap_or(current.state);
+            if !current.state.can_transition_to(new_state) {
+                return Err(AppError::db(format!(
+                    "illegal state transition: {} -> {}",
+                    current.state.as_str(),
+                    new_state.as_str()
+                )));
+            }
+
+            let new_anchor = patch.anchor.unwrap_or(current.anchor);
+            let new_body = patch.body.unwrap_or(current.body);
+            let (kind, data, start, end) = encode_anchor(&new_anchor);
+
+            conn.execute(
+                "UPDATE local_comments SET \
+                    body = ?1, state = ?2, anchor_kind = ?3, anchor_data = ?4, \
+                    anchor_start_line = ?5, anchor_end_line = ?6, updated_at = ?7 \
+                 WHERE id = ?8",
+                params![
+                    new_body,
+                    new_state.as_str(),
+                    kind,
+                    data,
+                    start,
+                    end,
+                    now_unix_ms,
+                    id
+                ],
+            )
+            .map_err(AppError::db)?;
+
+            fetch_one(&conn, id)
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn delete(&self, id: i64, now_unix_ms: i64) -> AppResult<()> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            conn.execute(
+                "UPDATE local_comments SET state = 'deleted', updated_at = ?1 WHERE id = ?2",
+                params![now_unix_ms, id],
+            )
+            .map_err(AppError::db)?;
+            Ok(())
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn record_submit(
+        &self,
+        id: i64,
+        outcome: SubmitOutcome,
+        now_unix_ms: i64,
+    ) -> AppResult<ReviewComment> {
+        let db = self.db.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let next_state = if outcome.github_id.is_some() {
+                CommentState::Submitted
+            } else {
+                CommentState::Draft
+            };
+            conn.execute(
+                "UPDATE local_comments SET \
+                    github_id = COALESCE(?1, github_id), \
+                    submit_error = ?2, \
+                    state = ?3, \
+                    updated_at = ?4 \
+                 WHERE id = ?5",
+                params![
+                    outcome.github_id,
+                    outcome.submit_error,
+                    next_state.as_str(),
+                    now_unix_ms,
+                    id
+                ],
+            )
+            .map_err(AppError::db)?;
+            fetch_one(&conn, id)
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+}

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -1,7 +1,5 @@
 use async_trait::async_trait;
-use markdown_reviewer_core::domain::{
-    CommentAnchor, CommentState, CommentUpdate, ReviewComment,
-};
+use markdown_reviewer_core::domain::{CommentAnchor, CommentState, CommentUpdate, ReviewComment};
 use markdown_reviewer_core::ports::{CommentsStore, NewComment, SubmitOutcome};
 use markdown_reviewer_core::{AppError, AppResult};
 use rusqlite::{params, Connection, Row};
@@ -27,10 +25,15 @@ fn row_to_comment(row: &Row<'_>) -> rusqlite::Result<ReviewComment> {
     let anchor_data: String = row.get(8)?;
     let anchor_start_line: i64 = row.get(9)?;
     let anchor_end_line: i64 = row.get(10)?;
-    let anchor = decode_anchor(&anchor_kind, &anchor_data, anchor_start_line, anchor_end_line)
-        .map_err(|e| {
-            rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
-        })?;
+    let anchor = decode_anchor(
+        &anchor_kind,
+        &anchor_data,
+        anchor_start_line,
+        anchor_end_line,
+    )
+    .map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(8, rusqlite::types::Type::Text, Box::new(e))
+    })?;
 
     let state_raw: String = row.get(6)?;
     let state = CommentState::from_str(&state_raw).ok_or_else(|| {
@@ -79,7 +82,11 @@ struct AnchorPayload {
     start_line: Option<u32>,
     #[serde(default, rename = "endLine", skip_serializing_if = "Option::is_none")]
     end_line: Option<u32>,
-    #[serde(default, rename = "codeStartLine", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "codeStartLine",
+        skip_serializing_if = "Option::is_none"
+    )]
     code_start_line: Option<u32>,
 }
 

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -155,14 +155,11 @@ fn decode_anchor(
     // Surface JSON corruption rather than silently inventing a line number.
     let payload: AnchorPayload = serde_json::from_str(data)
         .map_err(|e| BadEnum(format!("anchor_data: invalid JSON: {e}")))?;
-    let start = payload
-        .start_line
-        .or(payload.line)
-        .unwrap_or_else(|| u32::try_from(start_line).unwrap_or(1));
-    let end = payload
-        .end_line
-        .or(payload.line)
-        .unwrap_or_else(|| u32::try_from(end_line).unwrap_or(start));
+    // Prefer the JSON payload, fall back to the dedicated columns. If neither
+    // yields a valid 1-indexed `u32`, fail loudly — defaulting to `1` would
+    // silently move the anchor.
+    let start = read_line(payload.start_line, payload.line, start_line, "start_line")?;
+    let end = read_line(payload.end_line, payload.line, end_line, "end_line")?;
     match kind {
         "singleLine" => Ok(CommentAnchor::SingleLine {
             line: payload.line.unwrap_or(start),
@@ -178,6 +175,37 @@ fn decode_anchor(
         }),
         other => Err(BadEnum(other.to_string())),
     }
+}
+
+/// Resolves a 1-indexed source line from the JSON payload, falling back to
+/// the dedicated `SQLite` column. Returns an error when neither yields a
+/// valid `u32 >= 1` so corrupt rows surface instead of getting a silent
+/// default.
+fn read_line(
+    primary: Option<u32>,
+    fallback: Option<u32>,
+    column: i64,
+    field: &str,
+) -> Result<u32, BadEnum> {
+    if let Some(v) = primary.or(fallback) {
+        if v == 0 {
+            return Err(BadEnum(format!(
+                "anchor_data.{field}: zero is not 1-indexed"
+            )));
+        }
+        return Ok(v);
+    }
+    let v = u32::try_from(column).map_err(|_| {
+        BadEnum(format!(
+            "anchor_data.{field}: column value {column} is out of range for u32"
+        ))
+    })?;
+    if v == 0 {
+        return Err(BadEnum(format!(
+            "anchor_data.{field}: zero is not 1-indexed"
+        )));
+    }
+    Ok(v)
 }
 
 fn fetch_one(conn: &Connection, id: i64) -> AppResult<ReviewComment> {

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -171,9 +171,27 @@ fn decode_anchor(
         "codeBlock" => Ok(CommentAnchor::CodeBlock {
             start_line: start,
             end_line: end,
-            code_start_line: payload.code_start_line.unwrap_or(start),
+            // No DB column tracks the fence opener, so a missing
+            // `codeStartLine` here is genuine corruption — fail loudly
+            // instead of silently anchoring to `start`.
+            code_start_line: read_required_payload_line(
+                payload.code_start_line,
+                "code_start_line",
+            )?,
         }),
         other => Err(BadEnum(other.to_string())),
+    }
+}
+
+/// Resolves a required 1-indexed source line that lives only in the JSON
+/// payload (no `SQLite` fallback column). Errors when missing or invalid.
+fn read_required_payload_line(value: Option<u32>, field: &str) -> Result<u32, BadEnum> {
+    match value {
+        Some(line) if line >= 1 => Ok(line),
+        Some(_) => Err(BadEnum(format!(
+            "anchor_data.{field}: zero is not 1-indexed"
+        ))),
+        None => Err(BadEnum(format!("anchor_data.{field}: missing"))),
     }
 }
 

--- a/crates/infra/src/sqlite/comments_store.rs
+++ b/crates/infra/src/sqlite/comments_store.rs
@@ -350,7 +350,7 @@ impl CommentsStore for SqliteCommentsStore {
 
             let new_state = patch.state.unwrap_or(current.state);
             if !current.state.can_transition_to(new_state) {
-                return Err(AppError::db(format!(
+                return Err(AppError::validation(format!(
                     "illegal state transition: {} -> {}",
                     current.state.as_str(),
                     new_state.as_str()

--- a/crates/infra/src/sqlite/connection.rs
+++ b/crates/infra/src/sqlite/connection.rs
@@ -15,6 +15,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0002_ui_state",
         include_str!("migrations/0002_ui_state.sql"),
     ),
+    (
+        "0003_local_comments",
+        include_str!("migrations/0003_local_comments.sql"),
+    ),
 ];
 
 pub fn open_and_migrate(path: &Path) -> AppResult<Db> {

--- a/crates/infra/src/sqlite/migrations/0003_local_comments.sql
+++ b/crates/infra/src/sqlite/migrations/0003_local_comments.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS local_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pr_number INTEGER NOT NULL,
+    file_path TEXT NOT NULL,
+    head_sha TEXT NOT NULL,
+    body TEXT NOT NULL,
+    author TEXT,
+    state TEXT NOT NULL,
+    anchor_kind TEXT NOT NULL,
+    anchor_data TEXT NOT NULL,
+    anchor_start_line INTEGER NOT NULL,
+    anchor_end_line INTEGER NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    github_id INTEGER,
+    submit_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_local_comments_pr
+    ON local_comments(pr_number);
+
+CREATE INDEX IF NOT EXISTS idx_local_comments_pr_file
+    ON local_comments(pr_number, file_path, anchor_start_line);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_local_comments_github_id
+    ON local_comments(github_id) WHERE github_id IS NOT NULL;

--- a/crates/infra/src/sqlite/mod.rs
+++ b/crates/infra/src/sqlite/mod.rs
@@ -1,5 +1,7 @@
+pub mod comments_store;
 pub mod connection;
 pub mod recents_store;
 
+pub use comments_store::SqliteCommentsStore;
 pub use connection::{open_and_migrate, Db};
 pub use recents_store::SqliteRecentsStore;

--- a/crates/infra/tests/phase1_e2e.rs
+++ b/crates/infra/tests/phase1_e2e.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use markdown_reviewer_core::application::repo_selection::{
     recents, validate_repository::validate_repository, RepoSelection,
 };
-use markdown_reviewer_core::ports::{GhAuthReport, GhClient};
+use markdown_reviewer_core::ports::{GhAuthReport, GhClient, ReviewCommentInput};
 use markdown_reviewer_core::AppError;
 use markdown_reviewer_infra::sqlite::{open_and_migrate, SqliteRecentsStore};
 use markdown_reviewer_infra::{GitCli, SystemClock};
@@ -62,6 +62,24 @@ impl GhClient for StubGh {
         _file_path: &str,
     ) -> markdown_reviewer_core::AppResult<String> {
         Ok(String::new())
+    }
+    async fn submit_review_batch(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comments: &[ReviewCommentInput],
+    ) -> markdown_reviewer_core::AppResult<Vec<i64>> {
+        Err(AppError::process("not implemented in test fake"))
+    }
+    async fn submit_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _head_sha: &str,
+        _comment: &ReviewCommentInput,
+    ) -> markdown_reviewer_core::AppResult<i64> {
+        Err(AppError::process("not implemented in test fake"))
     }
 }
 

--- a/crates/infra/tests/sqlite_comments.rs
+++ b/crates/infra/tests/sqlite_comments.rs
@@ -1,0 +1,191 @@
+//! Integration tests for `SqliteCommentsStore` against a real `SQLite` file.
+
+use markdown_reviewer_core::domain::{CommentAnchor, CommentState, CommentUpdate};
+use markdown_reviewer_core::ports::{CommentsStore, NewComment, SubmitOutcome};
+use markdown_reviewer_infra::sqlite::{open_and_migrate, SqliteCommentsStore};
+use tempfile::TempDir;
+
+fn new(path: &str, body: &str, anchor: CommentAnchor) -> NewComment {
+    NewComment {
+        pr_number: 42,
+        file_path: path.to_string(),
+        head_sha: "deadbeef".to_string(),
+        body: body.to_string(),
+        author: Some("octocat".to_string()),
+        anchor,
+    }
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn create_then_list_for_pr() {
+    let dir = TempDir::new().unwrap();
+    let db = open_and_migrate(&dir.path().join("c.sqlite")).unwrap();
+    let store = SqliteCommentsStore::new(db.clone());
+
+    store
+        .create(
+            new("README.md", "lgtm", CommentAnchor::SingleLine { line: 4 }),
+            1_000,
+        )
+        .await
+        .unwrap();
+    store
+        .create(
+            new(
+                "docs/a.md",
+                "context?",
+                CommentAnchor::LineRange {
+                    start_line: 12,
+                    end_line: 14,
+                },
+            ),
+            2_000,
+        )
+        .await
+        .unwrap();
+
+    let list = store.list_for_pr(42).await.unwrap();
+    assert_eq!(list.len(), 2);
+    assert_eq!(list[0].file_path, "README.md");
+    assert_eq!(list[1].file_path, "docs/a.md");
+    assert!(matches!(list[1].anchor, CommentAnchor::LineRange { .. }));
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn update_changes_body_and_state() {
+    let dir = TempDir::new().unwrap();
+    let db = open_and_migrate(&dir.path().join("c.sqlite")).unwrap();
+    let store = SqliteCommentsStore::new(db);
+
+    let c = store
+        .create(
+            new("R.md", "first", CommentAnchor::SingleLine { line: 1 }),
+            1_000,
+        )
+        .await
+        .unwrap();
+
+    let updated = store
+        .update(
+            c.id,
+            CommentUpdate {
+                body: Some("second".into()),
+                state: Some(CommentState::Hidden),
+                anchor: None,
+            },
+            2_000,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(updated.body, "second");
+    assert_eq!(updated.state, CommentState::Hidden);
+    assert_eq!(updated.updated_at, 2_000);
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn delete_soft_deletes() {
+    let dir = TempDir::new().unwrap();
+    let db = open_and_migrate(&dir.path().join("c.sqlite")).unwrap();
+    let store = SqliteCommentsStore::new(db);
+
+    let c = store
+        .create(
+            new("R.md", "x", CommentAnchor::SingleLine { line: 1 }),
+            1_000,
+        )
+        .await
+        .unwrap();
+    store.delete(c.id, 2_000).await.unwrap();
+
+    let row = store.get(c.id).await.unwrap().unwrap();
+    assert_eq!(row.state, CommentState::Deleted);
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn record_submit_marks_submitted() {
+    let dir = TempDir::new().unwrap();
+    let db = open_and_migrate(&dir.path().join("c.sqlite")).unwrap();
+    let store = SqliteCommentsStore::new(db);
+
+    let c = store
+        .create(
+            new("R.md", "x", CommentAnchor::SingleLine { line: 1 }),
+            1_000,
+        )
+        .await
+        .unwrap();
+    let updated = store
+        .record_submit(
+            c.id,
+            SubmitOutcome {
+                github_id: Some(98765),
+                submit_error: None,
+            },
+            2_000,
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.state, CommentState::Submitted);
+    assert_eq!(updated.github_id, Some(98765));
+    assert!(updated.submit_error.is_none());
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn record_submit_failure_keeps_draft_with_error() {
+    let dir = TempDir::new().unwrap();
+    let db = open_and_migrate(&dir.path().join("c.sqlite")).unwrap();
+    let store = SqliteCommentsStore::new(db);
+
+    let c = store
+        .create(
+            new("R.md", "x", CommentAnchor::SingleLine { line: 1 }),
+            1_000,
+        )
+        .await
+        .unwrap();
+    let updated = store
+        .record_submit(
+            c.id,
+            SubmitOutcome {
+                github_id: None,
+                submit_error: Some("rate limited".into()),
+            },
+            2_000,
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.state, CommentState::Draft);
+    assert_eq!(updated.submit_error.as_deref(), Some("rate limited"));
+}
+
+#[tokio::test]
+#[ignore = "touches a real sqlite file; run with --ignored"]
+async fn survives_reopen() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("c.sqlite");
+
+    let id = {
+        let db = open_and_migrate(&path).unwrap();
+        let store = SqliteCommentsStore::new(db);
+        store
+            .create(
+                new("R.md", "persist", CommentAnchor::SingleLine { line: 7 }),
+                1_000,
+            )
+            .await
+            .unwrap()
+            .id
+    };
+
+    let db = open_and_migrate(&path).unwrap();
+    let store = SqliteCommentsStore::new(db);
+    let row = store.get(id).await.unwrap().unwrap();
+    assert_eq!(row.body, "persist");
+    assert_eq!(row.anchor, CommentAnchor::SingleLine { line: 7 });
+}

--- a/crates/ipc/src/commands/comments.rs
+++ b/crates/ipc/src/commands/comments.rs
@@ -1,0 +1,72 @@
+use markdown_reviewer_core::application::comments::{crud, submit};
+use markdown_reviewer_core::domain::{CommentAnchor, CommentUpdate, ReviewComment};
+use markdown_reviewer_core::ports::{NewComment, ReviewSubmissionResult};
+use markdown_reviewer_core::AppError;
+use tauri::State;
+
+use crate::state::AppState;
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn list_local_comments(
+    state: State<'_, AppState>,
+    pr_number: u64,
+) -> Result<Vec<ReviewComment>, AppError> {
+    crud::list_for_pr(&state.comments, pr_number).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn list_local_comments_for_file(
+    state: State<'_, AppState>,
+    pr_number: u64,
+    file_path: String,
+) -> Result<Vec<ReviewComment>, AppError> {
+    crud::list_for_file(&state.comments, pr_number, &file_path).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn create_local_comment(
+    state: State<'_, AppState>,
+    pr_number: u64,
+    file_path: String,
+    head_sha: String,
+    body: String,
+    author: Option<String>,
+    anchor: CommentAnchor,
+) -> Result<ReviewComment, AppError> {
+    crud::create(
+        &state.comments,
+        NewComment {
+            pr_number,
+            file_path,
+            head_sha,
+            body,
+            author,
+            anchor,
+        },
+    )
+    .await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn update_local_comment(
+    state: State<'_, AppState>,
+    id: i64,
+    patch: CommentUpdate,
+) -> Result<ReviewComment, AppError> {
+    crud::update(&state.comments, id, patch).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn delete_local_comment(state: State<'_, AppState>, id: i64) -> Result<(), AppError> {
+    crud::delete(&state.comments, id).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn submit_review(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+    comment_ids: Vec<i64>,
+) -> Result<ReviewSubmissionResult, AppError> {
+    submit::run(&state.comments, &repo_path, pr_number, &comment_ids).await
+}

--- a/crates/ipc/src/commands/mod.rs
+++ b/crates/ipc/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod comments;
 pub mod files;
 pub mod pull_requests;
 pub mod recents;

--- a/crates/ipc/src/commands/tools.rs
+++ b/crates/ipc/src/commands/tools.rs
@@ -9,3 +9,14 @@ use crate::state::AppState;
 pub async fn check_tools(state: State<'_, AppState>) -> Result<ToolStatus, AppError> {
     check_tools::check_tools(&state.repo_selection).await
 }
+
+/// Returns the authenticated GitHub username (`null` when not logged in).
+/// Used by the comments feature to stamp `author` on freshly created drafts.
+#[tauri::command]
+pub async fn get_gh_user(state: State<'_, AppState>) -> Result<Option<String>, AppError> {
+    let report = state.repo_selection.gh.auth_status().await?;
+    if !report.authenticated {
+        return Ok(None);
+    }
+    Ok(report.username)
+}

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -10,6 +10,7 @@ use tauri::{generate_handler, Runtime};
 pub fn register<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
     builder.invoke_handler(generate_handler![
         commands::tools::check_tools,
+        commands::tools::get_gh_user,
         commands::repo::select_repository,
         commands::repo::validate_repository,
         commands::recents::list_recent_repositories,
@@ -20,5 +21,11 @@ pub fn register<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
         commands::pull_requests::list_changed_files,
         commands::pull_requests::load_file_diff,
         commands::files::read_markdown_file,
+        commands::comments::list_local_comments,
+        commands::comments::list_local_comments_for_file,
+        commands::comments::create_local_comment,
+        commands::comments::update_local_comment,
+        commands::comments::delete_local_comment,
+        commands::comments::submit_review,
     ])
 }

--- a/crates/ipc/src/state.rs
+++ b/crates/ipc/src/state.rs
@@ -1,3 +1,4 @@
+use markdown_reviewer_core::application::comments::Comments;
 use markdown_reviewer_core::application::files::Files;
 use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
@@ -9,4 +10,5 @@ pub struct AppState {
     pub repo_selection: RepoSelection,
     pub pull_requests: PullRequests,
     pub files: Files,
+    pub comments: Comments,
 }

--- a/design.pen
+++ b/design.pen
@@ -107,6 +107,26 @@
               "fontWeight": "500"
             },
             {
+              "type": "text",
+              "id": "KXY94",
+              "name": "sep1",
+              "fill": "#d4d4d4",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "QUn6q",
+              "name": "title1",
+              "fill": "#0a0a0a",
+              "content": "Atualizar fluxo de autenticação e renovação de sessão",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
               "type": "frame",
               "id": "NIPKk",
               "name": "spacer",
@@ -151,6 +171,34 @@
                   "fontFamily": "Inter",
                   "fontSize": 12,
                   "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "izji4",
+              "name": "Refresh",
+              "width": 32,
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "xcY2T",
+                  "name": "ri1",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "#525252"
                 }
               ]
             },
@@ -350,18 +398,22 @@
                       "type": "text",
                       "id": "gdwLC",
                       "name": "filesTitle",
-                      "fill": "#0a0a0a",
-                      "content": "Changes",
+                      "fill": "#525252",
+                      "content": "CHANGES",
                       "fontFamily": "Inter",
-                      "fontSize": 14,
-                      "fontWeight": "600"
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
                     },
                     {
                       "type": "text",
                       "id": "mDltt",
                       "name": "filesMeta",
                       "fill": "#737373",
-                      "content": "5 markdown files modified",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "8 of 8 Markdown files (6 non-Markdown hidden)",
+                      "lineHeight": 1.4,
                       "fontFamily": "Inter",
                       "fontSize": 12,
                       "fontWeight": "normal"
@@ -412,224 +464,754 @@
                 },
                 {
                   "type": "frame",
-                  "id": "YYg3H",
-                  "name": "stats",
+                  "id": "hcEf9",
+                  "name": "tree",
                   "width": "fill_container",
-                  "height": 32,
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "lUE2s",
-                      "name": "added",
-                      "height": 28,
-                      "fill": "#f0fdf4",
-                      "cornerRadius": 6,
-                      "padding": [
-                        5,
-                        8
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "RlHl1",
-                          "name": "addedText",
-                          "fill": "#166534",
-                          "content": "+42",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "V7GBh",
-                      "name": "removed",
-                      "height": 28,
-                      "fill": "#fef2f2",
-                      "cornerRadius": 6,
-                      "padding": [
-                        5,
-                        8
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "IOCsD",
-                          "name": "removedText",
-                          "fill": "#991b1b",
-                          "content": "-17",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "HnP29",
-                      "name": "statSpacer",
-                      "width": "fill_container",
-                      "height": 1
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "srViy",
-                  "name": "Active file",
-                  "width": "fill_container",
-                  "fill": "#ffffff",
-                  "cornerRadius": 8,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "#e5e5e5"
-                  },
                   "layout": "vertical",
-                  "gap": 8,
-                  "padding": 10,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "cPHYA",
-                      "name": "activeTop",
+                      "id": "WBFEL",
+                      "name": "docsRow",
                       "width": "fill_container",
+                      "height": 28,
+                      "cornerRadius": 6,
                       "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
                       "alignItems": "center",
                       "children": [
                         {
                           "type": "icon_font",
-                          "id": "1LiR4",
-                          "name": "activeIcon",
+                          "id": "7xeDh",
+                          "name": "docsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "wipTX",
+                          "name": "docsFold",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "file-text",
+                          "iconFontName": "folder",
                           "iconFontFamily": "lucide",
-                          "fill": "#0a0a0a"
+                          "fill": "#737373"
                         },
                         {
                           "type": "text",
-                          "id": "wI6Yl",
-                          "name": "activeName",
+                          "id": "RQVdl",
+                          "name": "docsName",
                           "fill": "#0a0a0a",
-                          "content": "authentication.md",
+                          "content": "docs",
                           "fontFamily": "Inter",
-                          "fontSize": 12,
+                          "fontSize": 13,
                           "fontWeight": "600"
                         }
                       ]
                     },
                     {
-                      "type": "text",
-                      "id": "MlkI1",
-                      "name": "activePath",
-                      "fill": "#737373",
-                      "content": "docs/authentication.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "normal"
+                      "type": "frame",
+                      "id": "qsquP",
+                      "name": "docsBody",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        0,
+                        0,
+                        0,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "lit7x",
+                          "name": "guidesRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ACrXW",
+                              "name": "gChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "3gtF7",
+                              "name": "gFold",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "4MmCK",
+                              "name": "gName",
+                              "fill": "#0a0a0a",
+                              "content": "guides",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "S20Xs",
+                          "name": "guidesBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Cyigp",
+                              "name": "f1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "rrIic",
+                                  "name": "f1i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QpifJ",
+                                  "name": "f1n",
+                                  "fill": "#404040",
+                                  "content": "github-integration.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "wutUm",
+                                  "name": "f1s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "9Bqb5",
+                                  "name": "f1b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "uptU4",
+                                  "name": "f1st",
+                                  "fill": "#16a34a",
+                                  "content": "+124",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Y7YOD",
+                              "name": "f2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "dRwjx",
+                                  "name": "f2i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hUgqn",
+                                  "name": "f2n",
+                                  "fill": "#404040",
+                                  "content": "markdown-rendering.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "1pgh2",
+                                  "name": "f2s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "xkzhf",
+                                  "name": "f2b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "o6ZHj",
+                                  "name": "f2st",
+                                  "fill": "#16a34a",
+                                  "content": "+173",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3KtO2",
+                          "name": "productRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "QXgWC",
+                              "name": "pChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "M09Vd",
+                              "name": "pFold",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "nvczL",
+                              "name": "pName",
+                              "fill": "#0a0a0a",
+                              "content": "product",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ox5xN",
+                          "name": "productBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "52AN2",
+                              "name": "f3",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "F7kda",
+                                  "name": "f3i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "hMtiv",
+                                  "name": "f3n",
+                                  "fill": "#404040",
+                                  "content": "comment-states.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "7Tb3P",
+                                  "name": "f3s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "399xK",
+                                  "name": "f3b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mexku",
+                                  "name": "f3st",
+                                  "fill": "#16a34a",
+                                  "content": "+114",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "z90BK",
+                              "name": "f4",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "TTQNT",
+                                  "name": "f4i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "WvlyS",
+                                  "name": "f4n",
+                                  "fill": "#404040",
+                                  "content": "onboarding-flow.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "i96B2",
+                                  "name": "f4s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fcXo7",
+                                  "name": "f4b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aTDzI",
+                                  "name": "f4st",
+                                  "fill": "#16a34a",
+                                  "content": "+142",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fW14M",
+                          "name": "rfcRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "aq0pv",
+                              "name": "rChev",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "faBGj",
+                              "name": "rFold",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "oZC6W",
+                              "name": "rName",
+                              "fill": "#0a0a0a",
+                              "content": "rfc",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AokNX",
+                          "name": "rfcBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "3jrjM",
+                              "name": "activeFile",
+                              "width": "fill_container",
+                              "height": 32,
+                              "fill": "#f5f5f5",
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "SfEF9",
+                                  "name": "f5i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#0a0a0a"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "GwSj3",
+                                  "name": "f5n",
+                                  "fill": "#0a0a0a",
+                                  "content": "0001-comment-anchoring.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "aZ6dE",
+                                  "name": "f5s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fSpUx",
+                                  "name": "f5b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "BqjQn",
+                              "name": "f6",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "OQprh",
+                                  "name": "f6i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ThSy1",
+                                  "name": "f6n",
+                                  "fill": "#404040",
+                                  "content": "0002-pr-cache-strategy.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "S5Qvb",
+                                  "name": "f6s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "tYdiH",
+                                  "name": "f6b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "67nV0",
+                                  "name": "f6st",
+                                  "fill": "#16a34a",
+                                  "content": "+89",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G0asM",
+                          "name": "f7",
+                          "width": "fill_container",
+                          "height": 32,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "3WVEP",
+                              "name": "f7i",
+                              "width": 15,
+                              "height": 15,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "PL2Ob",
+                              "name": "f7n",
+                              "fill": "#404040",
+                              "content": "README.md",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "tjReV",
+                              "name": "f7s",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "text",
+                              "id": "Z91Xx",
+                              "name": "f7b",
+                              "fill": "#16a34a",
+                              "content": "A",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "kZxyp",
+                              "name": "f7st",
+                              "fill": "#16a34a",
+                              "content": "+57",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
                     },
                     {
                       "type": "frame",
-                      "id": "4W21c",
-                      "name": "activeStatus",
+                      "id": "mtPo5",
+                      "name": "f8",
                       "width": "fill_container",
+                      "height": 32,
+                      "cornerRadius": 6,
                       "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "ellipse",
-                          "id": "Rifsc",
-                          "name": "statusDot",
-                          "fill": "#f59e0b",
-                          "width": 7,
-                          "height": 7
+                          "type": "icon_font",
+                          "id": "TZ3nz",
+                          "name": "f8i",
+                          "width": 15,
+                          "height": 15,
+                          "iconFontName": "file-text",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
                         },
                         {
                           "type": "text",
-                          "id": "l9Dcy",
-                          "name": "statusText",
-                          "fill": "#737373",
-                          "content": "2 unresolved comments",
+                          "id": "DtaRj",
+                          "name": "f8n",
+                          "fill": "#404040",
+                          "content": "README.md",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vMi2n",
+                          "name": "f8s",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "YRBEN",
+                          "name": "f8b",
+                          "fill": "#d97706",
+                          "content": "M",
                           "fontFamily": "Inter",
                           "fontSize": 11,
-                          "fontWeight": "normal"
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "AIVUt",
+                          "name": "f8st",
+                          "fill": "#dc2626",
+                          "content": "-14",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
                         }
                       ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "qQgCa",
-                  "name": "File row",
-                  "width": "fill_container",
-                  "height": 40,
-                  "gap": 8,
-                  "padding": [
-                    6,
-                    8
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "owFYY",
-                      "name": "file2Icon",
-                      "width": 15,
-                      "height": 15,
-                      "iconFontName": "file-text",
-                      "iconFontFamily": "lucide",
-                      "fill": "#737373"
-                    },
-                    {
-                      "type": "text",
-                      "id": "hOsTJ",
-                      "name": "file2Text",
-                      "fill": "#404040",
-                      "content": "session-lifecycle.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "JfKTV",
-                  "name": "File row",
-                  "width": "fill_container",
-                  "height": 40,
-                  "gap": 8,
-                  "padding": [
-                    6,
-                    8
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "Hus9F",
-                      "name": "file3Icon",
-                      "width": 15,
-                      "height": 15,
-                      "iconFontName": "file-text",
-                      "iconFontFamily": "lucide",
-                      "fill": "#737373"
-                    },
-                    {
-                      "type": "text",
-                      "id": "ozr63",
-                      "name": "file3Text",
-                      "fill": "#404040",
-                      "content": "0007-oauth-refresh.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
                     }
                   ]
                 }
@@ -2184,6 +2766,26 @@
               "fontWeight": "500"
             },
             {
+              "type": "text",
+              "id": "D8bpf",
+              "name": "sep2",
+              "fill": "#d4d4d4",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "blGk6",
+              "name": "title2",
+              "fill": "#0a0a0a",
+              "content": "Atualizar fluxo de autenticação e renovação de sessão",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
               "type": "frame",
               "id": "mrexTopSpacer",
               "name": "Spacer",
@@ -2226,6 +2828,34 @@
                   "fontFamily": "Inter",
                   "fontSize": 12,
                   "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "GXHho",
+              "name": "Refresh",
+              "width": 32,
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "teeoM",
+                  "name": "ri2",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "#525252"
                 }
               ]
             },
@@ -2418,17 +3048,21 @@
                     {
                       "type": "text",
                       "id": "mrexFilesTitle",
-                      "fill": "#0a0a0a",
-                      "content": "Changes",
+                      "fill": "#525252",
+                      "content": "CHANGES",
                       "fontFamily": "Inter",
-                      "fontSize": 14,
-                      "fontWeight": "600"
+                      "fontSize": 11,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
                     },
                     {
                       "type": "text",
                       "id": "mrexFilesMeta",
                       "fill": "#737373",
-                      "content": "5 markdown files modified",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "8 of 8 Markdown files (6 non-Markdown hidden)",
+                      "lineHeight": 1.4,
                       "fontFamily": "Inter",
                       "fontSize": 12,
                       "fontWeight": "normal"
@@ -2477,206 +3111,754 @@
                 },
                 {
                   "type": "frame",
-                  "id": "mrexStats",
-                  "name": "Diff stats",
+                  "id": "T8E8m",
+                  "name": "tree",
                   "width": "fill_container",
-                  "height": 32,
-                  "gap": 8,
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "mrexAdded",
-                      "name": "Added",
-                      "height": 28,
-                      "fill": "#f0fdf4",
-                      "cornerRadius": 6,
-                      "padding": [
-                        5,
-                        8
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "mrexAddedText",
-                          "fill": "#166534",
-                          "content": "+42",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "mrexRemoved",
-                      "name": "Removed",
-                      "height": 28,
-                      "fill": "#fef2f2",
-                      "cornerRadius": 6,
-                      "padding": [
-                        5,
-                        8
-                      ],
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "mrexRemovedText",
-                          "fill": "#991b1b",
-                          "content": "-17",
-                          "fontFamily": "Inter",
-                          "fontSize": 12,
-                          "fontWeight": "500"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "mrexActiveFile",
-                  "name": "Active file",
-                  "width": "fill_container",
-                  "fill": "#ffffff",
-                  "cornerRadius": 8,
-                  "stroke": {
-                    "align": "inside",
-                    "thickness": 1,
-                    "fill": "#e5e5e5"
-                  },
                   "layout": "vertical",
-                  "gap": 8,
-                  "padding": 10,
+                  "gap": 2,
                   "children": [
                     {
                       "type": "frame",
-                      "id": "mrexActiveFileTop",
-                      "name": "Active file top",
+                      "id": "o9DnV",
+                      "name": "docsRow",
                       "width": "fill_container",
+                      "height": 28,
+                      "cornerRadius": 6,
                       "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
                       "alignItems": "center",
                       "children": [
                         {
                           "type": "icon_font",
-                          "id": "mrexActiveIcon",
+                          "id": "zgVBk",
+                          "name": "mDocsChev",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "EKmp9",
+                          "name": "mDocsFold",
                           "width": 16,
                           "height": 16,
-                          "iconFontName": "file-text",
+                          "iconFontName": "folder",
                           "iconFontFamily": "lucide",
-                          "fill": "#0a0a0a"
+                          "fill": "#737373"
                         },
                         {
                           "type": "text",
-                          "id": "mrexActiveName",
+                          "id": "l2jRB",
+                          "name": "mDocsName",
                           "fill": "#0a0a0a",
-                          "content": "review-examples.md",
+                          "content": "docs",
                           "fontFamily": "Inter",
-                          "fontSize": 12,
+                          "fontSize": 13,
                           "fontWeight": "600"
                         }
                       ]
                     },
                     {
-                      "type": "text",
-                      "id": "mrexActivePath",
-                      "fill": "#737373",
-                      "content": "docs/review-examples.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 11,
-                      "fontWeight": "normal"
+                      "type": "frame",
+                      "id": "3rJ5t",
+                      "name": "docsBody",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        0,
+                        0,
+                        0,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "j9tsp",
+                          "name": "mGuidesRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "cWhhb",
+                              "name": "mgC",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "J8BGt",
+                              "name": "mgF",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "q6Z6v",
+                              "name": "mgN",
+                              "fill": "#0a0a0a",
+                              "content": "guides",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "vSBOU",
+                          "name": "mGuidesBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "zMXg2",
+                              "name": "mf1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "o8sad",
+                                  "name": "mf1i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pb8pm",
+                                  "name": "mf1n",
+                                  "fill": "#404040",
+                                  "content": "github-integration.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "WwtYZ",
+                                  "name": "mf1s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6yV08",
+                                  "name": "mf1b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pMo0l",
+                                  "name": "mf1st",
+                                  "fill": "#16a34a",
+                                  "content": "+124",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "d4apG",
+                              "name": "mf2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "zGaqM",
+                                  "name": "mf2i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "BjWaq",
+                                  "name": "mf2n",
+                                  "fill": "#404040",
+                                  "content": "markdown-rendering.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "QeJ9o",
+                                  "name": "mf2s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ptnyw",
+                                  "name": "mf2b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "GpbjN",
+                                  "name": "mf2st",
+                                  "fill": "#16a34a",
+                                  "content": "+173",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "w1Syt",
+                          "name": "mProductRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "1M6I7",
+                              "name": "mpC",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "7O1nX",
+                              "name": "mpF",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "7l14v",
+                              "name": "mpN",
+                              "fill": "#0a0a0a",
+                              "content": "product",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3XtS8",
+                          "name": "mProductBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "oRNME",
+                              "name": "mf3",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "v5163",
+                                  "name": "mf3i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "sm4iF",
+                                  "name": "mf3n",
+                                  "fill": "#404040",
+                                  "content": "comment-states.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "01fkq",
+                                  "name": "mf3s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "1EdjH",
+                                  "name": "mf3b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "rEbJ2",
+                                  "name": "mf3st",
+                                  "fill": "#16a34a",
+                                  "content": "+114",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "IOnZt",
+                              "name": "mf4",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "rx0tF",
+                                  "name": "mf4i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "QZ23l",
+                                  "name": "mf4n",
+                                  "fill": "#404040",
+                                  "content": "onboarding-flow.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "JqKOm",
+                                  "name": "mf4s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zXXiC",
+                                  "name": "mf4b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "W4GCy",
+                                  "name": "mf4st",
+                                  "fill": "#16a34a",
+                                  "content": "+142",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "mjjXs",
+                          "name": "mRfcRow",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "PlEr3",
+                              "name": "mrC",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "SB7Im",
+                              "name": "mrF",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "JY1Dh",
+                              "name": "mrN",
+                              "fill": "#0a0a0a",
+                              "content": "rfc",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k2FDR",
+                          "name": "mRfcBody",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "8eNIR",
+                              "name": "mf5",
+                              "width": "fill_container",
+                              "height": 32,
+                              "fill": "#f5f5f5",
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "sSSMb",
+                                  "name": "mf5i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#0a0a0a"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "PICBO",
+                                  "name": "mf5n",
+                                  "fill": "#0a0a0a",
+                                  "content": "0001-comment-anchoring.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "B2rum",
+                                  "name": "mf5s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "xkwOB",
+                                  "name": "mf5b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "83SAE",
+                              "name": "mf6",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "pZ1fE",
+                                  "name": "mf6i",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "kXtm8",
+                                  "name": "mf6n",
+                                  "fill": "#404040",
+                                  "content": "0002-pr-cache-strategy.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "FoaVo",
+                                  "name": "mf6s",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "c3pQb",
+                                  "name": "mf6b",
+                                  "fill": "#16a34a",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "VnCqt",
+                                  "name": "mf6st",
+                                  "fill": "#16a34a",
+                                  "content": "+89",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "UWXZv",
+                          "name": "mf7",
+                          "width": "fill_container",
+                          "height": 32,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "qlPQO",
+                              "name": "mf7i",
+                              "width": 15,
+                              "height": 15,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "mbLKs",
+                              "name": "mf7n",
+                              "fill": "#404040",
+                              "content": "README.md",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "uDeSt",
+                              "name": "mf7s",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "text",
+                              "id": "jVTde",
+                              "name": "mf7b",
+                              "fill": "#16a34a",
+                              "content": "A",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "nYokF",
+                              "name": "mf7st",
+                              "fill": "#16a34a",
+                              "content": "+57",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
                     },
                     {
                       "type": "frame",
-                      "id": "mrexActiveStatus",
-                      "name": "Status",
+                      "id": "ltFHv",
+                      "name": "mf8",
                       "width": "fill_container",
+                      "height": 32,
+                      "cornerRadius": 6,
                       "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
                       "alignItems": "center",
                       "children": [
                         {
-                          "type": "ellipse",
-                          "id": "mrexStatusDot",
-                          "fill": "#f59e0b",
-                          "width": 7,
-                          "height": 7
+                          "type": "icon_font",
+                          "id": "EZtng",
+                          "name": "mf8i",
+                          "width": 15,
+                          "height": 15,
+                          "iconFontName": "file-text",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
                         },
                         {
                           "type": "text",
-                          "id": "mrexStatusText",
-                          "fill": "#737373",
-                          "content": "edge case examples",
+                          "id": "1Jtzh",
+                          "name": "mf8n",
+                          "fill": "#404040",
+                          "content": "README.md",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "XI6bV",
+                          "name": "mf8s",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "P889y",
+                          "name": "mf8b",
+                          "fill": "#d97706",
+                          "content": "M",
                           "fontFamily": "Inter",
                           "fontSize": 11,
-                          "fontWeight": "normal"
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "text",
+                          "id": "0Lc4f",
+                          "name": "mf8st",
+                          "fill": "#dc2626",
+                          "content": "-14",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
                         }
                       ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "mrexFile2",
-                  "name": "File row",
-                  "width": "fill_container",
-                  "height": 40,
-                  "gap": 8,
-                  "padding": [
-                    6,
-                    8
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "mrexFile2Icon",
-                      "width": 15,
-                      "height": 15,
-                      "iconFontName": "file-text",
-                      "iconFontFamily": "lucide",
-                      "fill": "#737373"
-                    },
-                    {
-                      "type": "text",
-                      "id": "mrexFile2Text",
-                      "fill": "#404040",
-                      "content": "authentication.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
-                  "id": "mrexFile3",
-                  "name": "File row",
-                  "width": "fill_container",
-                  "height": 40,
-                  "gap": 8,
-                  "padding": [
-                    6,
-                    8
-                  ],
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "icon_font",
-                      "id": "mrexFile3Icon",
-                      "width": 15,
-                      "height": 15,
-                      "iconFontName": "file-text",
-                      "iconFontFamily": "lucide",
-                      "fill": "#737373"
-                    },
-                    {
-                      "type": "text",
-                      "id": "mrexFile3Text",
-                      "fill": "#404040",
-                      "content": "oauth-refresh.md",
-                      "fontFamily": "Inter",
-                      "fontSize": 12,
-                      "fontWeight": "normal"
                     }
                   ]
                 }
@@ -2925,7 +4107,6 @@
                       "id": "mrexDoc",
                       "name": "Scrollable rendered markdown examples",
                       "width": "fill_container",
-                      "height": 1720,
                       "fill": "#ffffff",
                       "cornerRadius": 8,
                       "stroke": {
@@ -4952,6 +6133,665 @@
                                   "fontFamily": "Menlo",
                                   "fontSize": 12,
                                   "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "qIhhk",
+                          "name": "Final - fluxo comentar",
+                          "width": "fill_container",
+                          "fill": "#f8fafc",
+                          "cornerRadius": 12,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#cbd5e1"
+                          },
+                          "layout": "vertical",
+                          "gap": 14,
+                          "padding": 16,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "pUS0o",
+                              "name": "finalTitle",
+                              "fill": "#0f172a",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Fluxo final da criação de comentário",
+                              "fontFamily": "Inter",
+                              "fontSize": 20,
+                              "fontWeight": "700"
+                            },
+                            {
+                              "type": "text",
+                              "id": "u2PIT",
+                              "name": "finalSub",
+                              "fill": "#475569",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Do destaque da linha até a thread criada, no formato final da interface.",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Wapl5",
+                              "name": "finalCols",
+                              "width": "fill_container",
+                              "gap": 14,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "CGYpI",
+                                  "name": "Examples final",
+                                  "width": "fill_container",
+                                  "layout": "vertical",
+                                  "gap": 10,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "PZD3P",
+                                      "name": "exTitle",
+                                      "fill": "#1d4ed8",
+                                      "content": "Exemplos do fluxo",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "700"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "UpIBx",
+                                      "name": "exSub",
+                                      "fill": "#475569",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Sequência real de criação de comentário em linha de código.",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "1lSZ4",
+                                      "name": "step1",
+                                      "width": "fill_container",
+                                      "fill": "#ffffff",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#e2e8f0"
+                                      },
+                                      "layout": "vertical",
+                                      "gap": 8,
+                                      "padding": 10,
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "QLmvl",
+                                          "name": "step1Title",
+                                          "fill": "#0f172a",
+                                          "content": "1. Seleção de linha",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "GRIWB",
+                                          "name": "step1Line",
+                                          "width": "fill_container",
+                                          "fill": "#fffbeb",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "align": "inside",
+                                            "thickness": 1,
+                                            "fill": "#fcd34d"
+                                          },
+                                          "gap": 8,
+                                          "padding": [
+                                            8,
+                                            10
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "BePUg",
+                                              "name": "step1Num",
+                                              "fill": "#a16207",
+                                              "content": "42",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "700"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "8aADc",
+                                              "name": "step1Code",
+                                              "fill": "#92400e",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "if (!isSessionValid(token)) refreshSession();",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "cdBNr",
+                                      "name": "step2",
+                                      "width": "fill_container",
+                                      "fill": "#ffffff",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#e2e8f0"
+                                      },
+                                      "layout": "vertical",
+                                      "gap": 8,
+                                      "padding": 10,
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "6FqI5",
+                                          "name": "step2Title",
+                                          "fill": "#0f172a",
+                                          "content": "2. Ícone de comentar aparece",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "PYx8a",
+                                          "name": "step2Line",
+                                          "width": "fill_container",
+                                          "fill": "#fffbeb",
+                                          "cornerRadius": 6,
+                                          "stroke": {
+                                            "align": "inside",
+                                            "thickness": 1,
+                                            "fill": "#fcd34d"
+                                          },
+                                          "gap": 8,
+                                          "padding": [
+                                            8,
+                                            10
+                                          ],
+                                          "alignItems": "center",
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "Tdwtc",
+                                              "name": "step2Num",
+                                              "fill": "#a16207",
+                                              "content": "42",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "700"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "GZKDQ",
+                                              "name": "step2Code",
+                                              "fill": "#92400e",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "if (!isSessionValid(token)) refreshSession();",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            },
+                                            {
+                                              "type": "frame",
+                                              "id": "PxE4P",
+                                              "name": "step2Cta",
+                                              "fill": "#eff6ff",
+                                              "cornerRadius": 999,
+                                              "stroke": {
+                                                "align": "inside",
+                                                "thickness": 1,
+                                                "fill": "#bfdbfe"
+                                              },
+                                              "gap": 6,
+                                              "padding": [
+                                                5,
+                                                9
+                                              ],
+                                              "children": [
+                                                {
+                                                  "type": "icon_font",
+                                                  "id": "l2p8E",
+                                                  "name": "step2Icon",
+                                                  "width": 14,
+                                                  "height": 14,
+                                                  "iconFontName": "message-square-plus",
+                                                  "iconFontFamily": "lucide",
+                                                  "fill": "#1d4ed8"
+                                                },
+                                                {
+                                                  "type": "text",
+                                                  "id": "7D513",
+                                                  "name": "step2Txt",
+                                                  "fill": "#1d4ed8",
+                                                  "content": "Comentar",
+                                                  "fontFamily": "Inter",
+                                                  "fontSize": 12,
+                                                  "fontWeight": "600"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "0OK7d",
+                                      "name": "step3",
+                                      "width": "fill_container",
+                                      "fill": "#ffffff",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#e2e8f0"
+                                      },
+                                      "layout": "vertical",
+                                      "gap": 8,
+                                      "padding": 10,
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "PGhsH",
+                                          "name": "step3Title",
+                                          "fill": "#0f172a",
+                                          "content": "3. Clique no ícone abre o balão",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "600"
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "lKJjO",
+                                          "name": "composer",
+                                          "width": "fill_container",
+                                          "fill": "#ffffff",
+                                          "cornerRadius": 8,
+                                          "stroke": {
+                                            "align": "inside",
+                                            "thickness": 1,
+                                            "fill": "#d4d4d8"
+                                          },
+                                          "layout": "vertical",
+                                          "gap": 8,
+                                          "padding": 8,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "TN4xj",
+                                              "name": "composerMeta",
+                                              "fill": "#64748b",
+                                              "content": "Comentando linha 42",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "PMFA7",
+                                              "name": "composerInput",
+                                              "fill": "#a1a1aa",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Escreva um comentário...",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            },
+                                            {
+                                              "type": "frame",
+                                              "id": "4Gofz",
+                                              "name": "composerActions",
+                                              "width": "fill_container",
+                                              "gap": 8,
+                                              "justifyContent": "end",
+                                              "children": [
+                                                {
+                                                  "type": "text",
+                                                  "id": "iMhQJ",
+                                                  "name": "composerCancel",
+                                                  "fill": "#71717a",
+                                                  "content": "Cancelar",
+                                                  "fontFamily": "Inter",
+                                                  "fontSize": 12,
+                                                  "fontWeight": "500"
+                                                },
+                                                {
+                                                  "type": "frame",
+                                                  "id": "O9ys6",
+                                                  "name": "composerSendOff",
+                                                  "fill": "#f4f4f5",
+                                                  "cornerRadius": 6,
+                                                  "stroke": {
+                                                    "align": "inside",
+                                                    "thickness": 1,
+                                                    "fill": "#e4e4e7"
+                                                  },
+                                                  "padding": [
+                                                    5,
+                                                    9
+                                                  ],
+                                                  "children": [
+                                                    {
+                                                      "type": "text",
+                                                      "id": "wVT5L",
+                                                      "name": "composerSendOffTxt",
+                                                      "fill": "#a1a1aa",
+                                                      "content": "Comentar",
+                                                      "fontFamily": "Inter",
+                                                      "fontSize": 12,
+                                                      "fontWeight": "600"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "6PfP7",
+                                      "name": "step4",
+                                      "width": "fill_container",
+                                      "fill": "#eff6ff",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#bfdbfe"
+                                      },
+                                      "layout": "vertical",
+                                      "gap": 8,
+                                      "padding": 10,
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "OgL5O",
+                                          "name": "step4Title",
+                                          "fill": "#1e3a8a",
+                                          "content": "4. Comentário criado",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 13,
+                                          "fontWeight": "700"
+                                        },
+                                        {
+                                          "type": "frame",
+                                          "id": "YPXUU",
+                                          "name": "comment",
+                                          "width": "fill_container",
+                                          "fill": "#ffffff",
+                                          "cornerRadius": 8,
+                                          "stroke": {
+                                            "align": "inside",
+                                            "thickness": 1,
+                                            "fill": "#dbeafe"
+                                          },
+                                          "layout": "vertical",
+                                          "gap": 7,
+                                          "padding": 8,
+                                          "children": [
+                                            {
+                                              "type": "text",
+                                              "id": "7cVte",
+                                              "name": "commentMeta",
+                                              "fill": "#64748b",
+                                              "content": "joao.dias • agora",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 11,
+                                              "fontWeight": "600"
+                                            },
+                                            {
+                                              "type": "text",
+                                              "id": "fColw",
+                                              "name": "commentBody",
+                                              "fill": "#1f2937",
+                                              "textGrowth": "fixed-width",
+                                              "width": "fill_container",
+                                              "content": "Pode haver corrida de estado aqui. Sugiro mover para helper e cobrir com teste de timeout.",
+                                              "fontFamily": "Inter",
+                                              "fontSize": 12,
+                                              "fontWeight": "normal"
+                                            },
+                                            {
+                                              "type": "frame",
+                                              "id": "ZmTFs",
+                                              "name": "commentTag",
+                                              "fill": "#dcfce7",
+                                              "cornerRadius": 999,
+                                              "padding": [
+                                                4,
+                                                8
+                                              ],
+                                              "children": [
+                                                {
+                                                  "type": "text",
+                                                  "id": "V4ARy",
+                                                  "name": "commentTagTxt",
+                                                  "fill": "#166534",
+                                                  "content": "Thread aberta",
+                                                  "fontFamily": "Inter",
+                                                  "fontSize": 11,
+                                                  "fontWeight": "600"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "t0w9g",
+                                  "name": "Rules final",
+                                  "width": 220,
+                                  "layout": "vertical",
+                                  "gap": 10,
+                                  "padding": 12,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "6wt5w",
+                                      "name": "header",
+                                      "fill": "#2B3440",
+                                      "textGrowth": "fixed-width",
+                                      "width": "fill_container",
+                                      "content": "Checklist de Review",
+                                      "fontFamily": "DM Sans",
+                                      "fontSize": 14,
+                                      "fontWeight": "700"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "a9mly",
+                                      "name": "note1",
+                                      "width": "fill_container",
+                                      "fill": "#FFF7D6",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#E9DDAD"
+                                      },
+                                      "layout": "vertical",
+                                      "padding": [
+                                        10,
+                                        12
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "tbhID",
+                                          "name": "note1Text",
+                                          "fill": "#3A4452",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Seja claro e específico no comentário.",
+                                          "lineHeight": 1.35,
+                                          "fontFamily": "DM Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "FwQTe",
+                                      "name": "note2",
+                                      "width": "fill_container",
+                                      "fill": "#FFF7D6",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#E9DDAD"
+                                      },
+                                      "layout": "vertical",
+                                      "padding": [
+                                        10,
+                                        12
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Utlz3",
+                                          "name": "note2Text",
+                                          "fill": "#3A4452",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Aponte impacto e proponha solução prática.",
+                                          "lineHeight": 1.35,
+                                          "fontFamily": "DM Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "YOy9A",
+                                      "name": "note3",
+                                      "width": "fill_container",
+                                      "fill": "#FFF7D6",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#E9DDAD"
+                                      },
+                                      "layout": "vertical",
+                                      "padding": [
+                                        10,
+                                        12
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "L2Hyz",
+                                          "name": "note3Text",
+                                          "fill": "#3A4452",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Priorize feedback por severidade e risco.",
+                                          "lineHeight": 1.35,
+                                          "fontFamily": "DM Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "7Q0FX",
+                                      "name": "note4",
+                                      "width": "fill_container",
+                                      "fill": "#FFF7D6",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#E9DDAD"
+                                      },
+                                      "layout": "vertical",
+                                      "padding": [
+                                        10,
+                                        12
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "jHrWh",
+                                          "name": "note4Text",
+                                          "fill": "#3A4452",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Evite tom pessoal; foque no código.",
+                                          "lineHeight": 1.35,
+                                          "fontFamily": "DM Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "MuA8T",
+                                      "name": "note5",
+                                      "width": "fill_container",
+                                      "fill": "#FFF7D6",
+                                      "cornerRadius": 10,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#E9DDAD"
+                                      },
+                                      "layout": "vertical",
+                                      "padding": [
+                                        10,
+                                        12
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "23AYu",
+                                          "name": "note5Text",
+                                          "fill": "#3A4452",
+                                          "textGrowth": "fixed-width",
+                                          "width": "fill_container",
+                                          "content": "Confirme contexto antes de sugerir mudanças.",
+                                          "lineHeight": 1.35,
+                                          "fontFamily": "DM Sans",
+                                          "fontSize": 12,
+                                          "fontWeight": "normal"
+                                        }
+                                      ]
+                                    }
+                                  ]
                                 }
                               ]
                             }
@@ -9881,6 +11721,6462 @@
                   "fontFamily": "Inter",
                   "fontSize": 16,
                   "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "6vGYd",
+      "x": 900,
+      "y": 4020,
+      "name": "Markdown Reviewer - Ultrawide shell",
+      "width": 2560,
+      "height": 1080,
+      "fill": "#fafafa",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Kmuuz",
+          "name": "App header",
+          "width": "fill_container",
+          "height": 57,
+          "fill": "#fafafa",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "#e5e5e5"
+          },
+          "gap": 12,
+          "padding": [
+            12,
+            32
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Mj9dJ",
+              "name": "Brand",
+              "height": 32,
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "E0yTB",
+                  "name": "mark",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "#171717",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "57uwW",
+                      "name": "markIcon",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "#fafafa"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "XbtVR",
+                  "name": "brandText",
+                  "fill": "#0a0a0a",
+                  "content": "Markdown Reviewer",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "yatyL",
+              "name": "crumb",
+              "fill": "#737373",
+              "content": "acme/docs",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "aDVz5",
+              "name": "slash",
+              "fill": "#d4d4d4",
+              "content": "/",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "c01To",
+              "name": "pr",
+              "fill": "#0a0a0a",
+              "content": "PR #128",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "9VfPY",
+              "name": "prDot",
+              "fill": "#d4d4d4",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "FWZ0M",
+              "name": "prTitle",
+              "fill": "#0a0a0a",
+              "content": "Atualizar fluxo de autenticação e renovação de sessão",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "frame",
+              "id": "H0zOj",
+              "name": "spacer",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "fy8cl",
+              "name": "Branch selector",
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "gap": 7,
+              "padding": [
+                6,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "WjAK9",
+                  "name": "branchIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "#737373"
+                },
+                {
+                  "type": "text",
+                  "id": "X2Mmq",
+                  "name": "branchText",
+                  "fill": "#0a0a0a",
+                  "content": "feature/auth-docs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "iA2zP",
+              "name": "Refresh",
+              "width": 32,
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "4iveo",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "#525252"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "CEoia",
+              "name": "Complete review",
+              "height": 32,
+              "fill": "#171717",
+              "cornerRadius": 6,
+              "gap": 7,
+              "padding": [
+                6,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "pA8MN",
+                  "name": "reviewIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "check",
+                  "iconFontFamily": "lucide",
+                  "fill": "#fafafa"
+                },
+                {
+                  "type": "text",
+                  "id": "pYPms",
+                  "name": "reviewText",
+                  "fill": "#fafafa",
+                  "content": "Finalizar",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dhQxQ",
+          "name": "Review shell",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "7Qase",
+              "name": "Icon rail",
+              "width": 48,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                12,
+                6
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "fYBul",
+                  "name": "home",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "#171717",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "5D1V2",
+                      "name": "homeIcon",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "#fafafa"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "G5u9R",
+                  "name": "reviewNav",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "#f5f5f5",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "MUArn",
+                      "name": "reviewNavIcon",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "message-square",
+                      "iconFontFamily": "lucide",
+                      "fill": "#525252"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "e6yy7",
+                  "name": "gitNav",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "6oqQ0",
+                      "name": "gitNavIcon",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "git-pull-request",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vQO8n",
+                  "name": "settingsSpacer",
+                  "width": 1,
+                  "height": "fill_container"
+                },
+                {
+                  "type": "frame",
+                  "id": "G4CHa",
+                  "name": "settings",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "zuBP9",
+                      "name": "settingsIcon",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "afcgv",
+              "name": "Changed files",
+              "width": 340,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OuCdp",
+                  "fill": "#525252",
+                  "content": "CHANGES",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "5ALcD",
+                  "fill": "#737373",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "8 of 8 Markdown files (6 non-Markdown hidden)",
+                  "lineHeight": 1.4,
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "yHtcu",
+                  "name": "sa",
+                  "width": "fill_container",
+                  "height": 36,
+                  "fill": "#fafafa",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "UUIY9",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    },
+                    {
+                      "type": "text",
+                      "id": "0udFW",
+                      "fill": "#737373",
+                      "content": "Filter files...",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jdIAF",
+                  "name": "treeA1",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "kmNEx",
+                      "name": "dr",
+                      "width": "fill_container",
+                      "height": 28,
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "T5nZr",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "pFjpo",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "folder",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xBbAm",
+                          "fill": "#0a0a0a",
+                          "content": "docs",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mPMla",
+                      "name": "docsCh1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        0,
+                        0,
+                        0,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "GLH8d",
+                          "name": "gr",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "G5ss6",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "ztoaT",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "u2GXD",
+                              "fill": "#0a0a0a",
+                              "content": "guides",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GqPQB",
+                          "name": "guidesCh1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "rGEF2",
+                              "name": "f1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "JigzD",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "P2713",
+                                  "fill": "#404040",
+                                  "content": "github-integration.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "0KeQv",
+                                  "name": "b1",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "sU3Ni",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "W3iAu",
+                                  "fill": "#166534",
+                                  "content": "+124",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vLy0i",
+                              "name": "f2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "uboFv",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "X0FP7",
+                                  "fill": "#404040",
+                                  "content": "markdown-rendering.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "tQSnd",
+                                  "name": "b2",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "z9NHO",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "GHKkr",
+                                  "fill": "#166534",
+                                  "content": "+173",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "zoVkZ",
+                          "name": "pr",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "hiGyR",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "uJ3Fv",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dgwnv",
+                              "fill": "#0a0a0a",
+                              "content": "product",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wMznN",
+                          "name": "productCh1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "CdJXi",
+                              "name": "p1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "rrusG",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "vymf3",
+                                  "fill": "#404040",
+                                  "content": "comment-states.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "bStH8",
+                                  "name": "pb1",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "MWjG2",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "wOHxd",
+                                  "fill": "#166534",
+                                  "content": "+114",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rhFnc",
+                              "name": "p2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "ciLdc",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "N99l1",
+                                  "fill": "#404040",
+                                  "content": "onboarding-flow.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "qntkN",
+                                  "name": "pb2",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "ToVQ6",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Bio8x",
+                                  "fill": "#166534",
+                                  "content": "+142",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "ErW89",
+                          "name": "rr",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Id4eB",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "D7ajM",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "5CV12",
+                              "fill": "#0a0a0a",
+                              "content": "rfc",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "LxJvQ",
+                          "name": "rfcCh1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "jQRqx",
+                              "name": "r1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "fill": "#f5f5f5",
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "fUgSo",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "odWYj",
+                                  "fill": "#0a0a0a",
+                                  "content": "0001-comment-anchoring.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "qE0ql",
+                                  "name": "rb1",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "nadnK",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "DDTEu",
+                                  "fill": "#166534",
+                                  "content": "+96",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "WMhV7",
+                              "name": "r2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "dzsx2",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2zyru",
+                                  "fill": "#404040",
+                                  "content": "0002-pr-cache-strategy.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "opLhZ",
+                                  "name": "rb2",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "M6ZK7",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "XKWkm",
+                                  "fill": "#166534",
+                                  "content": "+89",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "U8A9g",
+                          "name": "dre",
+                          "width": "fill_container",
+                          "height": 32,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "ADyqc",
+                              "width": 15,
+                              "height": 15,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "VzCp8",
+                              "fill": "#404040",
+                              "content": "README.md",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Ct05m",
+                              "name": "dreb",
+                              "fill": "#dcfce7",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                6
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ZElex",
+                                  "fill": "#166534",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "j8oiN",
+                              "fill": "#166534",
+                              "content": "+57",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZPGRM",
+                      "name": "rre",
+                      "width": "fill_container",
+                      "height": 32,
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "T7W12",
+                          "width": 15,
+                          "height": 15,
+                          "iconFontName": "file-text",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hVJNd",
+                          "fill": "#404040",
+                          "content": "README.md",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "foyFB",
+                          "name": "rreb",
+                          "fill": "#fef3c7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Hsk3R",
+                              "fill": "#92400e",
+                              "content": "M",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "mjnSb",
+                          "fill": "#991b1b",
+                          "content": "-14",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BiJPU",
+              "name": "Review canvas",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#f5f5f5",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "S79zA",
+                  "name": "Review toolbar",
+                  "width": "fill_container",
+                  "height": 56,
+                  "fill": "#fafafa",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    32
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "3lfgE",
+                      "name": "Tabs",
+                      "height": 36,
+                      "fill": "#f5f5f5",
+                      "cornerRadius": 8,
+                      "gap": 2,
+                      "padding": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "efLDS",
+                          "name": "previewTab",
+                          "height": 30,
+                          "fill": "#ffffff",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "padding": [
+                            6,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "iqYoX",
+                              "name": "previewLabel",
+                              "fill": "#0a0a0a",
+                              "content": "Preview",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "QPVVy",
+                          "name": "diffLabel",
+                          "fill": "#737373",
+                          "content": "Diff",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "jzVbR",
+                          "name": "splitLabel",
+                          "fill": "#737373",
+                          "content": "Split",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "S0Hxy",
+                      "name": "filePath",
+                      "fill": "#737373",
+                      "content": "docs/authentication.md",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XskK9",
+                      "name": "spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CFmBa",
+                      "name": "commentToggle",
+                      "height": 32,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "cIDtj",
+                          "name": "commentIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "#525252"
+                        },
+                        {
+                          "type": "text",
+                          "id": "y92RV",
+                          "name": "commentText",
+                          "fill": "#0a0a0a",
+                          "content": "Comments",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZvgwZ",
+                      "name": "Hide all comments",
+                      "height": 32,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "81Mzb",
+                          "name": "hideAllIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "eye-off",
+                          "iconFontFamily": "lucide",
+                          "fill": "#525252"
+                        },
+                        {
+                          "type": "text",
+                          "id": "YCTnd",
+                          "name": "hideAllText",
+                          "fill": "#0a0a0a",
+                          "content": "Hide all",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kB2Z0",
+                      "name": "Hidden comments badge",
+                      "height": 32,
+                      "fill": "#fff7ed",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#fed7aa"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "mfXn6",
+                          "name": "hiddenBadgeIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "message-square-more",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9a3412"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Sm4Gq",
+                          "name": "hiddenBadgeText",
+                          "fill": "#9a3412",
+                          "content": "2 hidden",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xz0Xk",
+                  "name": "Document stage",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#f5f5f5",
+                  "gap": 20,
+                  "padding": [
+                    24,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "z8hZM",
+                      "name": "Rendered markdown",
+                      "width": 920,
+                      "fill": "#ffffff",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "layout": "vertical",
+                      "gap": 8,
+                      "padding": [
+                        28,
+                        44
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "2g3UO",
+                          "name": "h1",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Autenticação e renovação de sessão",
+                          "fontFamily": "Inter",
+                          "fontSize": 30,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "hWkvX",
+                          "name": "lead",
+                          "fill": "#404040",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Este documento descreve o fluxo de login, renovação de token e invalidação de sessão usado pelos clientes web e mobile.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "line",
+                          "id": "m6BbJ",
+                          "name": "divider",
+                          "width": "fill_container",
+                          "height": 1,
+                          "stroke": {
+                            "align": "center",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          }
+                        },
+                        {
+                          "type": "text",
+                          "id": "vJJDK",
+                          "name": "paragraph",
+                          "fill": "#404040",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "O access token deve ser validado em todas as chamadas internas antes de consultar serviços protegidos.",
+                          "lineHeight": 1.5,
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "SluwM",
+                          "name": "Selected review range",
+                          "width": "fill_container",
+                          "fill": "#fffbeb",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#fde68a"
+                          },
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            12
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "urUs9",
+                              "name": "line",
+                              "fill": "#92400e",
+                              "content": "42",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "WgobI",
+                              "name": "selectedText",
+                              "fill": "#78350f",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "O refresh token deve permanecer válido por 30 dias e ser renovado automaticamente quando faltar menos de 5 minutos para expirar.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "0wZCG",
+                          "name": "h2",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Fluxo esperado",
+                          "fontFamily": "Inter",
+                          "fontSize": 20,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QyCu9",
+                          "name": "Visible inline review comment",
+                          "width": "fill_container",
+                          "fill": "#ffffff",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#d4d4d4"
+                          },
+                          "layout": "vertical",
+                          "gap": 6,
+                          "padding": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ESZAI",
+                              "name": "popMeta",
+                              "fill": "#0a0a0a",
+                              "content": "João commented on lines 42-43",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "zyi6E",
+                              "name": "Comment body",
+                              "width": "fill_container",
+                              "fill": "#fafafa",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#e5e5e5"
+                              },
+                              "layout": "vertical",
+                              "padding": 8,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "mF4Ks",
+                                  "name": "popPlaceholder",
+                                  "fill": "#404040",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Esse prazo de 30 dias precisa citar a política de segurança mobile e o comportamento offline.",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xLUv1",
+                              "name": "popActions",
+                              "width": "fill_container",
+                              "height": 30,
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "YrSnL",
+                                  "name": "cancel",
+                                  "fill": "#737373",
+                                  "content": "Reply",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "v0JCT",
+                                  "name": "popSpacer",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "9QpFQ",
+                                  "name": "submit",
+                                  "height": 30,
+                                  "fill": "#171717",
+                                  "cornerRadius": 6,
+                                  "padding": [
+                                    5,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "IEaBb",
+                                      "name": "submitText",
+                                      "fill": "#fafafa",
+                                      "content": "Hide",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "1yhZ1",
+                                  "name": "Resolve inline comment",
+                                  "height": 30,
+                                  "fill": "#fafafa",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#e5e5e5"
+                                  },
+                                  "gap": 6,
+                                  "padding": [
+                                    5,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "gFKUK",
+                                      "name": "resolveInlineIcon",
+                                      "width": 13,
+                                      "height": 13,
+                                      "iconFontName": "check",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#166534"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "8yrG1",
+                                      "name": "resolveInlineText",
+                                      "fill": "#166534",
+                                      "content": "Resolve",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "xIsb2",
+                          "name": "li1",
+                          "fill": "#404040",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "- Validar assinatura do access token antes de qualquer chamada interna.",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Is1ej",
+                          "name": "li2",
+                          "fill": "#404040",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "- Emitir novo par de tokens apenas quando o refresh token estiver íntegro.",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "VyU1V",
+                          "name": "Commented visible line",
+                          "width": "fill_container",
+                          "fill": "#eff6ff",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "left": 3
+                            },
+                            "fill": "#2563eb"
+                          },
+                          "gap": 10,
+                          "padding": [
+                            8,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "x0qAt",
+                              "name": "commentedLineNo",
+                              "fill": "#1d4ed8",
+                              "content": "58",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "anIf7",
+                              "name": "commentedText",
+                              "fill": "#1e3a8a",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Ao detectar refresh token inválido, o cliente deve encerrar a sessão local e redirecionar para login.",
+                              "lineHeight": 1.5,
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Wg97z",
+                              "name": "Visible comment count",
+                              "height": 24,
+                              "fill": "#dbeafe",
+                              "cornerRadius": 999,
+                              "gap": 5,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "f3KpT",
+                                  "name": "pillIcon",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "message-square",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#1d4ed8"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zvUhW",
+                                  "name": "pillText",
+                                  "fill": "#1d4ed8",
+                                  "content": "1",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "pxvFj",
+                          "name": "Second inline comment",
+                          "width": "fill_container",
+                          "fill": "#ffffff",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#bfdbfe"
+                          },
+                          "layout": "vertical",
+                          "gap": 5,
+                          "padding": 8,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "dbJeW",
+                              "name": "commentCardMeta",
+                              "fill": "#1d4ed8",
+                              "content": "Maria commented on line 58",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "F9esG",
+                              "name": "commentCardBody",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Esse comportamento precisa aparecer também na seção de erros esperados.",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "wTn6O",
+                              "name": "commentCardActions",
+                              "width": "fill_container",
+                              "height": 28,
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tqEin",
+                                  "name": "reply2",
+                                  "fill": "#737373",
+                                  "content": "Reply",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "V1p2T",
+                                  "name": "spacer2",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Qfyxd",
+                                  "name": "hide2",
+                                  "height": 28,
+                                  "fill": "#171717",
+                                  "cornerRadius": 6,
+                                  "padding": [
+                                    4,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "8Q0dH",
+                                      "name": "hide2Text",
+                                      "fill": "#fafafa",
+                                      "content": "Hide",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "0ZVfB",
+                                  "name": "Resolve second comment",
+                                  "height": 28,
+                                  "fill": "#f0fdf4",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#bbf7d0"
+                                  },
+                                  "gap": 6,
+                                  "padding": [
+                                    4,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "fUgxo",
+                                      "name": "resolveSecondIcon",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "check",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#166534"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "TqyAW",
+                                      "name": "resolveSecondText",
+                                      "fill": "#166534",
+                                      "content": "Resolve",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "DpZyQ",
+                          "name": "Hidden comments marker",
+                          "width": "fill_container",
+                          "height": 36,
+                          "fill": "#fff7ed",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#fed7aa"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "9ao92",
+                              "name": "hiddenMarkerIcon",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "message-square-more",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9a3412"
+                            },
+                            {
+                              "type": "text",
+                              "id": "68oMF",
+                              "name": "hiddenMarkerText",
+                              "fill": "#9a3412",
+                              "content": "2 hidden comments near lines 66-71",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "sAyT8",
+                              "name": "hiddenMarkerSpacer",
+                              "width": "fill_container",
+                              "height": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "6Rkh4",
+                              "name": "Show hidden comments",
+                              "height": 24,
+                              "fill": "#ffffff",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#fed7aa"
+                              },
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "0Z3sx",
+                                  "name": "showHiddenText",
+                                  "fill": "#9a3412",
+                                  "content": "Show",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f1KKK",
+                          "name": "Collapsed resolved comment marker",
+                          "width": "fill_container",
+                          "fill": "#ffffff",
+                          "gap": 8,
+                          "padding": [
+                            2,
+                            0
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "W1ELN",
+                              "name": "Resolved marker icon",
+                              "width": 18,
+                              "height": 18,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "sxOe4",
+                                  "width": 14,
+                                  "height": 14,
+                                  "iconFontName": "message-square-off",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#94a3b8"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "9I3hm",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Registrar auditoria para login, renovação automática, logout manual e expiração forçada.",
+                              "lineHeight": 1.45,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rGFeo",
+              "name": "Review comments",
+              "width": 460,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "left": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "aPFKP",
+                  "name": "Comments header",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ST8eS",
+                      "name": "titleRow",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "HTnfa",
+                          "name": "title",
+                          "fill": "#0a0a0a",
+                          "content": "Review threads",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Bf5Jf",
+                          "name": "titleSpacer",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Oel0V",
+                          "name": "badge",
+                          "height": 22,
+                          "fill": "#f5f5f5",
+                          "cornerRadius": 999,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XgvC9",
+                              "name": "badgeText",
+                              "fill": "#525252",
+                              "content": "2 open",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "mRXgn",
+                      "name": "subtitle",
+                      "fill": "#737373",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Comments attached to rendered Markdown ranges",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NmwRv",
+                  "name": "Thread filter",
+                  "width": "fill_container",
+                  "height": 36,
+                  "fill": "#fafafa",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "g8PdD",
+                      "name": "filterIcon",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "list-filter",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rnHjV",
+                      "name": "filterText",
+                      "fill": "#0a0a0a",
+                      "content": "Open threads",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "1dLxj",
+                  "name": "Active thread",
+                  "width": "fill_container",
+                  "fill": "#ffffff",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#d4d4d4"
+                  },
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "9BL4J",
+                      "name": "activeMeta",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "SeTsq",
+                          "name": "avatar",
+                          "width": 24,
+                          "height": 24,
+                          "fill": "#171717",
+                          "cornerRadius": 999,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "q7XZh",
+                              "name": "avatarText",
+                              "fill": "#fafafa",
+                              "content": "JD",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "rnWdn",
+                          "name": "metaText",
+                          "fill": "#0a0a0a",
+                          "content": "João on line 42",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "vBshg",
+                      "name": "threadBody",
+                      "fill": "#404040",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Esse tempo de 30 dias precisa estar alinhado com a política de segurança mobile?",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "523GD",
+                      "name": "Reply input",
+                      "width": "fill_container",
+                      "height": 64,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "layout": "vertical",
+                      "padding": 10,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Kbta6",
+                          "name": "replyPlaceholder",
+                          "fill": "#737373",
+                          "content": "Reply...",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "kXe8p",
+                      "name": "threadActions",
+                      "width": "fill_container",
+                      "height": 30,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ULDpp",
+                          "name": "resolve",
+                          "height": 30,
+                          "fill": "#fafafa",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "padding": [
+                            5,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gyjUw",
+                              "name": "resolveText",
+                              "fill": "#0a0a0a",
+                              "content": "Resolve",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "NuH9L",
+                  "name": "Thread summary",
+                  "width": "fill_container",
+                  "fill": "#fafafa",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "I72ct",
+                      "name": "thread2Meta",
+                      "fill": "#0a0a0a",
+                      "content": "Maria on line 73",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "K6X2w",
+                      "name": "thread2Body",
+                      "fill": "#525252",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Confirmar se o TTL também vale para clientes offline.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ymHu6",
+                  "name": "Resolved thread summary",
+                  "opacity": 0.72,
+                  "width": "fill_container",
+                  "fill": "#fafafa",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "3wRup",
+                      "name": "thread3Meta",
+                      "fill": "#737373",
+                      "content": "Ana on line 18 - resolved",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "4owx0",
+                      "name": "thread3Body",
+                      "fill": "#737373",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "A seção de escopo ficou clara depois da última alteração.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "apQzT",
+                  "name": "Comment visibility controls",
+                  "width": "fill_container",
+                  "fill": "#ffffff",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "2YSSZ",
+                      "name": "visibilityIcon",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "eye",
+                      "iconFontFamily": "lucide",
+                      "fill": "#525252"
+                    },
+                    {
+                      "type": "text",
+                      "id": "rSRTE",
+                      "name": "visibilityText",
+                      "fill": "#0a0a0a",
+                      "content": "Visibility",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "8nwMN",
+                      "name": "visibilitySpacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "3UiHo",
+                      "name": "showAllButton",
+                      "height": 28,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "padding": [
+                        4,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "0GNsn",
+                          "name": "showAllText",
+                          "fill": "#0a0a0a",
+                          "content": "Show hidden",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "OOkNB",
+                  "name": "Collapsed resolved thread summary",
+                  "opacity": 0.74,
+                  "width": "fill_container",
+                  "fill": "#fafafa",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e2e8f0"
+                  },
+                  "layout": "vertical",
+                  "gap": 6,
+                  "padding": 8,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Xjypk",
+                      "name": "resolvedPanelMeta",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "6mLHK",
+                          "name": "resolvedPanelIcon",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "check-check",
+                          "iconFontFamily": "lucide",
+                          "fill": "#64748b"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Uroll",
+                          "name": "resolvedPanelTitle",
+                          "fill": "#64748b",
+                          "content": "Resolved - line 82",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Mkijm",
+                      "name": "resolvedPanelBody",
+                      "fill": "#64748b",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Auditoria atualizada com expiração forçada.",
+                      "lineHeight": 1.4,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "2p6cJ",
+                      "name": "resolvedPanelActions",
+                      "width": "fill_container",
+                      "height": 28,
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "W5fXi",
+                          "name": "resolvedPanelSpacer",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Eemyy",
+                          "name": "resolvedPanelReopen",
+                          "height": 28,
+                          "fill": "#ffffff",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e2e8f0"
+                          },
+                          "padding": [
+                            4,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "B5UtQ",
+                              "name": "resolvedPanelReopenText",
+                              "fill": "#475569",
+                              "content": "Reopen",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "LpY5A",
+      "x": 900,
+      "y": 5200,
+      "name": "Markdown Reviewer - Ultrawide comment examples",
+      "clip": true,
+      "width": 2560,
+      "height": 1880,
+      "fill": "#fafafa",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "qFhsm",
+          "name": "App header",
+          "width": "fill_container",
+          "height": 57,
+          "fill": "#fafafa",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "bottom": 1
+            },
+            "fill": "#e5e5e5"
+          },
+          "gap": 12,
+          "padding": [
+            12,
+            20
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "s8h9W",
+              "name": "Brand",
+              "height": 32,
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "FKD9w",
+                  "name": "Mark",
+                  "width": 28,
+                  "height": 28,
+                  "fill": "#171717",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "yDZCz",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "#fafafa"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Qp8rI",
+                  "fill": "#0a0a0a",
+                  "content": "Markdown Reviewer",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "mIYxl",
+              "fill": "#737373",
+              "content": "acme/docs",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "x2MKu",
+              "fill": "#d4d4d4",
+              "content": "/",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "SK25g",
+              "fill": "#0a0a0a",
+              "content": "PR #128",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "text",
+              "id": "XsUSK",
+              "name": "prDot",
+              "fill": "#d4d4d4",
+              "content": "·",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "0XdLf",
+              "name": "prTitle",
+              "fill": "#0a0a0a",
+              "content": "Atualizar fluxo de autenticação e renovação de sessão",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "500"
+            },
+            {
+              "type": "frame",
+              "id": "DBybD",
+              "name": "Spacer",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "Ino6H",
+              "name": "Branch selector",
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "gap": 7,
+              "padding": [
+                6,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "irnFo",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "git-branch",
+                  "iconFontFamily": "lucide",
+                  "fill": "#737373"
+                },
+                {
+                  "type": "text",
+                  "id": "3zFTw",
+                  "fill": "#0a0a0a",
+                  "content": "feature/auth-docs",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LT5HO",
+              "name": "Refresh",
+              "width": 32,
+              "height": 32,
+              "fill": "#fafafa",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#e5e5e5"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "KKLw5",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "refresh-cw",
+                  "iconFontFamily": "lucide",
+                  "fill": "#525252"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QwcVo",
+              "name": "Complete review",
+              "height": 32,
+              "fill": "#171717",
+              "cornerRadius": 6,
+              "gap": 7,
+              "padding": [
+                6,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Ng71l",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "check",
+                  "iconFontFamily": "lucide",
+                  "fill": "#fafafa"
+                },
+                {
+                  "type": "text",
+                  "id": "0Htr8",
+                  "fill": "#fafafa",
+                  "content": "Finalizar",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "XOQRY",
+          "name": "Review shell",
+          "width": "fill_container",
+          "height": "fill_container",
+          "children": [
+            {
+              "type": "frame",
+              "id": "AUqio",
+              "name": "Icon rail",
+              "width": 48,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 8,
+              "padding": [
+                12,
+                6
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BFAGF",
+                  "name": "Docs nav",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "#171717",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "oKoOm",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "file-text",
+                      "iconFontFamily": "lucide",
+                      "fill": "#fafafa"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "4xkHq",
+                  "name": "Comments nav",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "#f5f5f5",
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "p3kvd",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "message-square",
+                      "iconFontFamily": "lucide",
+                      "fill": "#525252"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "donjX",
+                  "name": "Git nav",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "MB5im",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "git-pull-request",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "32d2S",
+                  "name": "Spacer",
+                  "width": 1,
+                  "height": "fill_container"
+                },
+                {
+                  "type": "frame",
+                  "id": "jzWSK",
+                  "name": "Settings",
+                  "width": 36,
+                  "height": 36,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "scWd7",
+                      "width": 17,
+                      "height": 17,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ykhzx",
+              "name": "Changed files",
+              "width": 340,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 14,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "idUMx",
+                  "fill": "#525252",
+                  "content": "CHANGES",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                },
+                {
+                  "type": "text",
+                  "id": "HGfeK",
+                  "fill": "#737373",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "8 of 8 Markdown files (6 non-Markdown hidden)",
+                  "lineHeight": 1.4,
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "irOw4",
+                  "name": "sb",
+                  "width": "fill_container",
+                  "height": 36,
+                  "fill": "#fafafa",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "DYQiA",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Khrzq",
+                      "fill": "#737373",
+                      "content": "Filter files...",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "nMJwG",
+                  "name": "treeB1",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "bvzpe",
+                      "name": "drB",
+                      "width": "fill_container",
+                      "height": 28,
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "4TkBj",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "RKucZ",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "folder",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "text",
+                          "id": "eq4sy",
+                          "fill": "#0a0a0a",
+                          "content": "docs",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rvaAw",
+                      "name": "docsChB1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "padding": [
+                        0,
+                        0,
+                        0,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Z1SbF",
+                          "name": "grB",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "tymig",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "iJpQt",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "S6Z3u",
+                              "fill": "#0a0a0a",
+                              "content": "guides",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OYWrZ",
+                          "name": "guidesChB1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "6Wv1u",
+                              "name": "g1B",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "AQ54E",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "JxP6K",
+                                  "fill": "#404040",
+                                  "content": "github-integration.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "p4VVN",
+                                  "name": "gb1B",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "cL8Ca",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "r9ALf",
+                                  "fill": "#166534",
+                                  "content": "+124",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "7reaF",
+                              "name": "g2B",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "bBmvX",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "PPM3C",
+                                  "fill": "#404040",
+                                  "content": "markdown-rendering.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "sZXtv",
+                                  "name": "gb2B",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "V6yYU",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "A4ybj",
+                                  "fill": "#166534",
+                                  "content": "+173",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "7cA7i",
+                          "name": "prB",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "Dt2NM",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "GCe74",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "F1C5H",
+                              "fill": "#0a0a0a",
+                              "content": "product",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Gf6OA",
+                          "name": "productChB1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "GxmGs",
+                              "name": "pp1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "VKskx",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Z0ATX",
+                                  "fill": "#404040",
+                                  "content": "comment-states.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "nCSFw",
+                                  "name": "ppb1",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Pn3I8",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "LGIcN",
+                                  "fill": "#166534",
+                                  "content": "+114",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "68nyy",
+                              "name": "pp2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "NQo3t",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "yNXtf",
+                                  "fill": "#404040",
+                                  "content": "onboarding-flow.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "mClqk",
+                                  "name": "ppb2",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "vtxjs",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aMKO9",
+                                  "fill": "#166534",
+                                  "content": "+142",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Q0aSQ",
+                          "name": "rrB",
+                          "width": "fill_container",
+                          "height": 28,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "gF4JM",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "yyysm",
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "folder",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "uwAoC",
+                              "fill": "#0a0a0a",
+                              "content": "rfc",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "z4x6g",
+                          "name": "rfcChB1",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "padding": [
+                            0,
+                            0,
+                            0,
+                            20
+                          ],
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "7VJLV",
+                              "name": "rr1",
+                              "width": "fill_container",
+                              "height": 32,
+                              "fill": "#f5f5f5",
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "1kXCc",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "TlzHS",
+                                  "fill": "#0a0a0a",
+                                  "content": "0001-comment-anchoring.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "w5TxH",
+                                  "name": "rrb1",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "lmunO",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "LncQV",
+                                  "fill": "#166534",
+                                  "content": "+96",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "jGIxg",
+                              "name": "rr2",
+                              "width": "fill_container",
+                              "height": 32,
+                              "cornerRadius": 6,
+                              "gap": 8,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "BLiRa",
+                                  "width": 15,
+                                  "height": 15,
+                                  "iconFontName": "file-text",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#737373"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "iW3OD",
+                                  "fill": "#404040",
+                                  "content": "0002-pr-cache-strategy.md",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Rrqy0",
+                                  "name": "rrb2",
+                                  "fill": "#dcfce7",
+                                  "cornerRadius": 4,
+                                  "padding": [
+                                    2,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "gtnA1",
+                                      "fill": "#166534",
+                                      "content": "A",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ziKpt",
+                                  "fill": "#166534",
+                                  "content": "+89",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NqXAE",
+                          "name": "dreB",
+                          "width": "fill_container",
+                          "height": 32,
+                          "cornerRadius": 6,
+                          "gap": 8,
+                          "padding": [
+                            4,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "m3wRo",
+                              "width": 15,
+                              "height": 15,
+                              "iconFontName": "file-text",
+                              "iconFontFamily": "lucide",
+                              "fill": "#737373"
+                            },
+                            {
+                              "type": "text",
+                              "id": "uUGvj",
+                              "fill": "#404040",
+                              "content": "README.md",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "bZS4h",
+                              "name": "drebB",
+                              "fill": "#dcfce7",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                6
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ScG65",
+                                  "fill": "#166534",
+                                  "content": "A",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "7gf67",
+                              "fill": "#166534",
+                              "content": "+57",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZZ0xM",
+                      "name": "rreB",
+                      "width": "fill_container",
+                      "height": 32,
+                      "cornerRadius": 6,
+                      "gap": 8,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "aIGJC",
+                          "width": 15,
+                          "height": 15,
+                          "iconFontName": "file-text",
+                          "iconFontFamily": "lucide",
+                          "fill": "#737373"
+                        },
+                        {
+                          "type": "text",
+                          "id": "6mcfR",
+                          "fill": "#404040",
+                          "content": "README.md",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "aiBWX",
+                          "name": "rrebB",
+                          "fill": "#fef3c7",
+                          "cornerRadius": 4,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "7JJCD",
+                              "fill": "#92400e",
+                              "content": "M",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ktu7t",
+                          "fill": "#991b1b",
+                          "content": "-14",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zY6Gz",
+              "name": "Review canvas",
+              "width": "fill_container",
+              "height": "fill_container",
+              "fill": "#f5f5f5",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "O7dkU",
+                  "name": "Review toolbar",
+                  "width": "fill_container",
+                  "height": 56,
+                  "fill": "#fafafa",
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": {
+                      "bottom": 1
+                    },
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 12,
+                  "padding": [
+                    10,
+                    20
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "dhBC1",
+                      "name": "Tabs",
+                      "height": 36,
+                      "fill": "#f5f5f5",
+                      "cornerRadius": 8,
+                      "gap": 8,
+                      "padding": 3,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "dFacK",
+                          "name": "Preview tab",
+                          "height": 30,
+                          "fill": "#ffffff",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "padding": [
+                            6,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "9E3h3",
+                              "fill": "#0a0a0a",
+                              "content": "Preview",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "6ohV0",
+                          "fill": "#737373",
+                          "content": "Diff",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Wq3gV",
+                          "fill": "#737373",
+                          "content": "Split",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "kGY8c",
+                      "fill": "#737373",
+                      "content": "docs/review-examples.md",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EExwX",
+                      "name": "Spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "62dVL",
+                      "name": "Comments toggle",
+                      "height": 32,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "iSrQQ",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "message-square",
+                          "iconFontFamily": "lucide",
+                          "fill": "#525252"
+                        },
+                        {
+                          "type": "text",
+                          "id": "GSE7s",
+                          "fill": "#0a0a0a",
+                          "content": "Comments",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "F9ush",
+                      "name": "Hide all comments",
+                      "height": 32,
+                      "fill": "#fafafa",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "KSQO4",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "eye-off",
+                          "iconFontFamily": "lucide",
+                          "fill": "#525252"
+                        },
+                        {
+                          "type": "text",
+                          "id": "UKIVQ",
+                          "fill": "#0a0a0a",
+                          "content": "Hide all",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YZueQ",
+                      "name": "Hidden badge",
+                      "height": 32,
+                      "fill": "#fff7ed",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#fed7aa"
+                      },
+                      "gap": 7,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "PUzTI",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "message-square-off",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9a3412"
+                        },
+                        {
+                          "type": "text",
+                          "id": "knTmz",
+                          "fill": "#9a3412",
+                          "content": "3 hidden",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Vmb33",
+                  "name": "Document stage",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "fill": "#f5f5f5",
+                  "padding": [
+                    28,
+                    40
+                  ],
+                  "justifyContent": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "BpuDC",
+                      "name": "Scrollable rendered markdown examples",
+                      "width": 960,
+                      "height": 1720,
+                      "fill": "#ffffff",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#e5e5e5"
+                      },
+                      "layout": "vertical",
+                      "gap": 12,
+                      "padding": [
+                        32,
+                        44
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jcEnG",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Exemplos de review em Markdown",
+                          "fontFamily": "Inter",
+                          "fontSize": 28,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zr3of",
+                          "fill": "#404040",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "A tela precisa suportar comentários em texto comum, blocos de código e seleções longas sem perder legibilidade.",
+                          "lineHeight": 1.45,
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "GEWV3",
+                          "name": "Same line with multiple comments",
+                          "width": "fill_container",
+                          "fill": "#eff6ff",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "left": 3
+                            },
+                            "fill": "#2563eb"
+                          },
+                          "gap": 10,
+                          "padding": [
+                            8,
+                            10
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "CECwf",
+                              "fill": "#1d4ed8",
+                              "content": "24",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "TTzGH",
+                              "fill": "#1e3a8a",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "O endpoint deve retornar 404 quando o usuário não existir e 403 quando o usuário não tiver acesso.",
+                              "lineHeight": 1.45,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "d02oo",
+                              "name": "Badge",
+                              "height": 24,
+                              "fill": "#dbeafe",
+                              "cornerRadius": 999,
+                              "gap": 5,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "5My4e",
+                                  "width": 12,
+                                  "height": 12,
+                                  "iconFontName": "messages-square",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#1d4ed8"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Nl4nc",
+                                  "fill": "#1d4ed8",
+                                  "content": "2",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "fsrXu",
+                          "name": "Two comments on same line",
+                          "width": "fill_container",
+                          "gap": 10,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Ngd7a",
+                              "name": "Inline comment card",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#d4d4d4"
+                              },
+                              "layout": "vertical",
+                              "gap": 7,
+                              "padding": 10,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "3yKUG",
+                                  "name": "Comment header",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "LvQW4",
+                                      "name": "Avatar",
+                                      "width": 22,
+                                      "height": 22,
+                                      "fill": "#171717",
+                                      "cornerRadius": 999,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "8AWZd",
+                                          "fill": "#fafafa",
+                                          "content": "JD",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 9,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "6QBNP",
+                                      "fill": "#0a0a0a",
+                                      "content": "João on line 24",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "cQvYU",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "ugtuP",
+                                      "name": "Badge",
+                                      "height": 24,
+                                      "fill": "#f0fdf4",
+                                      "cornerRadius": 999,
+                                      "gap": 5,
+                                      "padding": [
+                                        3,
+                                        8
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "MOrHy",
+                                          "fill": "#166534",
+                                          "content": "Open",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "ImoBR",
+                                  "fill": "#404040",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Separar explicitamente 404 de 403 para evitar ambiguidade no contrato da API.",
+                                  "lineHeight": 1.4,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "2Fj1R",
+                                  "name": "Comment actions",
+                                  "width": "fill_container",
+                                  "height": 28,
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "bXQJi",
+                                      "fill": "#737373",
+                                      "content": "Reply",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "zdH7K",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "5rFIE",
+                                      "name": "Resolve",
+                                      "height": 28,
+                                      "fill": "#f0fdf4",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#bbf7d0"
+                                      },
+                                      "gap": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon_font",
+                                          "id": "waPAA",
+                                          "width": 12,
+                                          "height": 12,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#166534"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "NrZSz",
+                                          "fill": "#166534",
+                                          "content": "Resolve",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EWNyG",
+                                      "name": "Hide",
+                                      "height": 28,
+                                      "fill": "#171717",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "7Zxvo",
+                                          "fill": "#fafafa",
+                                          "content": "Hide",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vPBGi",
+                              "name": "Inline comment card",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#d4d4d4"
+                              },
+                              "layout": "vertical",
+                              "gap": 7,
+                              "padding": 10,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "eGWi8",
+                                  "name": "Comment header",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "9V9uN",
+                                      "name": "Avatar",
+                                      "width": 22,
+                                      "height": 22,
+                                      "fill": "#334155",
+                                      "cornerRadius": 999,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "aNIJ5",
+                                          "fill": "#fafafa",
+                                          "content": "MA",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 9,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "P5ivB",
+                                      "fill": "#0a0a0a",
+                                      "content": "Maria on line 24",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "olQOo",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "OErxP",
+                                      "name": "Badge",
+                                      "height": 24,
+                                      "fill": "#f0fdf4",
+                                      "cornerRadius": 999,
+                                      "gap": 5,
+                                      "padding": [
+                                        3,
+                                        8
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "q6nwv",
+                                          "fill": "#166534",
+                                          "content": "Open",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "e5f8f",
+                                  "fill": "#404040",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Adicionar exemplo de payload de erro para cada caso.",
+                                  "lineHeight": 1.4,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "wuzrG",
+                                  "name": "Comment actions",
+                                  "width": "fill_container",
+                                  "height": 28,
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "DJxLp",
+                                      "fill": "#737373",
+                                      "content": "Reply",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EzQFi",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EGD6w",
+                                      "name": "Resolve",
+                                      "height": 28,
+                                      "fill": "#f0fdf4",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#bbf7d0"
+                                      },
+                                      "gap": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon_font",
+                                          "id": "bGSrG",
+                                          "width": 12,
+                                          "height": 12,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#166534"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "dGY6K",
+                                          "fill": "#166534",
+                                          "content": "Resolve",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "6THUh",
+                                      "name": "Hide",
+                                      "height": 28,
+                                      "fill": "#171717",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "gGU4f",
+                                          "fill": "#fafafa",
+                                          "content": "Hide",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "x5n4b",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Seleção longa em bloco de código",
+                          "fontFamily": "Inter",
+                          "fontSize": 18,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "KthcG",
+                          "name": "TypeScript code block with long selection",
+                          "width": "fill_container",
+                          "fill": "#fafafa",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "layout": "vertical",
+                          "padding": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "00UOM",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "5kwwh",
+                                  "fill": "#a3a3a3",
+                                  "content": "01",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "S3pyU",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "export async function getUserProfile(userId: number) {",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NlM8S",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tGq0y",
+                                  "fill": "#92400e",
+                                  "content": "02",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Lghiq",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  const user = await usersService.getById(userId);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "7m5HA",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "LSKl5",
+                                  "fill": "#92400e",
+                                  "content": "03",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "LVRvb",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  if (!user) {",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "DuU50",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "JKKyT",
+                                  "fill": "#92400e",
+                                  "content": "04",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "bM7hi",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "    throw new NotFoundError(\"User not found\");",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ZNaSE",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tfk1R",
+                                  "fill": "#92400e",
+                                  "content": "05",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Sbx5h",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  }",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "7gcBM",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "pztH0",
+                                  "fill": "#92400e",
+                                  "content": "06",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "TTWvI",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  const permissions = await permissionsService.list(user.id);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "cwtLY",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "MlPhq",
+                                  "fill": "#92400e",
+                                  "content": "07",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "mPYNp",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  const teams = await teamsService.listByUser(user.id);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "57cH5",
+                                  "name": "Badge",
+                                  "height": 24,
+                                  "fill": "#fed7aa",
+                                  "cornerRadius": 999,
+                                  "gap": 5,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "61m2c",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "message-square",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#9a3412"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "2FDQK",
+                                      "fill": "#9a3412",
+                                      "content": "1",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "h7Eve",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "cLYNw",
+                                  "fill": "#92400e",
+                                  "content": "08",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "oG4x8",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  return {",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "30oON",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "cz07I",
+                                  "fill": "#92400e",
+                                  "content": "09",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "By96u",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "    id: user.id,",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xQrTM",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "3ouE1",
+                                  "fill": "#92400e",
+                                  "content": "10",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zdaYQ",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "    name: user.name,",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Yea4Z",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Gi0ZG",
+                                  "fill": "#92400e",
+                                  "content": "11",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Rrlon",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "    permissions,",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "j2liG",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#fffbeb",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#f59e0b"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "eX5jG",
+                                  "fill": "#92400e",
+                                  "content": "12",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "itmdY",
+                                  "fill": "#78350f",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "    teams,",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "wo9hv",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Cd4Ej",
+                                  "fill": "#a3a3a3",
+                                  "content": "13",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "rXDOP",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  };",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "n1QCZ",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zUbSi",
+                                  "fill": "#a3a3a3",
+                                  "content": "14",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "LoDla",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "}",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "8PWJz",
+                          "name": "Inline comment card",
+                          "width": "fill_container",
+                          "fill": "#ffffff",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#fed7aa"
+                          },
+                          "layout": "vertical",
+                          "gap": 7,
+                          "padding": 10,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "p7q9V",
+                              "name": "Comment header",
+                              "width": "fill_container",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "bOcKO",
+                                  "name": "Avatar",
+                                  "width": 22,
+                                  "height": 22,
+                                  "fill": "#475569",
+                                  "cornerRadius": 999,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "xbUuw",
+                                      "fill": "#fafafa",
+                                      "content": "AN",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 9,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Pe4ld",
+                                  "fill": "#0a0a0a",
+                                  "content": "Ana on lines 2-12",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "EF8sf",
+                                  "name": "Spacer",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "pOuwr",
+                                  "name": "Badge",
+                                  "height": 24,
+                                  "fill": "#fff7ed",
+                                  "cornerRadius": 999,
+                                  "gap": 5,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "KHF1t",
+                                      "fill": "#9a3412",
+                                      "content": "Range 2-12",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "NeQta",
+                              "fill": "#404040",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Essa seleção longa deve aceitar comentário único sobre o fluxo inteiro, inclusive quando houver código no meio.",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "9GaTd",
+                              "name": "Comment actions",
+                              "width": "fill_container",
+                              "height": 28,
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "mGKLM",
+                                  "fill": "#737373",
+                                  "content": "Reply",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "fIzgT",
+                                  "name": "Spacer",
+                                  "width": "fill_container",
+                                  "height": 1
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Ajtrm",
+                                  "name": "Resolve",
+                                  "height": 28,
+                                  "fill": "#f0fdf4",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#bbf7d0"
+                                  },
+                                  "gap": 6,
+                                  "padding": [
+                                    4,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "7350q",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "check",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#166534"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "XyYlP",
+                                      "fill": "#166534",
+                                      "content": "Resolve",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "v8h6N",
+                                  "name": "Hide",
+                                  "height": 28,
+                                  "fill": "#171717",
+                                  "cornerRadius": 6,
+                                  "padding": [
+                                    4,
+                                    10
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "WSK9h",
+                                      "fill": "#fafafa",
+                                      "content": "Hide",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "9ilti",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Código sem comentário visível, mas com marker oculto",
+                          "fontFamily": "Inter",
+                          "fontSize": 18,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AQnsG",
+                          "name": "Code block with hidden marker",
+                          "width": "fill_container",
+                          "fill": "#fafafa",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "layout": "vertical",
+                          "padding": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ycaLQ",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "WDJKf",
+                                  "fill": "#a3a3a3",
+                                  "content": "01",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "XSWe6",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "const user = await usersService.getById(1);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "2XSdc",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Vp49d",
+                                  "fill": "#a3a3a3",
+                                  "content": "02",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "0RrC9",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "beZCB",
+                                  "name": "Badge",
+                                  "height": 24,
+                                  "fill": "#fff7ed",
+                                  "cornerRadius": 999,
+                                  "gap": 5,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "6uc8I",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "message-square-off",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#9a3412"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "KT1VS",
+                                      "fill": "#9a3412",
+                                      "content": "hidden",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "59lhH",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bXUvf",
+                                  "fill": "#a3a3a3",
+                                  "content": "03",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "pv6TJ",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "return user",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "FHMlB",
+                          "fill": "#0a0a0a",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Código com comentário aberto no meio",
+                          "fontFamily": "Inter",
+                          "fontSize": 18,
+                          "fontWeight": "650"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "stzO8",
+                          "name": "TypeScript code block with open comment",
+                          "width": "fill_container",
+                          "fill": "#fafafa",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#e5e5e5"
+                          },
+                          "layout": "vertical",
+                          "padding": 8,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "LJ1vG",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "4dMvv",
+                                  "fill": "#a3a3a3",
+                                  "content": "01",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "a4aZ4",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "async function updateUserEmail(userId: number, email: string) {",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "aOAwL",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "om39g",
+                                  "fill": "#a3a3a3",
+                                  "content": "02",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "6rI5b",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  const user = await usersService.getById(userId);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lMsKK",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "PjKzg",
+                                  "fill": "#a3a3a3",
+                                  "content": "03",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "OOyC9",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  if (!user) throw new NotFoundError(\"User not found\");",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "eaPXe",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#eff6ff",
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": {
+                                  "left": 3
+                                },
+                                "fill": "#2563eb"
+                              },
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8xb9G",
+                                  "fill": "#1d4ed8",
+                                  "content": "04",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "xFJE1",
+                                  "fill": "#1e3a8a",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  await usersService.update(user.id, { email });",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "RdWDW",
+                                  "name": "Badge",
+                                  "height": 24,
+                                  "fill": "#dbeafe",
+                                  "cornerRadius": 999,
+                                  "gap": 5,
+                                  "padding": [
+                                    3,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "4BMqW",
+                                      "width": 12,
+                                      "height": 12,
+                                      "iconFontName": "message-square",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#1d4ed8"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "XkCdi",
+                                      "fill": "#1d4ed8",
+                                      "content": "open",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "lZlcf",
+                              "name": "Open code comment",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "cornerRadius": 8,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#bfdbfe"
+                              },
+                              "layout": "vertical",
+                              "gap": 7,
+                              "padding": 10,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "0ziMN",
+                                  "name": "Comment header",
+                                  "width": "fill_container",
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "t6Sos",
+                                      "name": "Avatar",
+                                      "width": 22,
+                                      "height": 22,
+                                      "fill": "#1d4ed8",
+                                      "cornerRadius": 999,
+                                      "justifyContent": "center",
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "2ZUzW",
+                                          "fill": "#ffffff",
+                                          "content": "RL",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 9,
+                                          "fontWeight": "600"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "azwFz",
+                                      "fill": "#1d4ed8",
+                                      "content": "Rafa on line 4",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "OYsLw",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "b0fg9",
+                                      "name": "Badge",
+                                      "height": 24,
+                                      "fill": "#dbeafe",
+                                      "cornerRadius": 999,
+                                      "gap": 5,
+                                      "padding": [
+                                        3,
+                                        8
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "DwKtN",
+                                          "fill": "#1d4ed8",
+                                          "content": "Open",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 11,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "AO6GM",
+                                  "fill": "#404040",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "Antes de atualizar o email, precisamos validar se o novo endereço já não pertence a outro usuário.",
+                                  "lineHeight": 1.4,
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "ATLwU",
+                                  "name": "Reply input",
+                                  "width": "fill_container",
+                                  "height": 54,
+                                  "fill": "#fafafa",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#e5e5e5"
+                                  },
+                                  "layout": "vertical",
+                                  "padding": 9,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "GS9B1",
+                                      "fill": "#737373",
+                                      "content": "Reply...",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "cOOD0",
+                                  "name": "Actions",
+                                  "width": "fill_container",
+                                  "height": 28,
+                                  "gap": 8,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "l3P87",
+                                      "fill": "#737373",
+                                      "content": "@mention",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "0M4SD",
+                                      "name": "Spacer",
+                                      "width": "fill_container",
+                                      "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "QepMi",
+                                      "name": "Resolve",
+                                      "height": 28,
+                                      "fill": "#f0fdf4",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#bbf7d0"
+                                      },
+                                      "gap": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon_font",
+                                          "id": "Hrzhb",
+                                          "width": 12,
+                                          "height": 12,
+                                          "iconFontName": "check",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#166534"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "gyrTD",
+                                          "fill": "#166534",
+                                          "content": "Resolve",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "2h2Q4",
+                                      "name": "Hide",
+                                      "height": 28,
+                                      "fill": "#171717",
+                                      "cornerRadius": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "Xvdh8",
+                                          "fill": "#fafafa",
+                                          "content": "Hide",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "9RsnV",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "KIULj",
+                                  "fill": "#a3a3a3",
+                                  "content": "05",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "zOWL3",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  await auditService.track(\"user.email.updated\", { userId });",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "J8uoW",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "4bqDX",
+                                  "fill": "#a3a3a3",
+                                  "content": "06",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "3Wo7S",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "  return usersService.getById(user.id);",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "CNnMr",
+                              "name": "Code line",
+                              "width": "fill_container",
+                              "fill": "#ffffff",
+                              "gap": 12,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "QI433",
+                                  "fill": "#a3a3a3",
+                                  "content": "07",
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "2zKrB",
+                                  "fill": "#262626",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "}",
+                                  "lineHeight": 1.45,
+                                  "fontFamily": "Menlo",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gw1PZ",
+              "name": "Review threads",
+              "width": 460,
+              "height": "fill_container",
+              "fill": "#fafafa",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "left": 1
+                },
+                "fill": "#e5e5e5"
+              },
+              "layout": "vertical",
+              "gap": 12,
+              "padding": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NLc94",
+                  "name": "Comments header",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vcGJU",
+                      "name": "Title row",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "poEHn",
+                          "fill": "#0a0a0a",
+                          "content": "Review threads",
+                          "fontFamily": "Inter",
+                          "fontSize": 14,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "cJwzK",
+                          "name": "Spacer",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TbESH",
+                          "name": "Open badge",
+                          "height": 22,
+                          "fill": "#f5f5f5",
+                          "cornerRadius": 999,
+                          "padding": [
+                            3,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "R6QPg",
+                              "fill": "#525252",
+                              "content": "4 open",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "gT4MO",
+                      "fill": "#737373",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Examples grouped by line and range",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ySTW5",
+                  "name": "Thread filter",
+                  "width": "fill_container",
+                  "height": 36,
+                  "fill": "#fafafa",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "x7W6p",
+                      "width": 15,
+                      "height": 15,
+                      "iconFontName": "list-filter",
+                      "iconFontFamily": "lucide",
+                      "fill": "#737373"
+                    },
+                    {
+                      "type": "text",
+                      "id": "o5T6w",
+                      "fill": "#0a0a0a",
+                      "content": "Open threads",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "ezice",
+                  "fill": "#0a0a0a",
+                  "content": "Thread index",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "bPtk7",
+                  "fill": "#737373",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Mostra como o painel agrupa comentários por linha ou por range.",
+                  "lineHeight": 1.4,
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "qWO6n",
+                  "name": "Thread same line",
+                  "width": "fill_container",
+                  "fill": "#ffffff",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#d4d4d4"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "T2kyN",
+                      "fill": "#0a0a0a",
+                      "content": "Line 24",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "W6jRa",
+                      "fill": "#525252",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "2 comments attached to the same paragraph.",
+                      "lineHeight": 1.35,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "8EMU0",
+                  "name": "Thread range",
+                  "width": "fill_container",
+                  "fill": "#ffffff",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#fed7aa"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "l4IXu",
+                      "fill": "#9a3412",
+                      "content": "Lines 2-12",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ux0jS",
+                      "fill": "#525252",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "One comment over an extended TypeScript selection.",
+                      "lineHeight": 1.35,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oWvr1",
+                  "name": "Hidden thread",
+                  "width": "fill_container",
+                  "fill": "#fafafa",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#e5e5e5"
+                  },
+                  "gap": 8,
+                  "padding": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "1Dzjk",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "message-square-off",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9a3412"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JQRkt",
+                      "fill": "#525252",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Hidden comment in code block",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "WdoLb",
+                  "name": "Open code thread summary",
+                  "width": "fill_container",
+                  "fill": "#ffffff",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#bfdbfe"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 10,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ghzrq",
+                      "fill": "#1d4ed8",
+                      "content": "Line 4 - open",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "5cowB",
+                      "fill": "#525252",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Open comment displayed inside a TypeScript block.",
+                      "lineHeight": 1.35,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
                 }
               ]
             }

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use markdown_reviewer_core::application::comments::Comments;
 use markdown_reviewer_core::application::files::Files;
 use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
 use markdown_reviewer_infra::{
     logging,
-    sqlite::{open_and_migrate, SqliteRecentsStore},
+    sqlite::{open_and_migrate, SqliteCommentsStore, SqliteRecentsStore},
     GhCli, GitCli, Paths, SystemClock,
 };
 use markdown_reviewer_ipc::AppState;
@@ -31,12 +32,14 @@ pub(crate) fn run() {
 
             let git = Arc::new(GitCli);
             let gh = Arc::new(GhCli);
+            let clock = Arc::new(SystemClock);
+            let comments_store = Arc::new(SqliteCommentsStore::new(db.clone()));
             let state = AppState {
                 repo_selection: RepoSelection {
                     git: git.clone(),
                     gh: gh.clone(),
                     recents: Arc::new(SqliteRecentsStore::new(db)),
-                    clock: Arc::new(SystemClock),
+                    clock: clock.clone(),
                 },
                 pull_requests: PullRequests {
                     gh: gh.clone(),
@@ -44,6 +47,11 @@ pub(crate) fn run() {
                 },
                 files: Files {
                     git: git.clone(),
+                    gh: gh.clone(),
+                },
+                comments: Comments {
+                    store: comments_store,
+                    clock,
                     gh: gh.clone(),
                 },
             };

--- a/src/features/comments/components/CommentComposer.tsx
+++ b/src/features/comments/components/CommentComposer.tsx
@@ -76,6 +76,12 @@ export function CommentComposer({
 
   function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     if (event.key === "Escape") {
+      // Don't dismiss while a save is in flight — match the click-outside
+      // guard so the user always sees the success/error state.
+      if (create.isPending) {
+        event.preventDefault();
+        return;
+      }
       event.preventDefault();
       onClose();
       return;

--- a/src/features/comments/components/CommentComposer.tsx
+++ b/src/features/comments/components/CommentComposer.tsx
@@ -1,0 +1,150 @@
+import type { CommentAnchor } from "@/shared/ipc/contract";
+import { describeError } from "@/shared/ipc/errors";
+import { cn } from "@/shared/lib/cn";
+import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
+import { Button } from "@/shared/ui/button";
+import { Textarea } from "@/shared/ui/textarea";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useCreateComment } from "../hooks/useCreateComment";
+import { useGhUser } from "../hooks/useGhUser";
+
+interface CommentComposerProps {
+  prNumber: number;
+  filePath: string;
+  headSha: string;
+  anchor: CommentAnchor;
+  onClose: () => void;
+}
+
+function useAnchorMeta(anchor: CommentAnchor): string {
+  const { t } = useTranslation();
+  if (anchor.kind === "singleLine") {
+    return t("comments.composer.metaSingle", { line: anchor.line });
+  }
+  if (anchor.startLine === anchor.endLine) {
+    return t("comments.composer.metaSingle", { line: anchor.startLine });
+  }
+  return t("comments.composer.metaRange", { start: anchor.startLine, end: anchor.endLine });
+}
+
+export function CommentComposer({
+  prNumber,
+  filePath,
+  headSha,
+  anchor,
+  onClose,
+}: CommentComposerProps) {
+  const { t } = useTranslation();
+  const [body, setBody] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const containerRef = useRef<HTMLElement>(null);
+  const create = useCreateComment();
+  const ghUser = useGhUser();
+  const trimmed = body.trim();
+  const canSubmit = trimmed.length > 0 && !create.isPending;
+
+  // Auto-focus the textarea once mounted.
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  // Click outside dismisses the composer (only when no in-flight save).
+  useEffect(() => {
+    function onPointerDown(event: MouseEvent) {
+      if (create.isPending) return;
+      if (!containerRef.current) return;
+      if (event.target instanceof Node && containerRef.current.contains(event.target)) return;
+      onClose();
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [create.isPending, onClose]);
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    create.mutate(
+      { prNumber, filePath, headSha, body: trimmed, anchor, author: ghUser.data ?? null },
+      {
+        onSuccess: () => {
+          setBody("");
+          onClose();
+        },
+      },
+    );
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      event.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  const errorView = create.error ? describeError(create.error) : null;
+  const metaLabel = useAnchorMeta(anchor);
+
+  return (
+    <section
+      ref={containerRef}
+      className={cn(
+        "flex w-full flex-col gap-1.5 rounded-lg border border-[hsl(var(--border))]",
+        "bg-[hsl(var(--card))] p-2 text-[hsl(var(--card-foreground))] shadow-sm",
+      )}
+      aria-label={t("comments.composer.placeholder")}
+    >
+      <span className="px-1 text-[11px] font-semibold text-[hsl(var(--foreground))]">
+        {metaLabel}
+      </span>
+      <div className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--muted))]">
+        <Textarea
+          ref={textareaRef}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("comments.composer.placeholder")}
+          rows={3}
+          disabled={create.isPending}
+          className={cn(
+            "min-h-[80px] resize-none border-0 bg-transparent px-2 py-2 text-[12px] leading-snug",
+            "shadow-none focus-visible:ring-0 focus-visible:border-0",
+          )}
+        />
+      </div>
+      {errorView ? (
+        <Alert tone="destructive">
+          <div>
+            <AlertTitle>{t("comments.composer.errorTitle")}</AlertTitle>
+            <AlertDescription>{errorView.description}</AlertDescription>
+          </div>
+        </Alert>
+      ) : null}
+      <div className="flex items-center justify-end gap-2 pt-0.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          disabled={create.isPending}
+          className="h-7 px-3 text-[12px] font-normal text-[hsl(var(--muted-foreground))] hover:bg-transparent hover:text-[hsl(var(--foreground))]"
+        >
+          {t("comments.composer.cancel")}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="h-7 rounded-md px-3 text-[12px] font-medium"
+        >
+          {t("comments.composer.save")}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,8 +1,9 @@
 import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, Trash2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useGhUser } from "../hooks/useGhUser";
 
 interface InlineThreadCardProps {
   comments: ReviewComment[];
@@ -11,6 +12,7 @@ interface InlineThreadCardProps {
   onResolve?: (comment: ReviewComment) => void;
   onHide?: (comment: ReviewComment) => void;
   onReply?: (head: ReviewComment) => void;
+  onDelete?: (comment: ReviewComment) => void;
 }
 
 function isRange(anchor: CommentAnchor): boolean {
@@ -84,8 +86,12 @@ export function InlineThreadCard({
   onResolve,
   onHide,
   onReply,
+  onDelete,
 }: InlineThreadCardProps) {
   const { t } = useTranslation();
+  const ghUser = useGhUser();
+  const currentUser = ghUser.data ?? null;
+  const isOwn = (c: ReviewComment) => Boolean(currentUser && c.author === currentUser);
   const head = comments[0];
   if (!head) return null;
   const isResolved = head.state === "resolved";
@@ -136,15 +142,34 @@ export function InlineThreadCard({
           key={c.id}
           className={cn(
             "px-1 text-[12px] leading-snug text-[hsl(var(--foreground))]/85",
-            idx === 0 ? "pt-0.5" : "border-t border-[hsl(var(--border))] pt-2 mt-1",
+            idx === 0 ? "pt-0.5" : "mt-1 border-[hsl(var(--border))] border-t pt-2",
           )}
         >
-          {idx > 0 && c.author ? (
-            <p className="mb-1 text-[11px] font-semibold text-[hsl(var(--foreground))]">
-              {c.author}
-            </p>
-          ) : null}
-          <p className="whitespace-pre-wrap">{c.body}</p>
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              {idx > 0 && c.author ? (
+                <p className="mb-1 text-[11px] font-semibold text-[hsl(var(--foreground))]">
+                  {c.author}
+                </p>
+              ) : null}
+              <p className="whitespace-pre-wrap">{c.body}</p>
+            </div>
+            {onDelete && isOwn(c) ? (
+              <button
+                type="button"
+                onClick={() => onDelete(c)}
+                aria-label={t("comments.thread.deleteAria")}
+                title={t("comments.thread.delete")}
+                className={cn(
+                  "shrink-0 rounded-md p-1 text-[hsl(var(--muted-foreground))]",
+                  "transition-colors hover:bg-[hsl(var(--accent))] hover:text-[hsl(var(--destructive))]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+                )}
+              >
+                <Trash2Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
         </div>
       ))}
 

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,0 +1,190 @@
+import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { CheckIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface InlineThreadCardProps {
+  comments: ReviewComment[];
+  /** When true, the thread is the currently selected one (clicked in pane). */
+  selected?: boolean;
+  onResolve?: (comment: ReviewComment) => void;
+  onHide?: (comment: ReviewComment) => void;
+  onReply?: (head: ReviewComment) => void;
+}
+
+function isRange(anchor: CommentAnchor): boolean {
+  if (anchor.kind === "singleLine") return false;
+  return anchor.startLine !== anchor.endLine;
+}
+
+function authorInitials(author: string | null): string {
+  if (!author) return "?";
+  const parts = author.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return (parts[0] ?? "").slice(0, 2).toUpperCase();
+  const first = (parts[0] ?? "")[0] ?? "";
+  const second = (parts[1] ?? "")[0] ?? "";
+  return `${first}${second}`.toUpperCase();
+}
+
+function metaLabel(t: ReturnType<typeof useTranslation>["t"], head: ReviewComment): string {
+  const author = head.author ?? t("comments.thread.anonAuthor");
+  const a = head.anchor;
+  if (a.kind === "singleLine") {
+    return t("comments.thread.metaSingle", { author, line: a.line });
+  }
+  if (a.startLine === a.endLine) {
+    return t("comments.thread.metaSingle", { author, line: a.startLine });
+  }
+  return t("comments.thread.metaRange", { author, start: a.startLine, end: a.endLine });
+}
+
+interface BadgeStyle {
+  label: string;
+  bgVar: string;
+  fgVar: string;
+}
+
+function badgeFor(t: ReturnType<typeof useTranslation>["t"], state: CommentState): BadgeStyle {
+  switch (state) {
+    case "draft":
+      return {
+        label: t("comments.thread.badgeDraft"),
+        bgVar: "--comment-draft-bg",
+        fgVar: "--comment-draft-fg",
+      };
+    case "submitted":
+      return {
+        label: t("comments.thread.badgeOpen"),
+        bgVar: "--comment-open-bg",
+        fgVar: "--comment-open-fg",
+      };
+    case "resolved":
+      return {
+        label: t("comments.thread.badgeResolved"),
+        bgVar: "--comment-open-bg",
+        fgVar: "--comment-open-fg",
+      };
+    case "hidden":
+    case "deleted":
+      return {
+        label: t(
+          state === "hidden" ? "comments.thread.badgeHidden" : "comments.thread.badgeDeleted",
+        ),
+        bgVar: "--comment-range-bg",
+        fgVar: "--comment-range-fg",
+      };
+  }
+}
+
+export function InlineThreadCard({
+  comments,
+  selected = false,
+  onResolve,
+  onHide,
+  onReply,
+}: InlineThreadCardProps) {
+  const { t } = useTranslation();
+  const head = comments[0];
+  if (!head) return null;
+  const isResolved = head.state === "resolved";
+  const isHidden = head.state === "hidden";
+  const range = isRange(head.anchor);
+  const avatarBgVar = range ? "--comment-avatar-range-bg" : "--comment-avatar-bg";
+  const cardBorderClass = range
+    ? "border-[hsl(var(--comment-range-border))]"
+    : "border-[hsl(var(--border))]";
+  const badge = badgeFor(t, head.state);
+
+  return (
+    <div
+      className={cn(
+        "my-3 flex flex-col gap-1.5 rounded-lg border bg-[hsl(var(--card))] p-3 text-[hsl(var(--card-foreground))]",
+        cardBorderClass,
+        selected ? "shadow-sm ring-1 ring-[hsl(var(--foreground))]/20" : null,
+        isResolved || isHidden ? "opacity-80" : null,
+      )}
+      data-thread-state={head.state}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full text-[9px] font-semibold"
+          style={{
+            backgroundColor: `hsl(var(${avatarBgVar}))`,
+            color: "hsl(var(--comment-avatar-fg))",
+          }}
+        >
+          {authorInitials(head.author)}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-[hsl(var(--foreground))]">
+          {metaLabel(t, head)}
+        </span>
+        <span
+          className="inline-flex h-6 shrink-0 items-center rounded-full px-2 text-[11px] font-medium"
+          style={{
+            backgroundColor: `hsl(var(${badge.bgVar}))`,
+            color: `hsl(var(${badge.fgVar}))`,
+          }}
+        >
+          {badge.label}
+        </span>
+      </div>
+
+      {comments.map((c, idx) => (
+        <div
+          key={c.id}
+          className={cn(
+            "px-1 text-[12px] leading-snug text-[hsl(var(--foreground))]/85",
+            idx === 0 ? "pt-0.5" : "border-t border-[hsl(var(--border))] pt-2 mt-1",
+          )}
+        >
+          {idx > 0 && c.author ? (
+            <p className="mb-1 text-[11px] font-semibold text-[hsl(var(--foreground))]">
+              {c.author}
+            </p>
+          ) : null}
+          <p className="whitespace-pre-wrap">{c.body}</p>
+        </div>
+      ))}
+
+      <div className="flex items-center justify-between gap-2 pt-1">
+        <button
+          type="button"
+          onClick={() => onReply?.(head)}
+          className="text-[12px] text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
+        >
+          {t("comments.thread.reply")}
+        </button>
+        <div className="flex items-center gap-2">
+          {!isResolved ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onResolve?.(head)}
+              className={cn(
+                "h-7 gap-1.5 rounded-md border-[hsl(var(--comment-resolve-border))] bg-[hsl(var(--comment-resolve-bg))]",
+                "px-2.5 text-[12px] font-medium text-[hsl(var(--comment-resolve-fg))]",
+                "hover:bg-[hsl(var(--comment-resolve-bg))]/80",
+              )}
+            >
+              <CheckIcon className="h-3 w-3" aria-hidden="true" />
+              <span>{t("comments.thread.resolve")}</span>
+            </Button>
+          ) : null}
+          {!isHidden ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => onHide?.(head)}
+              className="h-7 rounded-md px-3 text-[12px] font-medium"
+            >
+              {t("comments.thread.hide")}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -26,11 +26,19 @@ interface InlineThreadsProps {
   onComposerClose: () => void;
 }
 
+/** Composite key `${startLine}:${endLine}` so two threads sharing a startLine
+ *  but with different end lines render in distinct slots. */
+type SlotKey = string;
+
+function slotKeyFor(startLine: number, endLine: number): SlotKey {
+  return `${startLine}:${endLine}`;
+}
+
 interface SlotMap {
-  /** sourceLine → portal target div for the expanded card */
-  threads: Map<number, HTMLDivElement>;
-  /** sourceLine → portal target span for the minimized "open" badge */
-  badges: Map<number, HTMLSpanElement>;
+  /** key → portal target div for the expanded card */
+  threads: Map<SlotKey, HTMLDivElement>;
+  /** key → portal target span for the minimized "open" badge */
+  badges: Map<SlotKey, HTMLSpanElement>;
   composerSlot: HTMLDivElement | null;
 }
 
@@ -167,13 +175,14 @@ export function InlineThreads({
   return (
     <>
       {groups.map((group) => {
+        const key = slotKeyFor(group.startLine, group.endLine);
         const minimized = minimizedSet.has(group.line);
         if (minimized) {
-          const badgeSlot = slots.badges.get(group.line);
+          const badgeSlot = slots.badges.get(key);
           if (!badgeSlot) return null;
           return createPortal(
             <MinimizedThreadBadge
-              key={group.line}
+              key={key}
               count={group.comments.length}
               onExpand={() => {
                 expand(group.line);
@@ -182,15 +191,15 @@ export function InlineThreads({
               }}
             />,
             badgeSlot,
-            `thread-badge-${group.line}`,
+            `thread-badge-${key}`,
           );
         }
-        const slot = slots.threads.get(group.line);
+        const slot = slots.threads.get(key);
         if (!slot) return null;
         const isSelected = group.comments.some((c) => c.id === selectedId);
         return createPortal(
           <InlineThreadCard
-            key={group.line}
+            key={key}
             comments={group.comments}
             selected={isSelected}
             onResolve={(c) => {
@@ -202,7 +211,7 @@ export function InlineThreads({
             onDelete={(c) => remove.mutate(c.id)}
           />,
           slot,
-          `thread-${group.line}`,
+          `thread-${key}`,
         );
       })}
       {composerAnchor && slots.composerSlot
@@ -266,38 +275,48 @@ function syncSlots(
   try {
     let changed = false;
 
-    // Per-line splitting for code blocks must happen before we look up
-    // anchors so each commented line has its own DOM element (and the
-    // `[data-has-comment]` highlight CSS targets just that line).
-    splitCodeBlocks(container);
+    // Collect every source line we may need to attach against. Lazy code-block
+    // splitting only touches `<pre>` blocks that actually intersect at least
+    // one commented or composer-pending line — keeps the DOM small for
+    // documents with lots of unrelated code blocks.
+    const wantedLines = new Set<number>();
+    for (const g of groups) {
+      for (let l = g.startLine; l <= g.endLine; l++) wantedLines.add(l);
+      wantedLines.add(g.attachLine);
+    }
+    if (composerStart !== null && composerEnd !== null) {
+      for (let l = composerStart; l <= composerEnd; l++) wantedLines.add(l);
+    }
+    splitCodeBlocks(container, wantedLines);
 
     // A group needs a card slot ONLY when it isn't minimized; otherwise it
     // needs a badge slot inside the line element.
-    const wantsCard = new Set<number>();
-    const wantsBadge = new Set<number>();
+    const wantsCard = new Set<SlotKey>();
+    const wantsBadge = new Set<SlotKey>();
     for (const g of groups) {
-      if (minimized.has(g.line)) wantsBadge.add(g.line);
-      else wantsCard.add(g.line);
+      const key = slotKeyFor(g.startLine, g.endLine);
+      if (minimized.has(g.line)) wantsBadge.add(key);
+      else wantsCard.add(key);
     }
 
     const lineNodes = nearestLineNodes(container);
 
     // 1a. Remove obsolete card slots (lines no longer commented or now
     //     minimized).
-    for (const [line, node] of current.threads) {
-      if (!wantsCard.has(line) || !node.isConnected) {
+    for (const [key, node] of current.threads) {
+      if (!wantsCard.has(key) || !node.isConnected) {
         node.remove();
-        current.threads.delete(line);
+        current.threads.delete(key);
         changed = true;
       }
     }
 
     // 1b. Remove obsolete badge slots (lines no longer commented or now
     //     expanded).
-    for (const [line, node] of current.badges) {
-      if (!wantsBadge.has(line) || !node.isConnected) {
+    for (const [key, node] of current.badges) {
+      if (!wantsBadge.has(key) || !node.isConnected) {
         node.remove();
-        current.badges.delete(line);
+        current.badges.delete(key);
         changed = true;
       }
     }
@@ -327,26 +346,27 @@ function syncSlots(
     //    card sits below the last highlighted row. Badge slot mounts INSIDE
     //    `attachLine` as a trailing inline element on that line.
     for (const group of groups) {
+      const key = slotKeyFor(group.startLine, group.endLine);
       const isMinimized = minimized.has(group.line);
       markRange(lineNodes, group.startLine, group.endLine, isMinimized);
       const anchor = lineNodes.get(group.attachLine);
       if (!anchor) continue;
       if (isMinimized) {
-        if (current.badges.has(group.line)) continue;
+        if (current.badges.has(key)) continue;
         const badge = document.createElement("span");
         badge.dataset.threadBadge = "true";
         badge.dataset.sourceLine = String(group.line);
         anchor.appendChild(badge);
-        current.badges.set(group.line, badge);
+        current.badges.set(key, badge);
         changed = true;
       } else {
-        if (current.threads.has(group.line)) continue;
+        if (current.threads.has(key)) continue;
         if (!anchor.parentNode) continue;
         const slot = document.createElement("div");
         slot.dataset.threadSlot = "thread";
         slot.dataset.sourceLine = String(group.line);
         anchor.parentNode.insertBefore(slot, anchor.nextSibling);
-        current.threads.set(group.line, slot);
+        current.threads.set(key, slot);
         changed = true;
       }
     }
@@ -410,14 +430,16 @@ function removeAllSlots(container: HTMLElement) {
 }
 
 /**
- * Walks every code block and breaks its content into one
+ * Splits each code block whose lines intersect `wantedLines` into one
  * `<span data-code-line data-source-line=N>` per line so the highlight CSS
  * (and slot-injection logic) can target individual lines instead of the
  * whole block. Handles both shapes remark-rehype may produce — the
  * `data-source-line` attribute can sit on the `<pre>` OR on its inner
- * `<code>`. Idempotent.
+ * `<code>`. Idempotent. We skip code blocks the user hasn't commented on
+ * to avoid blowing up the DOM in code-heavy documents.
  */
-function splitCodeBlocks(container: HTMLElement) {
+function splitCodeBlocks(container: HTMLElement, wantedLines: Set<number>) {
+  if (wantedLines.size === 0) return;
   const seen = new WeakSet<HTMLElement>();
   const candidates = container.querySelectorAll<HTMLElement>(
     "pre[data-source-line], pre > code[data-source-line]",
@@ -437,6 +459,16 @@ function splitCodeBlocks(container: HTMLElement) {
     const host = code ?? pre;
     const text = host.textContent ?? "";
     if (text.length === 0) continue;
+    const lineCount = text.split("\n").length;
+    // Only split when at least one of this block's lines was requested.
+    let intersects = false;
+    for (let i = 0; i < lineCount; i++) {
+      if (wantedLines.has(fenceLine + 1 + i)) {
+        intersects = true;
+        break;
+      }
+    }
+    if (!intersects) continue;
 
     // Drop the trailing newline (markdown always emits one) so we don't add
     // an empty span the user can't visibly select.

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -1,6 +1,6 @@
 import { ipc } from "@/shared/ipc/client";
 import type { CommentAnchor, CommentUpdate, ReviewComment } from "@/shared/ipc/contract";
-import { useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
+import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -175,8 +175,8 @@ export function InlineThreads({
   return (
     <>
       {groups.map((group) => {
-        const key = slotKeyFor(group.startLine, group.endLine);
-        const minimized = minimizedSet.has(group.line);
+        const key = minimizedKey(group.startLine, group.endLine);
+        const minimized = minimizedSet.has(key);
         if (minimized) {
           const badgeSlot = slots.badges.get(key);
           if (!badgeSlot) return null;
@@ -185,7 +185,7 @@ export function InlineThreads({
               key={key}
               count={group.comments.length}
               onExpand={() => {
-                expand(group.line);
+                expand(key);
                 const head = group.comments[0];
                 if (head) select(head.id);
               }}
@@ -206,7 +206,7 @@ export function InlineThreads({
               select(c.id);
               update.mutate({ id: c.id, patch: { state: "resolved" } });
             }}
-            onHide={() => minimize(group.line)}
+            onHide={() => minimize(key)}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
           />,
@@ -266,7 +266,7 @@ function syncSlots(
   container: HTMLElement,
   current: SlotMap,
   groups: CommentGroup[],
-  minimized: Set<number>,
+  minimized: Set<SlotKey>,
   composerStart: number | null,
   composerEnd: number | null,
   mutatingRef: { current: boolean },
@@ -295,7 +295,7 @@ function syncSlots(
     const wantsBadge = new Set<SlotKey>();
     for (const g of groups) {
       const key = slotKeyFor(g.startLine, g.endLine);
-      if (minimized.has(g.line)) wantsBadge.add(key);
+      if (minimized.has(key)) wantsBadge.add(key);
       else wantsCard.add(key);
     }
 
@@ -326,7 +326,7 @@ function syncSlots(
       current.composerSlot &&
       (composerEnd === null ||
         !current.composerSlot.isConnected ||
-        Number(current.composerSlot.dataset.sourceLine ?? "0") !== composerEnd)
+        Number(current.composerSlot.dataset.threadSlotLine ?? "0") !== composerEnd)
     ) {
       current.composerSlot.remove();
       current.composerSlot = null;
@@ -347,7 +347,7 @@ function syncSlots(
     //    `attachLine` as a trailing inline element on that line.
     for (const group of groups) {
       const key = slotKeyFor(group.startLine, group.endLine);
-      const isMinimized = minimized.has(group.line);
+      const isMinimized = minimized.has(key);
       markRange(lineNodes, group.startLine, group.endLine, isMinimized);
       const anchor = lineNodes.get(group.attachLine);
       if (!anchor) continue;
@@ -355,7 +355,7 @@ function syncSlots(
         if (current.badges.has(key)) continue;
         const badge = document.createElement("span");
         badge.dataset.threadBadge = "true";
-        badge.dataset.sourceLine = String(group.line);
+        badge.dataset.threadSlotLine = String(group.line);
         anchor.appendChild(badge);
         current.badges.set(key, badge);
         changed = true;
@@ -364,7 +364,7 @@ function syncSlots(
         if (!anchor.parentNode) continue;
         const slot = document.createElement("div");
         slot.dataset.threadSlot = "thread";
-        slot.dataset.sourceLine = String(group.line);
+        slot.dataset.threadSlotLine = String(group.line);
         anchor.parentNode.insertBefore(slot, anchor.nextSibling);
         current.threads.set(key, slot);
         changed = true;
@@ -379,7 +379,7 @@ function syncSlots(
         if (anchor?.parentNode) {
           const slot = document.createElement("div");
           slot.dataset.threadSlot = "composer";
-          slot.dataset.sourceLine = String(composerEnd);
+          slot.dataset.threadSlotLine = String(composerEnd);
           anchor.parentNode.insertBefore(slot, anchor.nextSibling);
           current.composerSlot = slot;
           changed = true;

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -1,0 +1,472 @@
+import { ipc } from "@/shared/ipc/client";
+import type { CommentAnchor, CommentUpdate, ReviewComment } from "@/shared/ipc/contract";
+import { useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
+import { useSelectedThread } from "@/shared/stores/useSelectedThread";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  type CommentGroup,
+  anchorEndLine,
+  anchorStartLine,
+  groupCommentsByStartLine,
+} from "../lib/groupAnchors";
+import { CommentComposer } from "./CommentComposer";
+import { InlineThreadCard } from "./InlineThreadCard";
+import { MinimizedThreadBadge } from "./MinimizedThreadBadge";
+
+interface InlineThreadsProps {
+  prNumber: number;
+  filePath: string;
+  headSha: string;
+  comments: ReviewComment[];
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** When set, renders an inline draft composer at this anchor's start line. */
+  composerAnchor: CommentAnchor | null;
+  onComposerClose: () => void;
+}
+
+interface SlotMap {
+  /** sourceLine → portal target div for the expanded card */
+  threads: Map<number, HTMLDivElement>;
+  /** sourceLine → portal target span for the minimized "open" badge */
+  badges: Map<number, HTMLSpanElement>;
+  composerSlot: HTMLDivElement | null;
+}
+
+/**
+ * Mounts thread cards (and the optional draft composer) inline in the document
+ * flow as siblings of the corresponding `[data-source-line]` element. Uses
+ * direct DOM injection + React portals so commented lines visibly push later
+ * content down — matching the design's "Comment under the line" layout.
+ */
+export function InlineThreads({
+  prNumber,
+  filePath,
+  headSha,
+  comments,
+  containerRef,
+  composerAnchor,
+  onComposerClose,
+}: InlineThreadsProps) {
+  const select = useSelectedThread((s) => s.select);
+  const selectedId = useSelectedThread((s) => s.selectedCommentId);
+  const minimizedSet = useMinimizedThreads((s) => s.minimized);
+  const minimize = useMinimizedThreads((s) => s.minimize);
+  const expand = useMinimizedThreads((s) => s.expand);
+  const queryClient = useQueryClient();
+
+  const update = useMutation({
+    mutationFn: ({ id, patch }: { id: number; patch: CommentUpdate }) =>
+      ipc.comments.update(id, patch).then((r) => {
+        if (!r.ok) throw r.error;
+        return r.value;
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber, filePath] });
+    },
+  });
+
+  // Memoize groups so identity is stable across renders unless comments
+  // actually change. We compute a fingerprint and use that to gate the memo.
+  const groupsKey = useMemo(
+    () =>
+      comments
+        .map((c) => `${c.id}:${c.state}:${anchorStart(c)}`)
+        .sort()
+        .join("|"),
+    [comments],
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: groupsKey is the stable fingerprint.
+  const groups = useMemo(() => groupCommentsByStartLine(comments), [groupsKey]);
+
+  const composerStart = composerAnchor ? anchorStartLine(composerAnchor) : null;
+  const composerEnd = composerAnchor
+    ? Math.max(composerStart ?? 0, anchorEndLine(composerAnchor))
+    : null;
+
+  // Slot map lives in a ref; we only bump `revision` when the slot identities
+  // actually change so the React tree re-renders the portals minimally.
+  const slotsRef = useRef<SlotMap>({
+    threads: new Map(),
+    badges: new Map(),
+    composerSlot: null,
+  });
+  const [, setRevision] = useState(0);
+  // Tracks whether the current DOM mutation batch was caused by our own slot
+  // injections (so the MutationObserver below ignores it).
+  const mutatingRef = useRef(false);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const changed = syncSlots(
+      container,
+      slotsRef.current,
+      groups,
+      minimizedSet,
+      composerStart,
+      composerEnd,
+      mutatingRef,
+    );
+    if (changed) setRevision((r) => r + 1);
+    return () => {
+      mutatingRef.current = true;
+      try {
+        removeAllSlots(container);
+        slotsRef.current = { threads: new Map(), badges: new Map(), composerSlot: null };
+      } finally {
+        // Allow the observer to see post-cleanup state.
+        queueMicrotask(() => {
+          mutatingRef.current = false;
+        });
+      }
+    };
+  }, [containerRef, groups, minimizedSet, composerStart, composerEnd]);
+
+  // Re-sync when the rendered article DOM changes (a markdown re-render).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer = new MutationObserver((records) => {
+      if (mutatingRef.current) return;
+      // If every mutation involves only slot/has-comment nodes we did
+      // ourselves, skip — our own mutations shouldn't trigger a re-sync.
+      const significant = records.some((r) => mutationIsSignificant(r));
+      if (!significant) return;
+      const changed = syncSlots(
+        container,
+        slotsRef.current,
+        groups,
+        minimizedSet,
+        composerStart,
+        composerEnd,
+        mutatingRef,
+      );
+      if (changed) setRevision((r) => r + 1);
+    });
+    observer.observe(container, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [containerRef, groups, minimizedSet, composerStart, composerEnd]);
+
+  const slots = slotsRef.current;
+
+  return (
+    <>
+      {groups.map((group) => {
+        const minimized = minimizedSet.has(group.line);
+        if (minimized) {
+          const badgeSlot = slots.badges.get(group.line);
+          if (!badgeSlot) return null;
+          return createPortal(
+            <MinimizedThreadBadge
+              key={group.line}
+              count={group.comments.length}
+              onExpand={() => {
+                expand(group.line);
+                const head = group.comments[0];
+                if (head) select(head.id);
+              }}
+            />,
+            badgeSlot,
+            `thread-badge-${group.line}`,
+          );
+        }
+        const slot = slots.threads.get(group.line);
+        if (!slot) return null;
+        const isSelected = group.comments.some((c) => c.id === selectedId);
+        return createPortal(
+          <InlineThreadCard
+            key={group.line}
+            comments={group.comments}
+            selected={isSelected}
+            onResolve={(c) => {
+              select(c.id);
+              update.mutate({ id: c.id, patch: { state: "resolved" } });
+            }}
+            onHide={() => minimize(group.line)}
+            onReply={(c) => select(c.id)}
+          />,
+          slot,
+          `thread-${group.line}`,
+        );
+      })}
+      {composerAnchor && slots.composerSlot
+        ? createPortal(
+            <div className="my-3">
+              <CommentComposer
+                prNumber={prNumber}
+                filePath={filePath}
+                headSha={headSha}
+                anchor={composerAnchor}
+                onClose={onComposerClose}
+              />
+            </div>,
+            slots.composerSlot,
+            "draft-composer",
+          )
+        : null}
+    </>
+  );
+}
+
+function anchorStart(c: ReviewComment): number {
+  return c.anchor.kind === "singleLine" ? c.anchor.line : c.anchor.startLine;
+}
+
+function mutationIsSignificant(record: MutationRecord): boolean {
+  const all = [...record.addedNodes, ...record.removedNodes];
+  for (const node of all) {
+    if (!(node instanceof HTMLElement)) return true;
+    // Our own DOM injections — slot wrappers, per-line code spans, badge
+    // slots — are self-inflicted; ignore them.
+    if (node.dataset.threadSlot) continue;
+    if (node.dataset.threadBadge) continue;
+    if (node.dataset.codeLine) continue;
+    return true;
+  }
+  // Pure attribute changes on the line nodes (data-has-comment /
+  // data-comment-minimized) are also self-inflicted — our toggles trigger them.
+  if (record.type === "attributes") {
+    if (record.attributeName === "data-has-comment") return false;
+    if (record.attributeName === "data-comment-minimized") return false;
+  }
+  return false;
+}
+
+/**
+ * Reconciles the DOM slots under each commented line and the optional draft
+ * composer slot. Mutates the article in place. Returns `true` when the slot
+ * identity map changed (callers re-render to update portal targets).
+ */
+function syncSlots(
+  container: HTMLElement,
+  current: SlotMap,
+  groups: CommentGroup[],
+  minimized: Set<number>,
+  composerStart: number | null,
+  composerEnd: number | null,
+  mutatingRef: { current: boolean },
+): boolean {
+  mutatingRef.current = true;
+  try {
+    let changed = false;
+
+    // Per-line splitting for code blocks must happen before we look up
+    // anchors so each commented line has its own DOM element (and the
+    // `[data-has-comment]` highlight CSS targets just that line).
+    splitCodeBlocks(container);
+
+    // A group needs a card slot ONLY when it isn't minimized; otherwise it
+    // needs a badge slot inside the line element.
+    const wantsCard = new Set<number>();
+    const wantsBadge = new Set<number>();
+    for (const g of groups) {
+      if (minimized.has(g.line)) wantsBadge.add(g.line);
+      else wantsCard.add(g.line);
+    }
+
+    const lineNodes = nearestLineNodes(container);
+
+    // 1a. Remove obsolete card slots (lines no longer commented or now
+    //     minimized).
+    for (const [line, node] of current.threads) {
+      if (!wantsCard.has(line) || !node.isConnected) {
+        node.remove();
+        current.threads.delete(line);
+        changed = true;
+      }
+    }
+
+    // 1b. Remove obsolete badge slots (lines no longer commented or now
+    //     expanded).
+    for (const [line, node] of current.badges) {
+      if (!wantsBadge.has(line) || !node.isConnected) {
+        node.remove();
+        current.badges.delete(line);
+        changed = true;
+      }
+    }
+
+    // 2. Remove obsolete composer slot.
+    if (
+      current.composerSlot &&
+      (composerEnd === null ||
+        !current.composerSlot.isConnected ||
+        Number(current.composerSlot.dataset.sourceLine ?? "0") !== composerEnd)
+    ) {
+      current.composerSlot.remove();
+      current.composerSlot = null;
+      changed = true;
+    }
+
+    // 3. Clear and reapply the data-has-comment attribute on commented lines.
+    for (const n of container.querySelectorAll<HTMLElement>("[data-has-comment]")) {
+      delete n.dataset.hasComment;
+    }
+    for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
+      delete n.dataset.commentMinimized;
+    }
+
+    // 4. Insert missing slots and tag every commented line in the range.
+    //    Card slot mounts AFTER `attachLine` (== endLine) so the expanded
+    //    card sits below the last highlighted row. Badge slot mounts INSIDE
+    //    `attachLine` as a trailing inline element on that line.
+    for (const group of groups) {
+      const isMinimized = minimized.has(group.line);
+      markRange(lineNodes, group.startLine, group.endLine, isMinimized);
+      const anchor = lineNodes.get(group.attachLine);
+      if (!anchor) continue;
+      if (isMinimized) {
+        if (current.badges.has(group.line)) continue;
+        const badge = document.createElement("span");
+        badge.dataset.threadBadge = "true";
+        badge.dataset.sourceLine = String(group.line);
+        anchor.appendChild(badge);
+        current.badges.set(group.line, badge);
+        changed = true;
+      } else {
+        if (current.threads.has(group.line)) continue;
+        if (!anchor.parentNode) continue;
+        const slot = document.createElement("div");
+        slot.dataset.threadSlot = "thread";
+        slot.dataset.sourceLine = String(group.line);
+        anchor.parentNode.insertBefore(slot, anchor.nextSibling);
+        current.threads.set(group.line, slot);
+        changed = true;
+      }
+    }
+
+    // 5. Insert the composer slot if needed.
+    if (composerStart !== null && composerEnd !== null) {
+      markRange(lineNodes, composerStart, composerEnd, false);
+      if (!current.composerSlot) {
+        const anchor = lineNodes.get(composerEnd);
+        if (anchor?.parentNode) {
+          const slot = document.createElement("div");
+          slot.dataset.threadSlot = "composer";
+          slot.dataset.sourceLine = String(composerEnd);
+          anchor.parentNode.insertBefore(slot, anchor.nextSibling);
+          current.composerSlot = slot;
+          changed = true;
+        }
+      }
+    }
+
+    return changed;
+  } finally {
+    queueMicrotask(() => {
+      mutatingRef.current = false;
+    });
+  }
+}
+
+/**
+ * Tags every line in `[start, end]` that has a rendered DOM element. When
+ * `minimized` is true, also stamps `data-comment-minimized="true"` so the
+ * highlight CSS can render a softer background.
+ */
+function markRange(
+  lineNodes: Map<number, HTMLElement>,
+  start: number,
+  end: number,
+  minimized: boolean,
+) {
+  for (let line = start; line <= end; line++) {
+    const el = lineNodes.get(line);
+    if (!el) continue;
+    el.dataset.hasComment = "true";
+    if (minimized) el.dataset.commentMinimized = "true";
+  }
+}
+
+function removeAllSlots(container: HTMLElement) {
+  for (const node of container.querySelectorAll("[data-thread-slot]")) {
+    node.remove();
+  }
+  for (const node of container.querySelectorAll("[data-thread-badge]")) {
+    node.remove();
+  }
+  for (const n of container.querySelectorAll<HTMLElement>("[data-has-comment]")) {
+    delete n.dataset.hasComment;
+  }
+  for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
+    delete n.dataset.commentMinimized;
+  }
+}
+
+/**
+ * Walks every code block and breaks its content into one
+ * `<span data-code-line data-source-line=N>` per line so the highlight CSS
+ * (and slot-injection logic) can target individual lines instead of the
+ * whole block. Handles both shapes remark-rehype may produce — the
+ * `data-source-line` attribute can sit on the `<pre>` OR on its inner
+ * `<code>`. Idempotent.
+ */
+function splitCodeBlocks(container: HTMLElement) {
+  const seen = new WeakSet<HTMLElement>();
+  const candidates = container.querySelectorAll<HTMLElement>(
+    "pre[data-source-line], pre > code[data-source-line]",
+  );
+  for (const node of candidates) {
+    const pre = (node.tagName === "PRE" ? node : node.parentElement) as HTMLElement | null;
+    if (!pre) continue;
+    if (seen.has(pre)) continue;
+    seen.add(pre);
+    if (pre.querySelector(":scope [data-code-line]")) continue;
+
+    const fenceLineRaw = node.dataset.sourceLine ?? pre.dataset.sourceLine ?? "";
+    const fenceLine = Number(fenceLineRaw);
+    if (!Number.isFinite(fenceLine) || fenceLine <= 0) continue;
+
+    const code = pre.querySelector(":scope > code") as HTMLElement | null;
+    const host = code ?? pre;
+    const text = host.textContent ?? "";
+    if (text.length === 0) continue;
+
+    // Drop the trailing newline (markdown always emits one) so we don't add
+    // an empty span the user can't visibly select.
+    const trimmed = text.endsWith("\n") ? text.slice(0, -1) : text;
+    const lines = trimmed.split("\n");
+
+    const fragment = document.createDocumentFragment();
+    for (let i = 0; i < lines.length; i++) {
+      const span = document.createElement("span");
+      span.dataset.codeLine = "true";
+      // Fence opener is `fenceLine`; first content line is `fenceLine + 1`.
+      span.dataset.sourceLine = String(fenceLine + 1 + i);
+      span.textContent = `${lines[i] ?? ""}\n`;
+      fragment.appendChild(span);
+    }
+    host.replaceChildren(fragment);
+
+    // Strip `data-source-line` from the pre / code so they can't shadow our
+    // per-line spans in `nearestLineNodes` (first-occurrence-wins traversal),
+    // and — crucially — so the `[data-source-line][data-has-comment]` CSS
+    // rule never paints the whole block by accident.
+    delete pre.dataset.sourceLine;
+    if (code) delete code.dataset.sourceLine;
+  }
+}
+
+/**
+ * Maps each rendered source-line to the most specific (deepest) DOM element
+ * that carries that line. Container blocks like `<ul>`, `<ol>`, `<blockquote>`
+ * inherit `data-source-line` from their first child, so naively picking the
+ * first-occurrence highlights the whole container — we walk descendants and
+ * keep replacing whenever the new candidate is contained by the previous one.
+ */
+function nearestLineNodes(container: HTMLElement): Map<number, HTMLElement> {
+  const out = new Map<number, HTMLElement>();
+  const nodes = container.querySelectorAll<HTMLElement>("[data-source-line]");
+  for (const node of nodes) {
+    const line = Number(node.dataset.sourceLine ?? "0");
+    if (!Number.isFinite(line) || line <= 0) continue;
+    const existing = out.get(line);
+    if (!existing || existing.contains(node)) {
+      out.set(line, node);
+    }
+  }
+  return out;
+}

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -88,18 +88,12 @@ export function InlineThreads({
     },
   });
 
-  // Memoize groups so identity is stable across renders unless comments
-  // actually change. We compute a fingerprint and use that to gate the memo.
-  const groupsKey = useMemo(
-    () =>
-      comments
-        .map((c) => `${c.id}:${c.state}:${anchorStart(c)}`)
-        .sort()
-        .join("|"),
-    [comments],
-  );
-  // biome-ignore lint/correctness/useExhaustiveDependencies: groupsKey is the stable fingerprint.
-  const groups = useMemo(() => groupCommentsByStartLine(comments), [groupsKey]);
+  // Memoize groups directly from `comments` — the previous fingerprint missed
+  // anchor end-line / kind changes, which left portals pointing at stale
+  // slots when an anchor moved. React Query already returns a stable array
+  // identity until the underlying data changes, so this re-runs precisely
+  // when needed.
+  const groups = useMemo(() => groupCommentsByStartLine(comments), [comments]);
 
   const composerStart = composerAnchor ? anchorStartLine(composerAnchor) : null;
   const composerEnd = composerAnchor
@@ -231,10 +225,6 @@ export function InlineThreads({
         : null}
     </>
   );
-}
-
-function anchorStart(c: ReviewComment): number {
-  return c.anchor.kind === "singleLine" ? c.anchor.line : c.anchor.startLine;
 }
 
 function mutationIsSignificant(record: MutationRecord): boolean {

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -68,6 +68,18 @@ export function InlineThreads({
     },
   });
 
+  const remove = useMutation({
+    mutationFn: (id: number) =>
+      ipc.comments.delete(id).then((r) => {
+        if (!r.ok) throw r.error;
+        return r.value;
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber, filePath] });
+    },
+  });
+
   // Memoize groups so identity is stable across renders unless comments
   // actually change. We compute a fingerprint and use that to gate the memo.
   const groupsKey = useMemo(
@@ -187,6 +199,7 @@ export function InlineThreads({
             }}
             onHide={() => minimize(group.line)}
             onReply={(c) => select(c.id)}
+            onDelete={(c) => remove.mutate(c.id)}
           />,
           slot,
           `thread-${group.line}`,

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -100,6 +100,19 @@ export function InlineThreads({
     ? Math.max(composerStart ?? 0, anchorEndLine(composerAnchor))
     : null;
 
+  // The minimized store is global and keyed by (prNumber, filePath, start,
+  // end). The slot Maps inside this component are per-instance and keyed by
+  // (start, end) only. Project the global state down to a local slot-key set
+  // so `syncSlots` can keep using the simple comparison.
+  const localMinimized = useMemo(() => {
+    const out = new Set<SlotKey>();
+    for (const g of groups) {
+      const k = minimizedKey(prNumber, filePath, g.startLine, g.endLine);
+      if (minimizedSet.has(k)) out.add(slotKeyFor(g.startLine, g.endLine));
+    }
+    return out;
+  }, [groups, minimizedSet, prNumber, filePath]);
+
   // Slot map lives in a ref; we only bump `revision` when the slot identities
   // actually change so the React tree re-renders the portals minimally.
   const slotsRef = useRef<SlotMap>({
@@ -119,7 +132,7 @@ export function InlineThreads({
       container,
       slotsRef.current,
       groups,
-      minimizedSet,
+      localMinimized,
       composerStart,
       composerEnd,
       mutatingRef,
@@ -137,7 +150,7 @@ export function InlineThreads({
         });
       }
     };
-  }, [containerRef, groups, minimizedSet, composerStart, composerEnd]);
+  }, [containerRef, groups, localMinimized, composerStart, composerEnd]);
 
   // Re-sync when the rendered article DOM changes (a markdown re-render).
   useEffect(() => {
@@ -153,7 +166,7 @@ export function InlineThreads({
         container,
         slotsRef.current,
         groups,
-        minimizedSet,
+        localMinimized,
         composerStart,
         composerEnd,
         mutatingRef,
@@ -162,50 +175,51 @@ export function InlineThreads({
     });
     observer.observe(container, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, [containerRef, groups, minimizedSet, composerStart, composerEnd]);
+  }, [containerRef, groups, localMinimized, composerStart, composerEnd]);
 
   const slots = slotsRef.current;
 
   return (
     <>
       {groups.map((group) => {
-        const key = minimizedKey(group.startLine, group.endLine);
-        const minimized = minimizedSet.has(key);
+        const slotKey = slotKeyFor(group.startLine, group.endLine);
+        const minKey = minimizedKey(prNumber, filePath, group.startLine, group.endLine);
+        const minimized = minimizedSet.has(minKey);
         if (minimized) {
-          const badgeSlot = slots.badges.get(key);
+          const badgeSlot = slots.badges.get(slotKey);
           if (!badgeSlot) return null;
           return createPortal(
             <MinimizedThreadBadge
-              key={key}
+              key={slotKey}
               count={group.comments.length}
               onExpand={() => {
-                expand(key);
+                expand(minKey);
                 const head = group.comments[0];
                 if (head) select(head.id);
               }}
             />,
             badgeSlot,
-            `thread-badge-${key}`,
+            `thread-badge-${slotKey}`,
           );
         }
-        const slot = slots.threads.get(key);
+        const slot = slots.threads.get(slotKey);
         if (!slot) return null;
         const isSelected = group.comments.some((c) => c.id === selectedId);
         return createPortal(
           <InlineThreadCard
-            key={key}
+            key={slotKey}
             comments={group.comments}
             selected={isSelected}
             onResolve={(c) => {
               select(c.id);
               update.mutate({ id: c.id, patch: { state: "resolved" } });
             }}
-            onHide={() => minimize(key)}
+            onHide={() => minimize(minKey)}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
           />,
           slot,
-          `thread-${key}`,
+          `thread-${slotKey}`,
         );
       })}
       {composerAnchor && slots.composerSlot
@@ -238,12 +252,9 @@ function mutationIsSignificant(record: MutationRecord): boolean {
     if (node.dataset.codeLine) continue;
     return true;
   }
-  // Pure attribute changes on the line nodes (data-has-comment /
-  // data-comment-minimized) are also self-inflicted — our toggles trigger them.
-  if (record.type === "attributes") {
-    if (record.attributeName === "data-has-comment") return false;
-    if (record.attributeName === "data-comment-minimized") return false;
-  }
+  // Observer is configured `{ childList: true, subtree: true }` only — no
+  // attribute mutations reach this callback, so any record with no
+  // significant added/removed nodes is by definition irrelevant.
   return false;
 }
 

--- a/src/features/comments/components/MinimizedThreadBadge.tsx
+++ b/src/features/comments/components/MinimizedThreadBadge.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/shared/lib/cn";
+import { MessageSquareIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface MinimizedThreadBadgeProps {
+  count: number;
+  onExpand: () => void;
+}
+
+/**
+ * Tiny pill rendered at the end of a collapsed thread's anchor line. Just the
+ * `message-square` icon plus a count when more than one comment is attached.
+ * Clicking it re-expands the thread card.
+ */
+export function MinimizedThreadBadge({ count, onExpand }: MinimizedThreadBadgeProps) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onExpand}
+      aria-label={t("comments.markers.expandAria")}
+      className={cn(
+        "inline-flex h-6 items-center gap-1 rounded-full px-1.5 align-middle text-[11px] font-semibold",
+        "border border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",
+        "text-[hsl(var(--comment-marker-fg))] transition-colors",
+        "hover:bg-[hsl(var(--comment-marker-hover))]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+      )}
+    >
+      <MessageSquareIcon className="h-3 w-3" aria-hidden="true" />
+      {count > 1 ? <span aria-hidden="true">{count}</span> : null}
+    </button>
+  );
+}

--- a/src/features/comments/components/SelectionCommentOverlay.tsx
+++ b/src/features/comments/components/SelectionCommentOverlay.tsx
@@ -1,0 +1,111 @@
+import type { CommentAnchor } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { MessageSquareIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { resolveAnchor } from "../lib/selectionToAnchor";
+
+interface SelectionCommentOverlayProps {
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** Suppress the floating button (e.g. while a composer is already open). */
+  disabled?: boolean;
+  onStartComposer: (anchor: CommentAnchor) => void;
+}
+
+interface FloatingState {
+  anchor: CommentAnchor;
+  /** Position relative to `container`. */
+  buttonTop: number;
+  buttonLeft: number;
+}
+
+const BUTTON_OFFSET_Y = 6;
+const BUTTON_WIDTH = 110;
+const SAFE_PADDING = 8;
+
+/**
+ * Listens for text selections inside `container` and surfaces a floating
+ * "Comment" button anchored to the selection. Clicking it lifts the chosen
+ * anchor up to the parent so the inline composer can open at that line.
+ */
+export function SelectionCommentOverlay({
+  containerRef,
+  disabled = false,
+  onStartComposer,
+}: SelectionCommentOverlayProps) {
+  const { t } = useTranslation();
+  const [floating, setFloating] = useState<FloatingState | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (disabled) {
+      setFloating(null);
+      return;
+    }
+
+    function refresh() {
+      const article = containerRef.current;
+      if (!article) return;
+      const selection = window.getSelection();
+      if (!selection) {
+        setFloating(null);
+        return;
+      }
+      const result = resolveAnchor(article, selection);
+      if (!result) {
+        setFloating(null);
+        return;
+      }
+      const containerRect = article.getBoundingClientRect();
+      const rawLeft = result.rangeRect.right - containerRect.left - BUTTON_WIDTH;
+      const rawTop = result.rangeRect.bottom - containerRect.top + BUTTON_OFFSET_Y;
+      const maxLeft = Math.max(SAFE_PADDING, containerRect.width - SAFE_PADDING - BUTTON_WIDTH);
+      const left = Math.min(Math.max(SAFE_PADDING, rawLeft), maxLeft);
+      const top = Math.max(SAFE_PADDING, rawTop);
+      setFloating({ anchor: result.anchor, buttonLeft: left, buttonTop: top });
+    }
+
+    document.addEventListener("selectionchange", refresh);
+    window.addEventListener("resize", refresh);
+    return () => {
+      document.removeEventListener("selectionchange", refresh);
+      window.removeEventListener("resize", refresh);
+    };
+  }, [containerRef, disabled]);
+
+  function open() {
+    if (!floating) return;
+    const anchor = floating.anchor;
+    setFloating(null);
+    window.getSelection()?.removeAllRanges();
+    onStartComposer(anchor);
+  }
+
+  if (!floating || disabled) return null;
+
+  return (
+    <button
+      type="button"
+      onMouseDown={(event) => {
+        // Prevent the click from collapsing the selection before we read it.
+        event.preventDefault();
+      }}
+      onClick={open}
+      aria-label={t("comments.markers.selectionAria")}
+      className={cn(
+        "absolute z-30 inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-[12px]",
+        "border-[hsl(var(--border))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))] shadow-md",
+        "transition-colors hover:bg-[hsl(var(--accent))]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+      )}
+      style={{ top: floating.buttonTop, left: floating.buttonLeft, width: BUTTON_WIDTH }}
+    >
+      <MessageSquareIcon
+        className="h-3.5 w-3.5 text-[hsl(var(--muted-foreground))]"
+        aria-hidden="true"
+      />
+      <span>{t("comments.composer.commentAction")}</span>
+    </button>
+  );
+}

--- a/src/features/comments/components/SelectionCommentOverlay.tsx
+++ b/src/features/comments/components/SelectionCommentOverlay.tsx
@@ -23,6 +23,22 @@ const BUTTON_OFFSET_Y = 6;
 const BUTTON_WIDTH = 110;
 const SAFE_PADDING = 8;
 
+/** Walks up from `node` collecting every ancestor that scrolls itself. */
+function collectScrollAncestors(node: HTMLElement): (HTMLElement | Document)[] {
+  const out: (HTMLElement | Document)[] = [];
+  let current: HTMLElement | null = node.parentElement;
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (/(auto|scroll|overlay)/.test(style.overflowY + style.overflowX)) {
+      out.push(current);
+    }
+    current = current.parentElement;
+  }
+  // Document scroll handles the window-level case.
+  out.push(document);
+  return out;
+}
+
 /**
  * Listens for text selections inside `container` and surfaces a floating
  * "Comment" button anchored to the selection. Clicking it lifts the chosen
@@ -68,9 +84,19 @@ export function SelectionCommentOverlay({
 
     document.addEventListener("selectionchange", refresh);
     window.addEventListener("resize", refresh);
+    // Also follow scrolls of any scrollable ancestor (the preview slot is
+    // `overflow-auto`, so without this the button drifts away from the
+    // selected text whenever the user scrolls the article).
+    const scrollAncestors = collectScrollAncestors(container);
+    for (const node of scrollAncestors) {
+      node.addEventListener("scroll", refresh, { passive: true });
+    }
     return () => {
       document.removeEventListener("selectionchange", refresh);
       window.removeEventListener("resize", refresh);
+      for (const node of scrollAncestors) {
+        node.removeEventListener("scroll", refresh);
+      }
     };
   }, [containerRef, disabled]);
 

--- a/src/features/comments/hooks/useCreateComment.ts
+++ b/src/features/comments/hooks/useCreateComment.ts
@@ -1,0 +1,31 @@
+import { ipc } from "@/shared/ipc/client";
+import type { AppError, CommentAnchor, ReviewComment } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface CreateArgs {
+  prNumber: number;
+  filePath: string;
+  headSha: string;
+  body: string;
+  anchor: CommentAnchor;
+  author?: string | null;
+}
+
+/**
+ * Wraps `ipc.comments.create` and invalidates both the per-PR and per-file
+ * comment query keys so the threads pane and inline markers refresh together.
+ */
+export function useCreateComment() {
+  const qc = useQueryClient();
+  return useMutation<ReviewComment, AppError, CreateArgs>({
+    mutationFn: async ({ prNumber, filePath, headSha, body, anchor, author = null }) => {
+      const res = await ipc.comments.create({ prNumber, filePath, headSha, body, author, anchor });
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: ["local-comments", vars.prNumber] });
+      qc.invalidateQueries({ queryKey: ["local-comments", vars.prNumber, vars.filePath] });
+    },
+  });
+}

--- a/src/features/comments/hooks/useFileComments.ts
+++ b/src/features/comments/hooks/useFileComments.ts
@@ -1,0 +1,24 @@
+import { ipc } from "@/shared/ipc/client";
+import type { AppError, ReviewComment } from "@/shared/ipc/contract";
+import { useQuery } from "@tanstack/react-query";
+
+interface Args {
+  prNumber: number | undefined;
+  filePath: string | undefined;
+}
+
+/**
+ * Fetches local comments for a single file in a PR. Shares its query key
+ * shape with the threads pane so mutations can invalidate both.
+ */
+export function useFileComments({ prNumber, filePath }: Args) {
+  return useQuery<ReviewComment[], AppError>({
+    queryKey: ["local-comments", prNumber, filePath],
+    enabled: Boolean(prNumber && filePath),
+    queryFn: async () => {
+      const res = await ipc.comments.listForFile(prNumber as number, filePath as string);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+  });
+}

--- a/src/features/comments/hooks/useGhUser.ts
+++ b/src/features/comments/hooks/useGhUser.ts
@@ -1,0 +1,23 @@
+import { ipc } from "@/shared/ipc/client";
+import type { AppError } from "@/shared/ipc/contract";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Returns the authenticated GitHub username (from `gh auth status`). Used to
+ * stamp the `author` field on freshly created local comments. Falls back to
+ * `null` when the user isn't logged in or the call fails.
+ */
+export function useGhUser() {
+  return useQuery<string | null, AppError>({
+    queryKey: ["gh-user"],
+    // The username is stable across an app session — no need to re-fetch
+    // unless the user explicitly invalidates.
+    staleTime: 1000 * 60 * 60,
+    retry: false,
+    queryFn: async () => {
+      const res = await ipc.tools.ghUser();
+      if (!res.ok) return null;
+      return res.value;
+    },
+  });
+}

--- a/src/features/comments/hooks/usePullRequestComments.ts
+++ b/src/features/comments/hooks/usePullRequestComments.ts
@@ -1,0 +1,20 @@
+import { ipc } from "@/shared/ipc/client";
+import type { AppError, ReviewComment } from "@/shared/ipc/contract";
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Fetches every local comment that belongs to a pull request. Used by the
+ * threads pane to hydrate state on app start; the same query key is invalidated
+ * by `useCreateComment` so writes propagate without manual refetching.
+ */
+export function usePullRequestComments(prNumber: number | undefined) {
+  return useQuery<ReviewComment[], AppError>({
+    queryKey: ["local-comments", prNumber],
+    enabled: prNumber !== undefined,
+    queryFn: async () => {
+      const res = await ipc.comments.list(prNumber as number);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+  });
+}

--- a/src/features/comments/index.ts
+++ b/src/features/comments/index.ts
@@ -1,1 +1,13 @@
-// Placeholder for Phase 2+ — this feature lives here.
+export { CommentComposer } from "./components/CommentComposer";
+export { InlineThreadCard } from "./components/InlineThreadCard";
+export { InlineThreads } from "./components/InlineThreads";
+export { MinimizedThreadBadge } from "./components/MinimizedThreadBadge";
+export { SelectionCommentOverlay } from "./components/SelectionCommentOverlay";
+export { useCreateComment } from "./hooks/useCreateComment";
+export { useFileComments } from "./hooks/useFileComments";
+export { useGhUser } from "./hooks/useGhUser";
+export { usePullRequestComments } from "./hooks/usePullRequestComments";
+export { anchorStartLine, groupCommentsByStartLine } from "./lib/groupAnchors";
+export { resolveAnchor } from "./lib/selectionToAnchor";
+export type { AnchorResult } from "./lib/selectionToAnchor";
+export type { CommentGroup } from "./lib/groupAnchors";

--- a/src/features/comments/lib/groupAnchors.ts
+++ b/src/features/comments/lib/groupAnchors.ts
@@ -39,14 +39,16 @@ export interface CommentGroup {
 }
 
 /**
- * Filters out hidden / resolved / deleted comments and buckets the rest by
+ * Filters out only deleted comments and buckets the rest by
  * `(startLine, endLine)`. Each bucket renders as one card; the head comment
- * decides the bucket's anchor extent.
+ * decides the bucket's anchor extent. Resolved/hidden threads are kept so
+ * marking a comment resolved doesn't make it disappear inline — the card
+ * surfaces the state via its badge.
  */
 export function groupCommentsByStartLine(comments: ReviewComment[]): CommentGroup[] {
   const buckets = new Map<string, CommentGroup>();
   for (const c of comments) {
-    if (c.state !== "draft" && c.state !== "submitted") continue;
+    if (c.state === "deleted") continue;
     const startLine = anchorStartLine(c.anchor);
     const endLine = Math.max(startLine, anchorEndLine(c.anchor));
     const key = `${startLine}:${endLine}`;

--- a/src/features/comments/lib/groupAnchors.ts
+++ b/src/features/comments/lib/groupAnchors.ts
@@ -1,0 +1,73 @@
+import type { CommentAnchor, ReviewComment } from "@/shared/ipc/contract";
+
+/** Returns the first source line a comment is *anchored to* visually. */
+export function anchorStartLine(anchor: CommentAnchor): number {
+  switch (anchor.kind) {
+    case "singleLine":
+      return anchor.line;
+    case "lineRange":
+    case "codeBlock":
+      return anchor.startLine;
+  }
+}
+
+/** Returns the last source line covered by the anchor. */
+export function anchorEndLine(anchor: CommentAnchor): number {
+  switch (anchor.kind) {
+    case "singleLine":
+      return anchor.line;
+    case "lineRange":
+    case "codeBlock":
+      return anchor.endLine;
+  }
+}
+
+export interface CommentGroup {
+  /** The visual source line the group is keyed by (== startLine). */
+  line: number;
+  /** First source line covered by every comment in the group. */
+  startLine: number;
+  /** Last source line covered by every comment in the group. */
+  endLine: number;
+  /**
+   * Source line of the DOM element to mount the comment slot under. For
+   * multi-line ranges this is `endLine` so the card sits *after* the last
+   * highlighted row.
+   */
+  attachLine: number;
+  comments: ReviewComment[];
+}
+
+/**
+ * Filters out hidden / resolved / deleted comments and buckets the rest by
+ * `(startLine, endLine)`. Each bucket renders as one card; the head comment
+ * decides the bucket's anchor extent.
+ */
+export function groupCommentsByStartLine(comments: ReviewComment[]): CommentGroup[] {
+  const buckets = new Map<string, CommentGroup>();
+  for (const c of comments) {
+    if (c.state !== "draft" && c.state !== "submitted") continue;
+    const startLine = anchorStartLine(c.anchor);
+    const endLine = Math.max(startLine, anchorEndLine(c.anchor));
+    const key = `${startLine}:${endLine}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.comments.push(c);
+      continue;
+    }
+    buckets.set(key, {
+      line: startLine,
+      startLine,
+      endLine,
+      attachLine: endLine,
+      comments: [c],
+    });
+  }
+  for (const group of buckets.values()) {
+    group.comments.sort((a, b) => a.createdAt - b.createdAt);
+  }
+  return Array.from(buckets.values()).sort((a, b) => {
+    if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+    return a.endLine - b.endLine;
+  });
+}

--- a/src/features/comments/lib/selectionToAnchor.ts
+++ b/src/features/comments/lib/selectionToAnchor.ts
@@ -1,0 +1,170 @@
+import type { CommentAnchor } from "@/shared/ipc/contract";
+
+export type AnchorResult = { anchor: CommentAnchor; rangeRect: DOMRect } | null;
+
+/**
+ * Walks up from `node` looking for the nearest ancestor (including itself)
+ * that carries a `data-source-line` attribute and lives inside `article`.
+ */
+function findSourceLineAncestor(article: HTMLElement, node: Node | null): HTMLElement | null {
+  let current: Node | null = node;
+  while (current && current !== article) {
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const el = current as HTMLElement;
+      if (el.dataset?.sourceLine) return el;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+/**
+ * Walks up looking for the nearest enclosing `<pre>` element inside `article`.
+ */
+function findEnclosingPre(article: HTMLElement, node: Node | null): HTMLElement | null {
+  let current: Node | null = node;
+  while (current && current !== article) {
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const el = current as HTMLElement;
+      if (el.tagName === "PRE") return el;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function readSourceLine(el: HTMLElement | null): number | null {
+  if (!el?.dataset.sourceLine) return null;
+  const n = Number(el.dataset.sourceLine);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * Returns the leaf node that visually precedes `(node, offset)` in document
+ * order. Used to "step back" when a selection's end caret has spilled to the
+ * start of the next block (offset 0) — visually nothing in that block is
+ * selected, so we want to anchor against the previous block instead.
+ */
+function previousLeaf(article: HTMLElement, node: Node): Node | null {
+  let current: Node | null = node;
+  while (current && current !== article) {
+    const prevSibling = current.previousSibling;
+    if (prevSibling) {
+      // Dive into the deepest last child of the previous sibling.
+      let cursor: Node = prevSibling;
+      while (cursor.lastChild) cursor = cursor.lastChild;
+      return cursor;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+interface EffectivePoint {
+  container: Node;
+  offset: number;
+}
+
+/**
+ * If `endOffset === 0` the visible selection ends *before* `endContainer`.
+ * Walk back to the previous leaf so the resolved line matches what the user
+ * actually highlighted.
+ */
+function effectiveEnd(article: HTMLElement, range: Range): EffectivePoint {
+  let container = range.endContainer;
+  let offset = range.endOffset;
+  // Step back past any zero-offset positions.
+  while (offset === 0 && container !== article) {
+    const prev = previousLeaf(article, container);
+    if (!prev) break;
+    container = prev;
+    if (prev.nodeType === Node.TEXT_NODE) {
+      offset = prev.textContent?.length ?? 0;
+    } else {
+      offset = prev.childNodes.length || 1;
+    }
+  }
+  return { container, offset };
+}
+
+/** Counts `\n` characters in the text from the start of `pre` up to `(container, offset)`. */
+function newlinesUpTo(pre: HTMLElement, container: Node, offset: number): number {
+  const measure = document.createRange();
+  try {
+    measure.setStart(pre, 0);
+    measure.setEnd(container, offset);
+  } catch {
+    return 0;
+  }
+  const text = measure.toString();
+  let count = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) count++;
+  }
+  return count;
+}
+
+/**
+ * Maps a `window.Selection` into a `CommentAnchor` plus the bounding rect
+ * of the selection (used by the floating action button).
+ *
+ * Returns `null` when:
+ *   - the selection is empty / collapsed,
+ *   - any endpoint sits outside `article`,
+ *   - any endpoint has no resolvable `data-source-line` ancestor.
+ */
+export function resolveAnchor(article: HTMLElement, selection: Selection): AnchorResult {
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  if (range.collapsed) return null;
+  if (!article.contains(range.startContainer) || !article.contains(range.endContainer)) {
+    return null;
+  }
+
+  // Step past spillover endpoints (selection ending right at the start of the
+  // next block). Without this, dragging from a paragraph down to a heading
+  // collapses to "just the paragraph line".
+  const end = effectiveEnd(article, range);
+
+  const rangeRect = range.getBoundingClientRect();
+  if (rangeRect.width === 0 && rangeRect.height === 0) return null;
+
+  // Code block: every line inside a `<pre>` shares the same
+  // `data-source-line` (= the fence opener). Count newlines to recover the
+  // actual selected lines.
+  const startPre = findEnclosingPre(article, range.startContainer);
+  const endPre = findEnclosingPre(article, end.container);
+  if (startPre && startPre === endPre) {
+    const preLine = readSourceLine(startPre);
+    if (preLine !== null) {
+      const startOffset = newlinesUpTo(startPre, range.startContainer, range.startOffset);
+      const endOffset = newlinesUpTo(startPre, end.container, end.offset);
+      // `+ 1` because the fence opener is line `preLine`, the first content
+      // line is `preLine + 1`. The newline counter returns 0 for the first
+      // content line; bump everything by 1 to land on it.
+      const startLine = preLine + 1 + startOffset;
+      const endLine = preLine + 1 + endOffset;
+      const [s, e] = startLine <= endLine ? [startLine, endLine] : [endLine, startLine];
+      return {
+        anchor: { kind: "codeBlock", startLine: s, endLine: e, codeStartLine: preLine },
+        rangeRect,
+      };
+    }
+  }
+
+  const startEl = findSourceLineAncestor(article, range.startContainer);
+  const endEl = findSourceLineAncestor(article, end.container);
+  if (!startEl || !endEl) return null;
+
+  const startLine = readSourceLine(startEl);
+  const endLine = readSourceLine(endEl);
+  if (startLine === null || endLine === null) return null;
+
+  if (startLine === endLine) {
+    return { anchor: { kind: "singleLine", line: startLine }, rangeRect };
+  }
+
+  const [s, e] = startLine <= endLine ? [startLine, endLine] : [endLine, startLine];
+  return { anchor: { kind: "lineRange", startLine: s, endLine: e }, rangeRect };
+}

--- a/src/features/comments/lib/selectionToAnchor.ts
+++ b/src/features/comments/lib/selectionToAnchor.ts
@@ -33,6 +33,19 @@ function findEnclosingPre(article: HTMLElement, node: Node | null): HTMLElement 
   return null;
 }
 
+/** True when `node` (or any ancestor) is one of the comments-feature wrappers. */
+function insideInjectedUi(node: Node | null): boolean {
+  let current: Node | null = node;
+  while (current) {
+    if (current.nodeType === Node.ELEMENT_NODE) {
+      const el = current as HTMLElement;
+      if (el.dataset?.threadSlot || el.dataset?.threadBadge) return true;
+    }
+    current = current.parentNode;
+  }
+  return false;
+}
+
 function readSourceLine(el: HTMLElement | null): number | null {
   if (!el?.dataset.sourceLine) return null;
   const n = Number(el.dataset.sourceLine);
@@ -68,21 +81,44 @@ interface EffectivePoint {
 /**
  * If `endOffset === 0` the visible selection ends *before* `endContainer`.
  * Walk back to the previous leaf so the resolved line matches what the user
- * actually highlighted.
+ * actually highlighted. We keep stepping back while the candidate position
+ * isn't a valid one to anchor against (e.g. an empty element with no
+ * children would produce an invalid `Range` offset).
  */
 function effectiveEnd(article: HTMLElement, range: Range): EffectivePoint {
   let container = range.endContainer;
   let offset = range.endOffset;
-  // Step back past any zero-offset positions.
-  while (offset === 0 && container !== article) {
+  // Bound the walk so a malformed DOM can't loop forever.
+  for (let safety = 0; safety < 256 && offset === 0 && container !== article; safety++) {
     const prev = previousLeaf(article, container);
     if (!prev) break;
-    container = prev;
     if (prev.nodeType === Node.TEXT_NODE) {
-      offset = prev.textContent?.length ?? 0;
-    } else {
-      offset = prev.childNodes.length || 1;
+      const len = prev.textContent?.length ?? 0;
+      if (len === 0) {
+        // Empty text node — treat its start as zero-offset and keep walking.
+        container = prev;
+        offset = 0;
+        continue;
+      }
+      container = prev;
+      offset = len;
+      break;
     }
+    if (prev.nodeType === Node.ELEMENT_NODE) {
+      const childCount = prev.childNodes.length;
+      if (childCount === 0) {
+        // Empty element — anchoring at offset 1 would be invalid; step back.
+        container = prev;
+        offset = 0;
+        continue;
+      }
+      container = prev;
+      offset = childCount;
+      break;
+    }
+    // Anything else (comment node, etc.) — skip past it.
+    container = prev;
+    offset = 0;
   }
   return { container, offset };
 }
@@ -119,6 +155,11 @@ export function resolveAnchor(article: HTMLElement, selection: Selection): Ancho
   const range = selection.getRangeAt(0);
   if (range.collapsed) return null;
   if (!article.contains(range.startContainer) || !article.contains(range.endContainer)) {
+    return null;
+  }
+  // Selections inside our own injected UI (thread cards, draft composers,
+  // minimized badges) must not be treated as a markdown selection.
+  if (insideInjectedUi(range.startContainer) || insideInjectedUi(range.endContainer)) {
     return null;
   }
 

--- a/src/features/comments/lib/selectionToAnchor.ts
+++ b/src/features/comments/lib/selectionToAnchor.ts
@@ -179,13 +179,24 @@ export function resolveAnchor(article: HTMLElement, selection: Selection): Ancho
   if (startPre && startPre === endPre) {
     const preLine = readSourceLine(startPre);
     if (preLine !== null) {
+      // Number of content lines, ignoring a trailing newline that markdown
+      // routinely emits (matches splitCodeBlocks which also trims it).
+      const raw = startPre.textContent ?? "";
+      const trimmed = raw.endsWith("\n") ? raw.slice(0, -1) : raw;
+      const lineCount = trimmed.length === 0 ? 0 : trimmed.split("\n").length;
+      const lastContentLine = lineCount === 0 ? preLine + 1 : preLine + lineCount;
+
       const startOffset = newlinesUpTo(startPre, range.startContainer, range.startOffset);
       const endOffset = newlinesUpTo(startPre, end.container, end.offset);
       // `+ 1` because the fence opener is line `preLine`, the first content
       // line is `preLine + 1`. The newline counter returns 0 for the first
-      // content line; bump everything by 1 to land on it.
-      const startLine = preLine + 1 + startOffset;
-      const endLine = preLine + 1 + endOffset;
+      // content line; bump everything by 1 to land on it. Clamp to the last
+      // real content line so a selection ending at the close of the `<pre>`
+      // (which counts the trailing newline) doesn't overshoot.
+      const rawStart = preLine + 1 + startOffset;
+      const rawEnd = preLine + 1 + endOffset;
+      const startLine = Math.min(rawStart, lastContentLine);
+      const endLine = Math.min(rawEnd, lastContentLine);
       const [s, e] = startLine <= endLine ? [startLine, endLine] : [endLine, startLine];
       return {
         anchor: { kind: "codeBlock", startLine: s, endLine: e, codeStartLine: preLine },

--- a/src/features/file-explorer/screens/PullRequestScreen/PreviewArea.tsx
+++ b/src/features/file-explorer/screens/PullRequestScreen/PreviewArea.tsx
@@ -59,5 +59,13 @@ export function PreviewArea({
       </div>
     );
   }
-  return <MarkdownPreview source={file.data ?? ""} hunks={diff.data?.hunks} />;
+  return (
+    <MarkdownPreview
+      source={file.data ?? ""}
+      hunks={diff.data?.hunks}
+      prNumber={prNumber}
+      filePath={filePath}
+      headSha={sha}
+    />
+  );
 }

--- a/src/features/file-explorer/screens/PullRequestScreen/index.tsx
+++ b/src/features/file-explorer/screens/PullRequestScreen/index.tsx
@@ -113,7 +113,7 @@ export function PullRequestScreen() {
           />
         ) : null}
       </PreviewSlot>
-      <ThreadsPane />
+      <ThreadsPane prNumber={prNumber} filePath={selectedPath} />
     </>
   );
 }

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -90,6 +90,7 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
               isLoading={query.isLoading}
               hideFilePath={effectiveScope === "currentFile"}
               hiddenCount={hiddenCount}
+              currentFilePath={filePath}
             />
           )}
         </div>

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -1,25 +1,173 @@
+import { usePullRequestComments } from "@/features/comments/hooks/usePullRequestComments";
+import type { CommentState, ReviewComment } from "@/shared/ipc/contract";
+import { describeError } from "@/shared/ipc/errors";
+import { cn } from "@/shared/lib/cn";
+import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
 import { ScrollArea } from "@/shared/ui/scroll-area";
-import { MessagesSquareIcon } from "lucide-react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { type FilterableState, ThreadFilterBar } from "./threads/ThreadFilterBar";
+import { ThreadList } from "./threads/ThreadList";
 
-export function ThreadsPane() {
+interface ThreadsPaneProps {
+  prNumber?: number;
+  filePath?: string;
+}
+
+const DEFAULT_FILTER: Record<FilterableState, boolean> = {
+  draft: true,
+  submitted: true,
+  resolved: false,
+  hidden: false,
+};
+
+type Scope = "currentFile" | "allFiles";
+
+export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
   const { t } = useTranslation();
+  const query = usePullRequestComments(prNumber);
+  const [filter, setFilter] = useState<Record<FilterableState, boolean>>(DEFAULT_FILTER);
+  const [scope, setScope] = useState<Scope>("currentFile");
+
+  const allComments = query.data ?? [];
+
+  // When no file is selected, force the "all files" view so the user still sees
+  // every PR-level thread instead of an empty pane.
+  const effectiveScope: Scope = filePath ? scope : "allFiles";
+
+  const scopedComments = useMemo(() => {
+    if (effectiveScope === "currentFile" && filePath) {
+      return allComments.filter((c) => c.filePath === filePath);
+    }
+    return allComments;
+  }, [allComments, effectiveScope, filePath]);
+
+  const { visible, hiddenCount } = useMemo(
+    () => partitionByFilter(scopedComments, filter),
+    [scopedComments, filter],
+  );
+
   return (
-    <aside className="flex h-full w-[336px] shrink-0 flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--card))]">
-      <div className="flex flex-col gap-1 px-4 pb-3 pt-4">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-[hsl(var(--muted-foreground))]">
-          {t("main.threads.title")}
-        </span>
-        <span className="text-xs text-[hsl(var(--muted-foreground))]">
-          {t("main.threads.subtitle")}
-        </span>
-      </div>
+    <aside className="flex h-full w-[336px] shrink-0 flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--muted))]">
+      <header className="flex flex-col gap-3 px-4 pb-3 pt-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-semibold text-[hsl(var(--foreground))]">
+            {t("main.threads.title")}
+          </span>
+          <span className="text-xs text-[hsl(var(--muted-foreground))]">
+            {t("main.threads.subtitle")}
+          </span>
+        </div>
+        {filePath ? (
+          <ScopeToggle
+            value={effectiveScope}
+            onChange={setScope}
+            currentLabel={t("main.threads.currentFile")}
+            allLabel={t("main.threads.allFiles")}
+          />
+        ) : null}
+        <ThreadFilterBar
+          enabled={filter}
+          onToggle={(s) => setFilter((prev) => ({ ...prev, [s]: !prev[s] }))}
+        />
+      </header>
       <ScrollArea className="flex-1">
-        <div className="flex flex-col items-center gap-2 px-4 py-10 text-center text-xs text-[hsl(var(--muted-foreground))]">
-          <MessagesSquareIcon className="size-6 opacity-60" />
-          <p>{t("main.threads.phase3Hint")}</p>
+        <div className="px-3 pb-4 pt-1">
+          {query.isError && query.error ? (
+            <Alert tone="destructive">
+              <div className="min-w-0 flex-1">
+                <AlertTitle>{t("main.threads.errorTitle")}</AlertTitle>
+                <AlertDescription>{describeError(query.error).description}</AlertDescription>
+              </div>
+            </Alert>
+          ) : prNumber === undefined ? (
+            <p className="px-1 py-6 text-center text-xs text-[hsl(var(--muted-foreground))]">
+              {t("main.threads.empty")}
+            </p>
+          ) : (
+            <ThreadList
+              comments={visible}
+              isLoading={query.isLoading}
+              hideFilePath={effectiveScope === "currentFile"}
+              hiddenCount={hiddenCount}
+            />
+          )}
         </div>
       </ScrollArea>
     </aside>
   );
 }
+
+function ScopeToggle({
+  value,
+  onChange,
+  currentLabel,
+  allLabel,
+}: {
+  value: Scope;
+  onChange: (s: Scope) => void;
+  currentLabel: string;
+  allLabel: string;
+}) {
+  return (
+    <div className="inline-flex w-full rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-0.5 text-[12px]">
+      <ScopeButton active={value === "currentFile"} onClick={() => onChange("currentFile")}>
+        {currentLabel}
+      </ScopeButton>
+      <ScopeButton active={value === "allFiles"} onClick={() => onChange("allFiles")}>
+        {allLabel}
+      </ScopeButton>
+    </div>
+  );
+}
+
+function ScopeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex-1 rounded-[4px] px-2 py-1.5 font-medium transition-colors",
+        active
+          ? "bg-[hsl(var(--muted))] text-[hsl(var(--foreground))] shadow-xs"
+          : "text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function partitionByFilter(
+  comments: ReviewComment[],
+  filter: Record<FilterableState, boolean>,
+): { visible: ReviewComment[]; hiddenCount: number } {
+  const visible: ReviewComment[] = [];
+  let hiddenCount = 0;
+  for (const comment of comments) {
+    if (comment.state === "deleted") {
+      // Deleted threads stay traceable as part of the "hidden" tally without
+      // showing the body — we never render them in the list.
+      hiddenCount += 1;
+      continue;
+    }
+    const allowed = filter[comment.state as FilterableState];
+    if (allowed) {
+      visible.push(comment);
+    } else {
+      hiddenCount += 1;
+    }
+  }
+  return { visible, hiddenCount };
+}
+
+// Internal re-export so the filter type stays alongside the pane.
+export type { CommentState };

--- a/src/features/main/components/threads/AnchorLabel.tsx
+++ b/src/features/main/components/threads/AnchorLabel.tsx
@@ -1,0 +1,34 @@
+import type { CommentAnchor } from "@/shared/ipc/contract";
+import { useTranslation } from "react-i18next";
+
+interface AnchorLabelProps {
+  filePath: string;
+  anchor: CommentAnchor;
+  /** When true, hide the file path and only render the line indicator. */
+  lineOnly?: boolean;
+}
+
+/**
+ * Renders an anchor descriptor like `README.md L4` or `docs/a.md L12–L14`.
+ * Code-block anchors collapse to their `(startLine, endLine)` extent because
+ * the user perceives them as a single block in the preview.
+ */
+export function AnchorLabel({ filePath, anchor, lineOnly = false }: AnchorLabelProps) {
+  const { t } = useTranslation();
+  const lineLabel =
+    anchor.kind === "singleLine"
+      ? t("threads.row.anchorLine", { line: anchor.line })
+      : anchor.startLine === anchor.endLine
+        ? t("threads.row.anchorLine", { line: anchor.startLine })
+        : t("threads.row.anchorRange", { start: anchor.startLine, end: anchor.endLine });
+
+  if (lineOnly) {
+    return <span className="font-mono text-[11px]">{lineLabel}</span>;
+  }
+  return (
+    <span className="inline-flex items-baseline gap-1.5">
+      <span className="truncate font-medium">{filePath}</span>
+      <span className="font-mono text-[11px] text-[hsl(var(--muted-foreground))]">{lineLabel}</span>
+    </span>
+  );
+}

--- a/src/features/main/components/threads/StateBadge.tsx
+++ b/src/features/main/components/threads/StateBadge.tsx
@@ -1,0 +1,28 @@
+import type { CommentState } from "@/shared/ipc/contract";
+import { Badge } from "@/shared/ui/badge";
+import { useTranslation } from "react-i18next";
+
+const toneByState: Record<
+  CommentState,
+  "default" | "muted" | "success" | "warning" | "destructive"
+> = {
+  draft: "warning",
+  submitted: "default",
+  hidden: "muted",
+  resolved: "success",
+  deleted: "destructive",
+};
+
+interface StateBadgeProps {
+  state: CommentState;
+  className?: string;
+}
+
+export function StateBadge({ state, className }: StateBadgeProps) {
+  const { t } = useTranslation();
+  return (
+    <Badge tone={toneByState[state]} className={className}>
+      {t(`threads.state.${state}`)}
+    </Badge>
+  );
+}

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -1,0 +1,95 @@
+import type { ReviewComment } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { useTranslation } from "react-i18next";
+import { AnchorLabel } from "./AnchorLabel";
+import { StateBadge } from "./StateBadge";
+
+const PREVIEW_LIMIT = 120;
+
+export interface ThreadGroup {
+  /** Stable id derived from `filePath` + the anchor's start line. */
+  key: string;
+  filePath: string;
+  startLine: number;
+  comments: ReviewComment[];
+}
+
+interface ThreadCardProps {
+  group: ThreadGroup;
+  /** When true, the card is associated with the currently selected comment. */
+  selected: boolean;
+  /** When true, the card is showing comments from a single file context. */
+  hideFilePath: boolean;
+  onSelect: (comment: ReviewComment) => void;
+}
+
+export function ThreadCard({ group, selected, hideFilePath, onSelect }: ThreadCardProps) {
+  const head = group.comments[0];
+  const { t } = useTranslation();
+  if (!head) return null;
+  const replyCount = group.comments.length - 1;
+  const isResolved = head.state === "resolved";
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(head)}
+      className={cn(
+        "flex w-full flex-col gap-2.5 rounded-lg border bg-[hsl(var(--card))] p-3 text-left text-sm transition-colors",
+        "hover:border-[hsl(var(--foreground))]/30",
+        selected ? "border-[hsl(var(--foreground))]/40 shadow-sm" : "border-[hsl(var(--border))]",
+        isResolved ? "opacity-70" : null,
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[hsl(var(--foreground))]">
+          <AnchorLabel filePath={group.filePath} anchor={head.anchor} lineOnly={hideFilePath} />
+        </span>
+        <StateBadge state={head.state} className="shrink-0" />
+      </div>
+      <p className="text-[12px] leading-snug text-[hsl(var(--muted-foreground))]">
+        {truncateBody(head.body)}
+      </p>
+      <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+        <span className="truncate">{head.author ?? ""}</span>
+        <span className="flex items-center gap-2">
+          {replyCount > 0 ? (
+            <span>
+              {t("threads.row.replyCount", {
+                count: replyCount,
+                defaultValue: replyCount === 1 ? "1 reply" : `${replyCount} replies`,
+              })}
+            </span>
+          ) : null}
+          <RelativeTime ms={head.createdAt} />
+        </span>
+      </div>
+    </button>
+  );
+}
+
+function truncateBody(body: string): string {
+  const trimmed = body.trim().replace(/\s+/g, " ");
+  if (trimmed.length <= PREVIEW_LIMIT) return trimmed;
+  return `${trimmed.slice(0, PREVIEW_LIMIT - 1)}…`;
+}
+
+function RelativeTime({ ms }: { ms: number }) {
+  const { t, i18n } = useTranslation();
+  const diff = Date.now() - ms;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  let label: string;
+  if (diff < minute) {
+    label = t("threads.row.justNow");
+  } else if (diff < hour) {
+    label = t("threads.row.minutesAgo", { n: Math.max(1, Math.round(diff / minute)) });
+  } else if (diff < day) {
+    label = t("threads.row.hoursAgo", { n: Math.round(diff / hour) });
+  } else if (diff < 30 * day) {
+    label = t("threads.row.daysAgo", { n: Math.round(diff / day) });
+  } else {
+    label = new Date(ms).toLocaleDateString(i18n.language);
+  }
+  return <time dateTime={new Date(ms).toISOString()}>{label}</time>;
+}

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -7,7 +7,12 @@ import { StateBadge } from "./StateBadge";
 const PREVIEW_LIMIT = 120;
 
 export interface ThreadGroup {
-  /** Stable id derived from `filePath` + the anchor's start line. */
+  /**
+   * Stable id derived from `filePath` + the anchor's `(startLine, endLine)`
+   * extent — kept in lockstep with `groupByAnchor` in `ThreadList`. A
+   * single-line and a multi-line range starting on the same line need
+   * distinct keys so they render as separate cards.
+   */
   key: string;
   filePath: string;
   startLine: number;

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -50,7 +50,7 @@ export function ThreadCard({ group, selected, hideFilePath, onSelect }: ThreadCa
         {truncateBody(head.body)}
       </p>
       <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
-        <span className="truncate">{head.author ?? ""}</span>
+        <span className="truncate">{head.author ?? t("comments.thread.anonAuthor")}</span>
         <span className="flex items-center gap-2">
           {replyCount > 0 ? (
             <span>

--- a/src/features/main/components/threads/ThreadFilterBar.tsx
+++ b/src/features/main/components/threads/ThreadFilterBar.tsx
@@ -1,0 +1,42 @@
+import type { CommentState } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { useTranslation } from "react-i18next";
+
+export type FilterableState = Exclude<CommentState, "deleted">;
+
+interface ThreadFilterBarProps {
+  enabled: Record<FilterableState, boolean>;
+  onToggle: (state: FilterableState) => void;
+}
+
+const ORDER: FilterableState[] = ["draft", "submitted", "resolved", "hidden"];
+
+export function ThreadFilterBar({ enabled, onToggle }: ThreadFilterBarProps) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-[11px] text-[hsl(var(--muted-foreground))]">
+        {t("threads.filter.label")}
+      </span>
+      {ORDER.map((state) => {
+        const active = enabled[state];
+        return (
+          <button
+            key={state}
+            type="button"
+            onClick={() => onToggle(state)}
+            aria-pressed={active}
+            className={cn(
+              "inline-flex h-6 items-center rounded-full border px-2.5 text-[11px] font-medium transition-colors",
+              active
+                ? "border-[hsl(var(--foreground))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))]"
+                : "border-[hsl(var(--border))] bg-[hsl(var(--card))] text-[hsl(var(--muted-foreground))] hover:bg-[hsl(var(--accent))]",
+            )}
+          >
+            {t(`threads.filter.${state}`)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -11,9 +11,17 @@ interface ThreadListProps {
   isLoading: boolean;
   hideFilePath: boolean;
   hiddenCount: number;
+  /** File path of the currently open preview, when one is selected. */
+  currentFilePath?: string;
 }
 
-export function ThreadList({ comments, isLoading, hideFilePath, hiddenCount }: ThreadListProps) {
+export function ThreadList({
+  comments,
+  isLoading,
+  hideFilePath,
+  hiddenCount,
+  currentFilePath,
+}: ThreadListProps) {
   const { t } = useTranslation();
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
   const select = useSelectedThread((s) => s.select);
@@ -49,7 +57,12 @@ export function ThreadList({ comments, isLoading, hideFilePath, hiddenCount }: T
             hideFilePath={hideFilePath}
             onSelect={(comment) => {
               select(comment.id);
-              scrollToAnchorLine(getAnchorScrollLine(comment));
+              // Scrolling targets the *currently open* preview's article;
+              // for cross-file threads we'd land on an unrelated same-numbered
+              // line. Skip until file navigation is wired.
+              if (comment.filePath === currentFilePath) {
+                scrollToAnchorLine(getAnchorScrollLine(comment));
+              }
             }}
           />
         );

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -86,7 +86,10 @@ function groupByAnchor(comments: ReviewComment[]): ThreadGroup[] {
   const buckets = new Map<string, ThreadGroup>();
   for (const comment of comments) {
     const startLine = startLineOf(comment);
-    const key = `${comment.filePath}::${startLine}`;
+    const endLine = endLineOf(comment);
+    // Include the anchor extent in the key so a single-line and a multi-line
+    // range that share `startLine` render as distinct cards.
+    const key = `${comment.filePath}::${startLine}:${endLine}`;
     const existing = buckets.get(key);
     if (existing) {
       existing.comments.push(comment);
@@ -102,7 +105,7 @@ function groupByAnchor(comments: ReviewComment[]): ThreadGroup[] {
   for (const group of buckets.values()) {
     group.comments.sort((a, b) => a.createdAt - b.createdAt);
   }
-  // Sort groups by file path, then by line number — stable, predictable order.
+  // Sort groups by file path, then by start line — stable, predictable order.
   return Array.from(buckets.values()).sort((a, b) => {
     if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
     return a.startLine - b.startLine;
@@ -113,4 +116,10 @@ function startLineOf(comment: ReviewComment): number {
   const a = comment.anchor;
   if (a.kind === "singleLine") return a.line;
   return a.startLine;
+}
+
+function endLineOf(comment: ReviewComment): number {
+  const a = comment.anchor;
+  if (a.kind === "singleLine") return a.line;
+  return a.endLine;
 }

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -1,0 +1,103 @@
+import type { ReviewComment } from "@/shared/ipc/contract";
+import { useSelectedThread } from "@/shared/stores/useSelectedThread";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { scrollToAnchorLine } from "../../lib/scrollToAnchor";
+import { ThreadCard, type ThreadGroup } from "./ThreadCard";
+
+interface ThreadListProps {
+  comments: ReviewComment[];
+  isLoading: boolean;
+  hideFilePath: boolean;
+  hiddenCount: number;
+}
+
+export function ThreadList({ comments, isLoading, hideFilePath, hiddenCount }: ThreadListProps) {
+  const { t } = useTranslation();
+  const selectedId = useSelectedThread((s) => s.selectedCommentId);
+  const select = useSelectedThread((s) => s.select);
+  const groups = useMemo(() => groupByAnchor(comments), [comments]);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+
+  if (groups.length === 0) {
+    return (
+      <p className="px-1 py-6 text-center text-xs text-[hsl(var(--muted-foreground))]">
+        {t("main.threads.empty")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {groups.map((group) => {
+        const isSelected = group.comments.some((c) => c.id === selectedId);
+        return (
+          <ThreadCard
+            key={group.key}
+            group={group}
+            selected={isSelected}
+            hideFilePath={hideFilePath}
+            onSelect={(comment) => {
+              select(comment.id);
+              scrollToAnchorLine(getAnchorScrollLine(comment));
+            }}
+          />
+        );
+      })}
+      {hiddenCount > 0 ? (
+        <p className="pt-2 text-center text-[11px] text-[hsl(var(--muted-foreground))]">
+          {t("main.threads.hiddenCount", { count: hiddenCount })}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function getAnchorScrollLine(comment: ReviewComment): number {
+  const a = comment.anchor;
+  if (a.kind === "singleLine") return a.line;
+  return a.startLine;
+}
+
+function groupByAnchor(comments: ReviewComment[]): ThreadGroup[] {
+  const buckets = new Map<string, ThreadGroup>();
+  for (const comment of comments) {
+    const startLine = startLineOf(comment);
+    const key = `${comment.filePath}::${startLine}`;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.comments.push(comment);
+    } else {
+      buckets.set(key, {
+        key,
+        filePath: comment.filePath,
+        startLine,
+        comments: [comment],
+      });
+    }
+  }
+  for (const group of buckets.values()) {
+    group.comments.sort((a, b) => a.createdAt - b.createdAt);
+  }
+  // Sort groups by file path, then by line number — stable, predictable order.
+  return Array.from(buckets.values()).sort((a, b) => {
+    if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+    return a.startLine - b.startLine;
+  });
+}
+
+function startLineOf(comment: ReviewComment): number {
+  const a = comment.anchor;
+  if (a.kind === "singleLine") return a.line;
+  return a.startLine;
+}

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -77,9 +77,13 @@ export function ThreadList({
 }
 
 function getAnchorScrollLine(comment: ReviewComment): number {
+  // Inline thread cards / badges mount under `attachLine` (== endLine for
+  // ranges; see `groupCommentsByStartLine`). Scrolling to the start line
+  // of a long range can leave the actual card off-screen, so target the
+  // end line instead.
   const a = comment.anchor;
   if (a.kind === "singleLine") return a.line;
-  return a.startLine;
+  return a.endLine;
 }
 
 function groupByAnchor(comments: ReviewComment[]): ThreadGroup[] {

--- a/src/features/main/lib/scrollToAnchor.ts
+++ b/src/features/main/lib/scrollToAnchor.ts
@@ -1,0 +1,12 @@
+/**
+ * Scrolls the rendered Markdown preview to the block tagged with the given
+ * source line. Returns the matched element (or null) so callers can flash a
+ * highlight if they want.
+ */
+export function scrollToAnchorLine(line: number): HTMLElement | null {
+  if (!Number.isFinite(line) || line <= 0) return null;
+  const el = document.querySelector<HTMLElement>(`article [data-source-line="${line}"]`);
+  if (!el) return null;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  return el;
+}

--- a/src/features/markdown-preview/components/MarkdownPreview.tsx
+++ b/src/features/markdown-preview/components/MarkdownPreview.tsx
@@ -1,6 +1,7 @@
-import type { DiffHunk } from "@/shared/ipc/contract";
+import { InlineThreads, SelectionCommentOverlay, useFileComments } from "@/features/comments";
+import type { CommentAnchor, DiffHunk } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import { renderMarkdown } from "../lib/pipeline";
 import { DiffGutter } from "./DiffGutter";
 
@@ -8,11 +9,27 @@ interface MarkdownPreviewProps {
   source: string;
   className?: string;
   hunks?: DiffHunk[];
+  /** When prNumber + filePath + headSha are present, mounts the comments UI. */
+  prNumber?: number;
+  filePath?: string;
+  headSha?: string;
 }
 
-export function MarkdownPreview({ source, className, hunks }: MarkdownPreviewProps) {
+export function MarkdownPreview({
+  source,
+  className,
+  hunks,
+  prNumber,
+  filePath,
+  headSha,
+}: MarkdownPreviewProps) {
   const html = useMemo(() => renderMarkdown(source), [source]);
   const articleRef = useRef<HTMLElement>(null);
+  const commentsEnabled = Boolean(prNumber && filePath && headSha);
+  const fileComments = useFileComments({ prNumber, filePath });
+  const comments = fileComments.data ?? [];
+  const [composerAnchor, setComposerAnchor] = useState<CommentAnchor | null>(null);
+
   return (
     <div className="relative mx-auto w-full max-w-3xl">
       {hunks && hunks.length > 0 ? <DiffGutter hunks={hunks} containerRef={articleRef} /> : null}
@@ -22,6 +39,24 @@ export function MarkdownPreview({ source, className, hunks }: MarkdownPreviewPro
         // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via rehype-sanitize.
         dangerouslySetInnerHTML={{ __html: html }}
       />
+      {commentsEnabled ? (
+        <>
+          <InlineThreads
+            prNumber={prNumber as number}
+            filePath={filePath as string}
+            headSha={headSha as string}
+            comments={comments}
+            containerRef={articleRef}
+            composerAnchor={composerAnchor}
+            onComposerClose={() => setComposerAnchor(null)}
+          />
+          <SelectionCommentOverlay
+            containerRef={articleRef}
+            disabled={composerAnchor !== null}
+            onStartComposer={(a) => setComposerAnchor(a)}
+          />
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -151,6 +151,8 @@
       "reply": "Reply",
       "hide": "Hide",
       "resolve": "Resolve",
+      "delete": "Delete",
+      "deleteAria": "Delete this comment",
       "badgeOpen": "Open",
       "badgeDraft": "Draft",
       "badgeResolved": "Resolved",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -85,7 +85,13 @@
     "threads": {
       "title": "Review threads",
       "subtitle": "Comments attached to rendered Markdown ranges.",
-      "phase3Hint": "Comments will land here in Phase 3."
+      "currentFile": "Current file",
+      "allFiles": "All files in PR",
+      "loading": "Loading comments…",
+      "empty": "No threads yet — select text in the preview to start one.",
+      "errorTitle": "Couldn't load comments",
+      "hiddenCount_one": "+ {{count}} hidden thread",
+      "hiddenCount_other": "+ {{count}} hidden threads"
     },
     "toolbar": {
       "backToRepositoriesAria": "Back to repositories"
@@ -93,6 +99,63 @@
     "sidebar": {
       "fallbackEmpty": "Nothing to show yet.",
       "resizeAria": "Resize sidebar"
+    }
+  },
+  "threads": {
+    "row": {
+      "anchorLine": "L{{line}}",
+      "anchorRange": "L{{start}}–L{{end}}",
+      "minutesAgo": "{{n}}m ago",
+      "hoursAgo": "{{n}}h ago",
+      "daysAgo": "{{n}}d ago",
+      "justNow": "just now",
+      "replyCount_one": "{{count}} reply",
+      "replyCount_other": "{{count}} replies"
+    },
+    "filter": {
+      "label": "Show",
+      "draft": "Drafts",
+      "submitted": "Submitted",
+      "resolved": "Resolved",
+      "hidden": "Hidden"
+    },
+    "state": {
+      "draft": "Draft",
+      "submitted": "Submitted",
+      "hidden": "Hidden",
+      "resolved": "Resolved",
+      "deleted": "Deleted"
+    }
+  },
+  "comments": {
+    "composer": {
+      "placeholder": "Add a comment…",
+      "save": "Save",
+      "cancel": "Cancel",
+      "commentAction": "Comment",
+      "submitShortcut": "{{shortcut}} to save",
+      "metaSingle": "Comment on line {{line}}",
+      "metaRange": "Comment on lines {{start}}–{{end}}",
+      "errorTitle": "Couldn't save comment"
+    },
+    "markers": {
+      "tooltipMore_one": "{{count}} comment",
+      "tooltipMore_other": "{{count}} comments",
+      "selectionAria": "Add comment for selected lines",
+      "expandAria": "Expand thread"
+    },
+    "thread": {
+      "anonAuthor": "Someone",
+      "metaSingle": "{{author}} on line {{line}}",
+      "metaRange": "{{author}} on lines {{start}}–{{end}}",
+      "reply": "Reply",
+      "hide": "Hide",
+      "resolve": "Resolve",
+      "badgeOpen": "Open",
+      "badgeDraft": "Draft",
+      "badgeResolved": "Resolved",
+      "badgeHidden": "Hidden",
+      "badgeDeleted": "Deleted"
     }
   },
   "errors": {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -198,6 +198,9 @@
     },
     "generic": {
       "title": "Something went wrong"
+    },
+    "validation": {
+      "title": "Invalid action"
     }
   }
 }

--- a/src/shared/ipc/client.ts
+++ b/src/shared/ipc/client.ts
@@ -1,7 +1,14 @@
 import { createLogger } from "@/shared/lib/logger";
 import { type Result, err, ok } from "@/shared/lib/result";
 import { invoke } from "@tauri-apps/api/core";
-import type { AppError, CommandName, Commands, Repository } from "./contract";
+import type {
+  AppError,
+  CommandName,
+  Commands,
+  CommentAnchor,
+  CommentUpdate,
+  Repository,
+} from "./contract";
 import { isAppError } from "./errors";
 
 const log = createLogger("ipc");
@@ -26,6 +33,7 @@ async function call<K extends CommandName>(
 export const ipc = {
   tools: {
     check: () => call("check_tools", undefined),
+    ghUser: () => call("get_gh_user", undefined),
   },
   repo: {
     select: () => call("select_repository", undefined),
@@ -47,5 +55,22 @@ export const ipc = {
   files: {
     readMarkdown: (repoPath: string, sha: string, filePath: string) =>
       call("read_markdown_file", { repoPath, sha, filePath }),
+  },
+  comments: {
+    list: (prNumber: number) => call("list_local_comments", { prNumber }),
+    listForFile: (prNumber: number, filePath: string) =>
+      call("list_local_comments_for_file", { prNumber, filePath }),
+    create: (args: {
+      prNumber: number;
+      filePath: string;
+      headSha: string;
+      body: string;
+      author: string | null;
+      anchor: CommentAnchor;
+    }) => call("create_local_comment", args),
+    update: (id: number, patch: CommentUpdate) => call("update_local_comment", { id, patch }),
+    delete: (id: number) => call("delete_local_comment", { id }),
+    submitReview: (repoPath: string, prNumber: number, commentIds: number[]) =>
+      call("submit_review", { repoPath, prNumber, commentIds }),
   },
 };

--- a/src/shared/ipc/contract.ts
+++ b/src/shared/ipc/contract.ts
@@ -93,6 +93,49 @@ export interface FileDiff {
   hunks: DiffHunk[];
 }
 
+export type CommentState = "draft" | "submitted" | "hidden" | "resolved" | "deleted";
+
+export type CommentAnchor =
+  | { kind: "singleLine"; line: number }
+  | { kind: "lineRange"; startLine: number; endLine: number }
+  | { kind: "codeBlock"; startLine: number; endLine: number; codeStartLine: number };
+
+export interface ReviewComment {
+  id: number;
+  prNumber: number;
+  filePath: string;
+  headSha: string;
+  body: string;
+  author: string | null;
+  state: CommentState;
+  anchor: CommentAnchor;
+  createdAt: number;
+  updatedAt: number;
+  githubId: number | null;
+  submitError: string | null;
+}
+
+export interface CommentUpdate {
+  body?: string;
+  state?: CommentState;
+  anchor?: CommentAnchor;
+}
+
+export interface SubmittedReviewComment {
+  localId: number;
+  githubId: number | null;
+  /** When the comment was published successfully. */
+  submitted: boolean;
+  /** Populated when the comment failed; cleared on success. */
+  error: string | null;
+}
+
+export interface ReviewSubmissionResult {
+  comments: SubmittedReviewComment[];
+  /** True when every requested comment was submitted. */
+  allSubmitted: boolean;
+}
+
 export type AppError =
   | { kind: "invalidPath"; data: { path: string } }
   | { kind: "notAGitRepo"; data: { path: string } }
@@ -108,6 +151,7 @@ export type AppError =
 
 export interface Commands {
   check_tools: { args: undefined; result: ToolStatus };
+  get_gh_user: { args: undefined; result: string | null };
   select_repository: { args: undefined; result: string | null };
   validate_repository: { args: { path: string }; result: Repository };
   list_recent_repositories: { args: undefined; result: RecentRepository[] };
@@ -129,6 +173,37 @@ export interface Commands {
   load_file_diff: {
     args: { repoPath: string; prNumber: number; filePath: string };
     result: FileDiff;
+  };
+  list_local_comments: {
+    args: { prNumber: number };
+    result: ReviewComment[];
+  };
+  list_local_comments_for_file: {
+    args: { prNumber: number; filePath: string };
+    result: ReviewComment[];
+  };
+  create_local_comment: {
+    args: {
+      prNumber: number;
+      filePath: string;
+      headSha: string;
+      body: string;
+      author: string | null;
+      anchor: CommentAnchor;
+    };
+    result: ReviewComment;
+  };
+  update_local_comment: {
+    args: { id: number; patch: CommentUpdate };
+    result: ReviewComment;
+  };
+  delete_local_comment: {
+    args: { id: number };
+    result: null;
+  };
+  submit_review: {
+    args: { repoPath: string; prNumber: number; commentIds: number[] };
+    result: ReviewSubmissionResult;
   };
 }
 

--- a/src/shared/ipc/contract.ts
+++ b/src/shared/ipc/contract.ts
@@ -147,6 +147,7 @@ export type AppError =
   | { kind: "io"; data: { message: string } }
   | { kind: "db"; data: { message: string } }
   | { kind: "process"; data: { message: string } }
+  | { kind: "validation"; data: { message: string } }
   | { kind: "unexpected"; data: { message: string } };
 
 export interface Commands {

--- a/src/shared/ipc/errors.ts
+++ b/src/shared/ipc/errors.ts
@@ -66,6 +66,11 @@ export function describeError(e: AppError): AppErrorView {
         }),
         actionHint: t("errors.fileNotFound.actionHint"),
       };
+    case "validation":
+      return {
+        title: t("errors.validation.title"),
+        description: e.data.message,
+      };
     case "io":
     case "db":
     case "process":

--- a/src/shared/stores/useMinimizedThreads.ts
+++ b/src/shared/stores/useMinimizedThreads.ts
@@ -1,0 +1,42 @@
+import { create } from "zustand";
+
+interface MinimizedThreadsState {
+  /** Set of group keys (the bucket's `line`) that are collapsed locally. */
+  minimized: Set<number>;
+  isMinimized: (line: number) => boolean;
+  minimize: (line: number) => void;
+  expand: (line: number) => void;
+  toggle: (line: number) => void;
+}
+
+/**
+ * Local-only UI state for collapsed inline threads. Not persisted — the Hide
+ * button on a thread card only collapses the visual card down to a small
+ * "open" badge inside the highlighted line; the underlying comment row stays
+ * `draft`/`submitted` exactly as before.
+ */
+export const useMinimizedThreads = create<MinimizedThreadsState>((set, get) => ({
+  minimized: new Set<number>(),
+  isMinimized: (line) => get().minimized.has(line),
+  minimize: (line) =>
+    set((s) => {
+      if (s.minimized.has(line)) return s;
+      const next = new Set(s.minimized);
+      next.add(line);
+      return { minimized: next };
+    }),
+  expand: (line) =>
+    set((s) => {
+      if (!s.minimized.has(line)) return s;
+      const next = new Set(s.minimized);
+      next.delete(line);
+      return { minimized: next };
+    }),
+  toggle: (line) =>
+    set((s) => {
+      const next = new Set(s.minimized);
+      if (next.has(line)) next.delete(line);
+      else next.add(line);
+      return { minimized: next };
+    }),
+}));

--- a/src/shared/stores/useMinimizedThreads.ts
+++ b/src/shared/stores/useMinimizedThreads.ts
@@ -1,12 +1,19 @@
 import { create } from "zustand";
 
+/** Composite key `${startLine}:${endLine}` matching the inline slot keying. */
+export type MinimizedKey = string;
+
+export function minimizedKey(startLine: number, endLine: number): MinimizedKey {
+  return `${startLine}:${endLine}`;
+}
+
 interface MinimizedThreadsState {
-  /** Set of group keys (the bucket's `line`) that are collapsed locally. */
-  minimized: Set<number>;
-  isMinimized: (line: number) => boolean;
-  minimize: (line: number) => void;
-  expand: (line: number) => void;
-  toggle: (line: number) => void;
+  /** Set of `(startLine, endLine)` keys that are collapsed locally. */
+  minimized: Set<MinimizedKey>;
+  isMinimized: (key: MinimizedKey) => boolean;
+  minimize: (key: MinimizedKey) => void;
+  expand: (key: MinimizedKey) => void;
+  toggle: (key: MinimizedKey) => void;
 }
 
 /**
@@ -16,27 +23,27 @@ interface MinimizedThreadsState {
  * `draft`/`submitted` exactly as before.
  */
 export const useMinimizedThreads = create<MinimizedThreadsState>((set, get) => ({
-  minimized: new Set<number>(),
-  isMinimized: (line) => get().minimized.has(line),
-  minimize: (line) =>
+  minimized: new Set<MinimizedKey>(),
+  isMinimized: (key) => get().minimized.has(key),
+  minimize: (key) =>
     set((s) => {
-      if (s.minimized.has(line)) return s;
+      if (s.minimized.has(key)) return s;
       const next = new Set(s.minimized);
-      next.add(line);
+      next.add(key);
       return { minimized: next };
     }),
-  expand: (line) =>
+  expand: (key) =>
     set((s) => {
-      if (!s.minimized.has(line)) return s;
+      if (!s.minimized.has(key)) return s;
       const next = new Set(s.minimized);
-      next.delete(line);
+      next.delete(key);
       return { minimized: next };
     }),
-  toggle: (line) =>
+  toggle: (key) =>
     set((s) => {
       const next = new Set(s.minimized);
-      if (next.has(line)) next.delete(line);
-      else next.add(line);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
       return { minimized: next };
     }),
 }));

--- a/src/shared/stores/useMinimizedThreads.ts
+++ b/src/shared/stores/useMinimizedThreads.ts
@@ -1,10 +1,20 @@
 import { create } from "zustand";
 
-/** Composite key `${startLine}:${endLine}` matching the inline slot keying. */
+/**
+ * Composite key `${prNumber}:${filePath}:${startLine}:${endLine}` so the
+ * minimized state is scoped per (PR, file) — minimizing a thread in one
+ * file no longer collapses an unrelated thread that happens to share the
+ * same line range in another file.
+ */
 export type MinimizedKey = string;
 
-export function minimizedKey(startLine: number, endLine: number): MinimizedKey {
-  return `${startLine}:${endLine}`;
+export function minimizedKey(
+  prNumber: number,
+  filePath: string,
+  startLine: number,
+  endLine: number,
+): MinimizedKey {
+  return `${prNumber}:${filePath}:${startLine}:${endLine}`;
 }
 
 interface MinimizedThreadsState {

--- a/src/shared/stores/useSelectedThread.ts
+++ b/src/shared/stores/useSelectedThread.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface SelectedThreadState {
+  selectedCommentId: number | null;
+  select: (id: number) => void;
+  clear: () => void;
+}
+
+/**
+ * Lightweight cross-feature bus so the threads pane can react when the user
+ * clicks an inline marker in the markdown preview. Intentionally not
+ * persisted — it's a transient UI selection.
+ */
+export const useSelectedThread = create<SelectedThreadState>((set) => ({
+  selectedCommentId: null,
+  select: (id) => set({ selectedCommentId: id }),
+  clear: () => set({ selectedCommentId: null }),
+}));

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -151,3 +151,72 @@ body {
   max-width: 100%;
   border-radius: 4px;
 }
+
+/* Soft brand-tinted text selection inside the rendered Markdown — matches the
+   `#eff6ff` highlight from design.pen instead of the harsh OS default blue. */
+.prose-styles ::selection {
+  background: hsl(var(--comment-selection-bg));
+  color: hsl(var(--comment-selection-fg));
+}
+
+/* Lines that already carry at least one comment get a soft persistent
+   highlight + 3px brand bar on the left, matching the `mrexSameLine` style. */
+.prose-styles [data-source-line][data-has-comment="true"] {
+  background: hsl(var(--comment-selection-bg));
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  border-radius: 6px;
+  padding-left: 0.6em;
+  margin-left: -0.6em;
+}
+/* Minimized threads keep the anchor visible with a much softer wash so the
+   document content stays the focus. */
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-minimized="true"] {
+  background: hsl(var(--comment-selection-bg) / 0.35);
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
+}
+
+/* Per-line spans inserted into `<pre>` by InlineThreads.splitCodeBlocks —
+   they need block layout so the highlight strip spans the full code width
+   instead of just the text glyphs. */
+.prose-styles pre [data-code-line] {
+  display: block;
+}
+.prose-styles pre [data-code-line][data-has-comment="true"] {
+  background: hsl(var(--comment-selection-bg));
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  /* Keep the highlight tight to the line — no rounded corners, no negative
+     margins, since we're inside a preformatted block. */
+  border-radius: 0;
+  padding-left: 0.5em;
+  margin-left: -0.5em;
+  color: hsl(var(--comment-selection-fg));
+}
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-minimized="true"] {
+  background: hsl(var(--comment-selection-bg) / 0.35);
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
+  color: inherit;
+}
+
+/* Inline thread / composer slots inserted by InlineThreads — make them sit
+   flush in the document flow under the anchor line. */
+.prose-styles [data-thread-slot] {
+  margin: 0;
+}
+
+/* Minimized "open" badge inserted at the end of the highlighted line. Pushed
+   to the right end so it doesn't disturb the surrounding text. */
+.prose-styles [data-thread-badge] {
+  float: right;
+  margin-left: 0.5em;
+  /* Reset preformatting when the badge lands inside a `<pre>` line span. */
+  white-space: normal;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+/* When a slot lands inside a `<pre>` (between code lines), reset
+   preformatting so the React card renders normally. */
+.prose-styles pre [data-thread-slot] {
+  white-space: normal;
+  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}

--- a/src/shared/styles/tokens.css
+++ b/src/shared/styles/tokens.css
@@ -17,6 +17,27 @@
   --destructive-foreground: 210 40% 98%;
   --ring: 215 20.2% 65.1%;
   --radius: 0.5rem;
+
+  /* Comment / review tokens — mirror design.pen markdownReviewExamples (light). */
+  --comment-marker-bg: 214 95% 93%; /* #dbeafe */
+  --comment-marker-fg: 224 76% 48%; /* #1d4ed8 */
+  --comment-marker-border: 213 97% 87%; /* #bfdbfe */
+  --comment-marker-hover: 214 100% 96%; /* #eff6ff */
+  --comment-selection-bg: 214 100% 96%; /* #eff6ff */
+  --comment-selection-fg: 224 76% 28%; /* #1e3a8a */
+  --comment-resolve-bg: 138 76% 97%; /* #f0fdf4 */
+  --comment-resolve-fg: 142 72% 29%; /* #166534 */
+  --comment-resolve-border: 141 79% 85%; /* #bbf7d0 */
+  --comment-avatar-bg: 0 0% 9%; /* #171717 */
+  --comment-avatar-fg: 0 0% 98%; /* #fafafa */
+  --comment-avatar-range-bg: 215 25% 27%; /* #475569 */
+  --comment-range-bg: 33 100% 96%; /* #fff7ed */
+  --comment-range-fg: 17 88% 34%; /* #9a3412 */
+  --comment-range-border: 32 98% 83%; /* #fed7aa */
+  --comment-open-bg: 138 76% 97%; /* #f0fdf4 */
+  --comment-open-fg: 142 72% 29%; /* #166534 */
+  --comment-draft-bg: 48 100% 96%; /* warm draft yellow */
+  --comment-draft-fg: 28 80% 35%;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -38,5 +59,25 @@
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
     --ring: 217.2 32.6% 17.5%;
+
+    --comment-marker-bg: 224 76% 22%;
+    --comment-marker-fg: 213 97% 87%;
+    --comment-marker-border: 224 76% 38%;
+    --comment-marker-hover: 224 76% 28%;
+    --comment-selection-bg: 224 76% 24%;
+    --comment-selection-fg: 213 97% 87%;
+    --comment-resolve-bg: 142 70% 18%;
+    --comment-resolve-fg: 141 79% 85%;
+    --comment-resolve-border: 142 70% 30%;
+    --comment-avatar-bg: 0 0% 90%;
+    --comment-avatar-fg: 0 0% 9%;
+    --comment-avatar-range-bg: 215 20% 65%;
+    --comment-range-bg: 17 60% 18%;
+    --comment-range-fg: 32 98% 83%;
+    --comment-range-border: 17 60% 30%;
+    --comment-open-bg: 142 70% 18%;
+    --comment-open-fg: 141 79% 85%;
+    --comment-draft-bg: 28 60% 18%;
+    --comment-draft-fg: 48 100% 88%;
   }
 }

--- a/src/shared/ui/textarea.tsx
+++ b/src/shared/ui/textarea.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/shared/lib/cn";
+import { type TextareaHTMLAttributes, forwardRef } from "react";
+
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        className={cn(
+          "min-h-[72px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow]",
+          "placeholder:text-muted-foreground",
+          "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          "disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";


### PR DESCRIPTION
Closes the entire **Phase 3 — Local-First Comments** milestone (issues #13–#20). Review threads anchored to rendered Markdown ranges, persisted locally in SQLite, with an explicit submit path to GitHub via `gh`.

## Summary

### Backend (Rust)
- **#13** — `ReviewComment` / `CommentState` (draft|submitted|hidden|resolved|deleted) / `CommentAnchor` (singleLine|lineRange|codeBlock) in `core/domain`. New `CommentsStore` port + `SqliteCommentsStore` + migration `0003_local_comments.sql`. Anchor serialization is camelCase JSON.
- **#14** — `comments` use case bundle wired into `AppState` and `bootstrap.rs`. Tauri commands: `create_local_comment`, `update_local_comment`, `delete_local_comment`, `list_local_comments`, `list_local_comments_for_file`.
- **#19 + #20** — `submit_review` use case + command. Batches drafts into a single `gh api POST /repos/{owner}/{repo}/pulls/{n}/reviews`; on failure (or mixed `head_sha`) falls back to per-comment `pulls/{n}/comments`. Idempotent via `github_id`; failures stay `draft` with `submit_error` populated so retries never duplicate. Returns `ReviewSubmissionResult { comments[], allSubmitted }`.
- New `get_gh_user` command surfaces the authenticated `gh` username so freshly created comments stamp `author` instead of "Someone".

### Frontend (React)
- **#15** — Selection → floating "Comment" pill → inline composer that mounts as a sibling of the anchor line. Cmd/Ctrl-Enter saves, Escape cancels, click-outside dismisses. Selection-to-anchor handles three tricky cases:
  1. Code blocks: counts `\n` from the `<pre>` start to map a selection to the right line.
  2. Selection spilling into the next block at `endOffset === 0`: walks back to the previous leaf so the heading below isn't accidentally included.
  3. Multi-line ranges: composer mounts under the **last** line.
- **#16** — `InlineThreads` does per-line code-block splitting (each line gets its own `<span data-code-line data-source-line>`), range highlighting on the actual selected lines (whole list / whole code block bugs fixed), cards mount under the LAST highlighted line, deepest-element-wins resolution so containers like `<ul>`/`<ol>` never get the highlight.
- **#17** — `ThreadsPane` (right pane): live thread list grouped by file/line, scope toggle (current file vs all files), filter pills, click scrolls preview to the anchor.
- **#18** — `usePullRequestComments` query hydrates threads on PR landing.

### Design fidelity (per `design.pen`)
- `InlineThreadCard` matches `mrexLongSelectionComment`: avatar with initials (slate `#475569` for ranges, dark `#171717` for single-line), `"X on lines A–B"` header, state badge always reflecting status (Draft / Open / Resolved / Hidden), Reply link, dark Hide button + green Resolve chip. Range selections get the orange `#fed7aa` card border.
- Per-line highlight matches `mrexSameLine` / `mrexOpenCode04`: soft `#eff6ff` background + 3px `#2563eb` left bar.
- Hide is a **local-only minimize**: collapses the card to a tiny `mrexOpenCodeBadge`-style pill (`message-square` icon + count) inside the anchor line; click expands. Minimized threads get a softer 35%-alpha highlight wash.
- ThreadsPane bg uses `#fafafa`, plain title (no caps), white-card thread items with subtle border.
- `::selection` inside the article is now a soft brand wash instead of the harsh OS blue.

## Validation
- `cargo build --workspace` ✓
- `cargo test -p markdown-reviewer-core` — 31/31 passing (incl. 5 new `comments_submit` tests covering batch success, batch-failure-fallback, mixed fallback, idempotency, mixed-head-sha)
- `cargo test -p markdown-reviewer-infra -- --ignored` — 18/18 passing (incl. 6 new `sqlite_comments` tests)
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `bun run check`, `bun run typecheck` ✓

## Test plan
- [ ] `cargo build --workspace`
- [ ] `cargo test -p markdown-reviewer-core`
- [ ] `cargo test -p markdown-reviewer-infra -- --ignored`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `bun run typecheck && bun run check`
- [ ] `bun run dev` → open a PR, select text in the Markdown preview, add a comment, verify card appears under the anchor; reload to confirm hydration.
- [ ] Select multi-line range → highlight covers all lines, card sits under the last one.
- [ ] Select inside a fenced code block → only the selected line(s) highlighted.
- [ ] Click Hide on a thread → collapses to badge; click badge → expands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)