### PR TITLE
feat(phase-4 #21): multi-comment counter + stacked panel view

### DIFF
--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,7 +1,7 @@
 import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { CheckIcon, Trash2Icon } from "lucide-react";
+import { CheckIcon, MessageSquareIcon, Trash2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useGhUser } from "../hooks/useGhUser";
 
@@ -13,6 +13,8 @@ interface InlineThreadCardProps {
   onHide?: (comment: ReviewComment) => void;
   onReply?: (head: ReviewComment) => void;
   onDelete?: (comment: ReviewComment) => void;
+  /** Click on the count badge — opens the stacked view in the threads panel. */
+  onShowStack?: (head: ReviewComment) => void;
 }
 
 function isRange(anchor: CommentAnchor): boolean {
@@ -87,6 +89,7 @@ export function InlineThreadCard({
   onHide,
   onReply,
   onDelete,
+  onShowStack,
 }: InlineThreadCardProps) {
   const { t } = useTranslation();
   const ghUser = useGhUser();
@@ -102,6 +105,7 @@ export function InlineThreadCard({
     ? "border-[hsl(var(--comment-range-border))]"
     : "border-[hsl(var(--border))]";
   const badge = badgeFor(t, head.state);
+  const total = comments.length;
 
   return (
     <div
@@ -126,6 +130,24 @@ export function InlineThreadCard({
         <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-[hsl(var(--foreground))]">
           {metaLabel(t, head)}
         </span>
+        {total > 1 ? (
+          <button
+            type="button"
+            onClick={() => onShowStack?.(head)}
+            aria-label={t("comments.markers.countBadgeAria", { count: total })}
+            title={t("comments.markers.countBadgeTooltip", { count: total })}
+            className={cn(
+              "inline-flex h-6 shrink-0 items-center gap-1 rounded-full px-2 text-[11px] font-semibold",
+              "border border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",
+              "text-[hsl(var(--comment-marker-fg))] transition-colors",
+              "hover:bg-[hsl(var(--comment-marker-hover))]",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+            )}
+          >
+            <MessageSquareIcon className="h-3 w-3" aria-hidden="true" />
+            <span aria-hidden="true">{total}</span>
+          </button>
+        ) : null}
         <span
           className="inline-flex h-6 shrink-0 items-center rounded-full px-2 text-[11px] font-medium"
           style={{

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -130,10 +130,10 @@ export function InlineThreadCard({
         <span className="min-w-0 flex-1 truncate text-[11px] font-semibold text-[hsl(var(--foreground))]">
           {metaLabel(t, head)}
         </span>
-        {total > 1 ? (
+        {total > 1 && onShowStack ? (
           <button
             type="button"
-            onClick={() => onShowStack?.(head)}
+            onClick={() => onShowStack(head)}
             aria-label={t("comments.markers.countBadgeAria", { count: total })}
             title={t("comments.markers.countBadgeTooltip", { count: total })}
             className={cn(
@@ -147,6 +147,19 @@ export function InlineThreadCard({
             <MessageSquareIcon className="h-3 w-3" aria-hidden="true" />
             <span aria-hidden="true">{total}</span>
           </button>
+        ) : total > 1 ? (
+          <span
+            aria-label={t("comments.markers.countBadgeAria", { count: total })}
+            title={t("comments.markers.countBadgeAria", { count: total })}
+            className={cn(
+              "inline-flex h-6 shrink-0 items-center gap-1 rounded-full px-2 text-[11px] font-semibold",
+              "border border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",
+              "text-[hsl(var(--comment-marker-fg))]",
+            )}
+          >
+            <MessageSquareIcon className="h-3 w-3" aria-hidden="true" />
+            <span aria-hidden="true">{total}</span>
+          </span>
         ) : null}
         <span
           className="inline-flex h-6 shrink-0 items-center rounded-full px-2 text-[11px] font-medium"

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -2,6 +2,7 @@ import { ipc } from "@/shared/ipc/client";
 import type { CommentAnchor, CommentUpdate, ReviewComment } from "@/shared/ipc/contract";
 import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
+import { type FilterableState, useThreadsFilter } from "@/shared/stores/useThreadsFilter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -62,6 +63,8 @@ export function InlineThreads({
   const minimizedSet = useMinimizedThreads((s) => s.minimized);
   const minimize = useMinimizedThreads((s) => s.minimize);
   const expand = useMinimizedThreads((s) => s.expand);
+  const paneFilter = useThreadsFilter((s) => s.filter);
+  const ensurePaneVisible = useThreadsFilter((s) => s.ensureVisible);
   const queryClient = useQueryClient();
 
   const update = useMutation({
@@ -217,7 +220,15 @@ export function InlineThreads({
             onHide={() => minimize(minKey)}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
-            onShowStack={(c) => select(pickPaneVisibleId(group.comments, c.id))}
+            onShowStack={(c) => {
+              const target = pickPaneVisibleComment(group.comments, paneFilter, c);
+              // If every comment in the group is filtered out of the pane,
+              // flip on the chip for the head's state so the pane shows it.
+              if (!isPaneVisible(target, paneFilter)) {
+                ensurePaneVisible(target.state as FilterableState);
+              }
+              select(target.id);
+            }}
           />,
           slot,
           `thread-${slotKey}`,
@@ -243,15 +254,29 @@ export function InlineThreads({
 }
 
 /**
- * Picks the first comment likely to be visible in the threads pane (which
- * defaults to showing `draft` and `submitted` only). Falls back to `fallback`
- * — usually the head — if every comment is `resolved` or `hidden`, so the
- * inline preview still has *something* selected even when the pane filter
- * hides the whole group.
+ * Returns true when the comment's state is currently shown in the threads
+ * pane filter. `deleted` comments are never shown.
  */
-function pickPaneVisibleId(comments: ReviewComment[], fallback: number): number {
-  const candidate = comments.find((c) => c.state === "draft" || c.state === "submitted");
-  return candidate?.id ?? fallback;
+function isPaneVisible(
+  comment: ReviewComment,
+  paneFilter: Record<FilterableState, boolean>,
+): boolean {
+  if (comment.state === "deleted") return false;
+  return paneFilter[comment.state] === true;
+}
+
+/**
+ * Picks a comment from the group that the threads pane is *currently* showing.
+ * Falls back to `fallback` (usually the head) when every comment in the group
+ * is filtered out — the caller can then flip the matching chip on so the
+ * selection becomes reachable in the pane.
+ */
+function pickPaneVisibleComment(
+  comments: ReviewComment[],
+  paneFilter: Record<FilterableState, boolean>,
+  fallback: ReviewComment,
+): ReviewComment {
+  return comments.find((c) => isPaneVisible(c, paneFilter)) ?? fallback;
 }
 
 function mutationIsSignificant(record: MutationRecord): boolean {

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -217,6 +217,7 @@ export function InlineThreads({
             onHide={() => minimize(minKey)}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
+            onShowStack={(c) => select(c.id)}
           />,
           slot,
           `thread-${slotKey}`,

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -217,7 +217,7 @@ export function InlineThreads({
             onHide={() => minimize(minKey)}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
-            onShowStack={(c) => select(c.id)}
+            onShowStack={(c) => select(pickPaneVisibleId(group.comments, c.id))}
           />,
           slot,
           `thread-${slotKey}`,
@@ -240,6 +240,18 @@ export function InlineThreads({
         : null}
     </>
   );
+}
+
+/**
+ * Picks the first comment likely to be visible in the threads pane (which
+ * defaults to showing `draft` and `submitted` only). Falls back to `fallback`
+ * — usually the head — if every comment is `resolved` or `hidden`, so the
+ * inline preview still has *something* selected even when the pane filter
+ * hides the whole group.
+ */
+function pickPaneVisibleId(comments: ReviewComment[], fallback: number): number {
+  const candidate = comments.find((c) => c.state === "draft" || c.state === "submitted");
+  return candidate?.id ?? fallback;
 }
 
 function mutationIsSignificant(record: MutationRecord): boolean {

--- a/src/features/comments/components/MinimizedThreadBadge.tsx
+++ b/src/features/comments/components/MinimizedThreadBadge.tsx
@@ -14,11 +14,16 @@ interface MinimizedThreadBadgeProps {
  */
 export function MinimizedThreadBadge({ count, onExpand }: MinimizedThreadBadgeProps) {
   const { t } = useTranslation();
+  const ariaLabel =
+    count > 1
+      ? t("comments.markers.expandAriaWithCount", { count })
+      : t("comments.markers.expandAria");
   return (
     <button
       type="button"
       onClick={onExpand}
-      aria-label={t("comments.markers.expandAria")}
+      aria-label={ariaLabel}
+      title={ariaLabel}
       className={cn(
         "inline-flex h-6 items-center gap-1 rounded-full px-1.5 align-middle text-[11px] font-semibold",
         "border border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",

--- a/src/features/comments/lib/groupAnchors.test.ts
+++ b/src/features/comments/lib/groupAnchors.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import type { CommentAnchor, ReviewComment } from "@/shared/ipc/contract";
+import { groupCommentsByStartLine } from "./groupAnchors";
+
+function makeComment(
+  id: number,
+  anchor: CommentAnchor,
+  overrides: Partial<ReviewComment> = {},
+): ReviewComment {
+  return {
+    id,
+    prNumber: 1,
+    filePath: "docs/intro.md",
+    headSha: "deadbeef",
+    body: `comment ${id}`,
+    author: `user${id}`,
+    state: "draft",
+    anchor,
+    createdAt: id * 1000,
+    updatedAt: id * 1000,
+    githubId: null,
+    submitError: null,
+    ...overrides,
+  };
+}
+
+describe("groupCommentsByStartLine", () => {
+  test("buckets multiple comments on the same single line into one group", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 5 }),
+      makeComment(2, { kind: "singleLine", line: 5 }),
+      makeComment(3, { kind: "singleLine", line: 5 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.comments).toHaveLength(3);
+    expect(groups[0]?.startLine).toBe(5);
+    expect(groups[0]?.endLine).toBe(5);
+    expect(groups[0]?.attachLine).toBe(5);
+  });
+
+  test("keeps comments on different lines as distinct groups", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 5 }),
+      makeComment(2, { kind: "singleLine", line: 7 }),
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]?.startLine).toBe(5);
+    expect(groups[1]?.startLine).toBe(7);
+  });
+
+  test("treats single-line and equal-extent range as the same anchor", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 5 }),
+      makeComment(2, { kind: "lineRange", startLine: 5, endLine: 5 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.comments).toHaveLength(2);
+  });
+
+  test("separates a range from a single line that share the start line", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 10 }),
+      makeComment(2, { kind: "lineRange", startLine: 10, endLine: 14 }),
+    ]);
+    expect(groups).toHaveLength(2);
+    const lonely = groups.find((g) => g.endLine === 10);
+    const ranged = groups.find((g) => g.endLine === 14);
+    expect(lonely?.comments).toHaveLength(1);
+    expect(ranged?.comments).toHaveLength(1);
+    expect(ranged?.attachLine).toBe(14);
+  });
+
+  test("sorts comments inside a group by createdAt", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 3 }, { createdAt: 200 }),
+      makeComment(2, { kind: "singleLine", line: 3 }, { createdAt: 100 }),
+      makeComment(3, { kind: "singleLine", line: 3 }, { createdAt: 300 }),
+    ]);
+    expect(groups[0]?.comments.map((c) => c.id)).toEqual([2, 1, 3]);
+  });
+
+  test("filters out deleted comments", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 4 }, { state: "deleted" }),
+      makeComment(2, { kind: "singleLine", line: 4 }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.comments).toHaveLength(1);
+    expect(groups[0]?.comments[0]?.id).toBe(2);
+  });
+
+  test("keeps resolved and hidden comments visible in the group", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "singleLine", line: 8 }, { state: "resolved" }),
+      makeComment(2, { kind: "singleLine", line: 8 }, { state: "hidden" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.comments).toHaveLength(2);
+  });
+
+  test("sorts groups by startLine then endLine", () => {
+    const groups = groupCommentsByStartLine([
+      makeComment(1, { kind: "lineRange", startLine: 5, endLine: 9 }),
+      makeComment(2, { kind: "singleLine", line: 5 }),
+      makeComment(3, { kind: "singleLine", line: 2 }),
+    ]);
+    expect(groups.map((g) => `${g.startLine}:${g.endLine}`)).toEqual(["2:2", "5:5", "5:9"]);
+  });
+});

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -2,6 +2,7 @@ import { usePullRequestComments } from "@/features/comments/hooks/usePullRequest
 import type { CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { describeError } from "@/shared/ipc/errors";
 import { cn } from "@/shared/lib/cn";
+import { useThreadsFilter } from "@/shared/stores/useThreadsFilter";
 import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
 import { ScrollArea } from "@/shared/ui/scroll-area";
 import { useMemo, useState } from "react";
@@ -14,19 +15,13 @@ interface ThreadsPaneProps {
   filePath?: string;
 }
 
-const DEFAULT_FILTER: Record<FilterableState, boolean> = {
-  draft: true,
-  submitted: true,
-  resolved: false,
-  hidden: false,
-};
-
 type Scope = "currentFile" | "allFiles";
 
 export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
   const { t } = useTranslation();
   const query = usePullRequestComments(prNumber);
-  const [filter, setFilter] = useState<Record<FilterableState, boolean>>(DEFAULT_FILTER);
+  const filter = useThreadsFilter((s) => s.filter);
+  const toggleFilter = useThreadsFilter((s) => s.toggle);
   const [scope, setScope] = useState<Scope>("currentFile");
 
   const allComments = query.data ?? [];
@@ -66,10 +61,7 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
             allLabel={t("main.threads.allFiles")}
           />
         ) : null}
-        <ThreadFilterBar
-          enabled={filter}
-          onToggle={(s) => setFilter((prev) => ({ ...prev, [s]: !prev[s] }))}
-        />
+        <ThreadFilterBar enabled={filter} onToggle={toggleFilter} />
       </header>
       <ScrollArea className="flex-1">
         <div className="px-3 pb-4 pt-1">

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -80,7 +80,7 @@ export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(functio
                   <RelativeTime ms={c.createdAt} />
                 </div>
                 <p className="whitespace-pre-wrap text-[12px] leading-snug text-[hsl(var(--foreground))]/85">
-                  {c.body.trim()}
+                  {c.body}
                 </p>
               </li>
             ))}

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -1,5 +1,6 @@
 import type { ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AnchorLabel } from "./AnchorLabel";
 import { StateBadge } from "./StateBadge";
@@ -28,16 +29,26 @@ interface ThreadCardProps {
   onSelect: (comment: ReviewComment) => void;
 }
 
-export function ThreadCard({ group, selected, hideFilePath, onSelect }: ThreadCardProps) {
+export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(function ThreadCard(
+  { group, selected, hideFilePath, onSelect },
+  ref,
+) {
   const head = group.comments[0];
   const { t } = useTranslation();
   if (!head) return null;
-  const replyCount = group.comments.length - 1;
+  const total = group.comments.length;
+  const replyCount = total - 1;
   const isResolved = head.state === "resolved";
+  // Selecting a multi-comment group expands the card into a stacked view —
+  // each comment fully rendered, top-down. Single-comment groups stay in the
+  // compact preview shape.
+  const isStacked = selected && total > 1;
   return (
     <button
+      ref={ref}
       type="button"
       onClick={() => onSelect(head)}
+      aria-expanded={isStacked || undefined}
       className={cn(
         "flex w-full flex-col gap-2.5 rounded-lg border bg-[hsl(var(--card))] p-3 text-left text-sm transition-colors",
         "hover:border-[hsl(var(--foreground))]/30",
@@ -51,26 +62,54 @@ export function ThreadCard({ group, selected, hideFilePath, onSelect }: ThreadCa
         </span>
         <StateBadge state={head.state} className="shrink-0" />
       </div>
-      <p className="text-[12px] leading-snug text-[hsl(var(--muted-foreground))]">
-        {truncateBody(head.body)}
-      </p>
-      <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
-        <span className="truncate">{head.author ?? t("comments.thread.anonAuthor")}</span>
-        <span className="flex items-center gap-2">
-          {replyCount > 0 ? (
-            <span>
-              {t("threads.row.replyCount", {
-                count: replyCount,
-                defaultValue: replyCount === 1 ? "1 reply" : `${replyCount} replies`,
-              })}
+      {isStacked ? (
+        <>
+          <p className="text-[11px] font-medium text-[hsl(var(--muted-foreground))]">
+            {t("threads.row.stackedCount", { count: total })}
+          </p>
+          <ul className="flex flex-col gap-2">
+            {group.comments.map((c) => (
+              <li
+                key={c.id}
+                className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--background))] p-2"
+              >
+                <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+                  <span className="truncate font-semibold text-[hsl(var(--foreground))]">
+                    {c.author ?? t("comments.thread.anonAuthor")}
+                  </span>
+                  <RelativeTime ms={c.createdAt} />
+                </div>
+                <p className="whitespace-pre-wrap text-[12px] leading-snug text-[hsl(var(--foreground))]/85">
+                  {c.body.trim()}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <>
+          <p className="text-[12px] leading-snug text-[hsl(var(--muted-foreground))]">
+            {truncateBody(head.body)}
+          </p>
+          <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+            <span className="truncate">{head.author ?? t("comments.thread.anonAuthor")}</span>
+            <span className="flex items-center gap-2">
+              {replyCount > 0 ? (
+                <span>
+                  {t("threads.row.replyCount", {
+                    count: replyCount,
+                    defaultValue: replyCount === 1 ? "1 reply" : `${replyCount} replies`,
+                  })}
+                </span>
+              ) : null}
+              <RelativeTime ms={head.createdAt} />
             </span>
-          ) : null}
-          <RelativeTime ms={head.createdAt} />
-        </span>
-      </div>
+          </div>
+        </>
+      )}
     </button>
   );
-}
+});
 
 function truncateBody(body: string): string {
   const trimmed = body.trim().replace(/\s+/g, " ");

--- a/src/features/main/components/threads/ThreadFilterBar.tsx
+++ b/src/features/main/components/threads/ThreadFilterBar.tsx
@@ -1,8 +1,8 @@
-import type { CommentState } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
+import type { FilterableState } from "@/shared/stores/useThreadsFilter";
 import { useTranslation } from "react-i18next";
 
-export type FilterableState = Exclude<CommentState, "deleted">;
+export type { FilterableState };
 
 interface ThreadFilterBarProps {
   enabled: Record<FilterableState, boolean>;

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -1,7 +1,7 @@
 import type { ReviewComment } from "@/shared/ipc/contract";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { Skeleton } from "@/shared/ui/skeleton";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { scrollToAnchorLine } from "../../lib/scrollToAnchor";
 import { ThreadCard, type ThreadGroup } from "./ThreadCard";
@@ -26,6 +26,19 @@ export function ThreadList({
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
   const select = useSelectedThread((s) => s.select);
   const groups = useMemo(() => groupByAnchor(comments), [comments]);
+  const cardRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  // When the selection changes (often from clicking an inline marker in the
+  // preview), bring the matching card into view so the stacked threads are
+  // visible without manual scrolling.
+  useEffect(() => {
+    if (selectedId === null) return;
+    const match = groups.find((g) => g.comments.some((c) => c.id === selectedId));
+    if (!match) return;
+    const node = cardRefs.current.get(match.key);
+    if (!node) return;
+    node.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }, [selectedId, groups]);
 
   if (isLoading) {
     return (
@@ -52,6 +65,10 @@ export function ThreadList({
         return (
           <ThreadCard
             key={group.key}
+            ref={(node) => {
+              if (node) cardRefs.current.set(group.key, node);
+              else cardRefs.current.delete(group.key);
+            }}
             group={group}
             selected={isSelected}
             hideFilePath={hideFilePath}

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -1,7 +1,7 @@
 import type { ReviewComment } from "@/shared/ipc/contract";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { Skeleton } from "@/shared/ui/skeleton";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { scrollToAnchorLine } from "../../lib/scrollToAnchor";
 import { ThreadCard, type ThreadGroup } from "./ThreadCard";
@@ -27,17 +27,51 @@ export function ThreadList({
   const select = useSelectedThread((s) => s.select);
   const groups = useMemo(() => groupByAnchor(comments), [comments]);
   const cardRefs = useRef(new Map<string, HTMLButtonElement>());
+  // Per-key callback cache so the same group key always yields the same
+  // callback ref across renders — avoids React calling the previous ref
+  // with `null` and the new one with the node on every render of the list.
+  const refSetters = useRef(new Map<string, (node: HTMLButtonElement | null) => void>());
+  const setCardRef = useCallback((key: string) => {
+    let cb = refSetters.current.get(key);
+    if (cb) return cb;
+    cb = (node: HTMLButtonElement | null) => {
+      if (node) cardRefs.current.set(key, node);
+      else cardRefs.current.delete(key);
+    };
+    refSetters.current.set(key, cb);
+    return cb;
+  }, []);
+
+  // Prune cached ref-setters and node refs for groups that no longer exist
+  // so the maps don't grow unbounded over a long review session.
+  useEffect(() => {
+    const live = new Set(groups.map((g) => g.key));
+    for (const key of refSetters.current.keys()) {
+      if (!live.has(key)) refSetters.current.delete(key);
+    }
+    for (const key of cardRefs.current.keys()) {
+      if (!live.has(key)) cardRefs.current.delete(key);
+    }
+  }, [groups]);
 
   // When the selection changes (often from clicking an inline marker in the
   // preview), bring the matching card into view so the stacked threads are
-  // visible without manual scrolling.
+  // visible without manual scrolling. Honor `prefers-reduced-motion` so the
+  // smooth scroll only kicks in for users who haven't opted out of motion.
   useEffect(() => {
     if (selectedId === null) return;
     const match = groups.find((g) => g.comments.some((c) => c.id === selectedId));
     if (!match) return;
     const node = cardRefs.current.get(match.key);
     if (!node) return;
-    node.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    const prefersReducedMotion =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    node.scrollIntoView({
+      block: "nearest",
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+    });
   }, [selectedId, groups]);
 
   if (isLoading) {
@@ -65,10 +99,7 @@ export function ThreadList({
         return (
           <ThreadCard
             key={group.key}
-            ref={(node) => {
-              if (node) cardRefs.current.set(group.key, node);
-              else cardRefs.current.delete(group.key);
-            }}
+            ref={setCardRef(group.key)}
             group={group}
             selected={isSelected}
             hideFilePath={hideFilePath}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -110,7 +110,9 @@
       "daysAgo": "{{n}}d ago",
       "justNow": "just now",
       "replyCount_one": "{{count}} reply",
-      "replyCount_other": "{{count}} replies"
+      "replyCount_other": "{{count}} replies",
+      "stackedCount_one": "{{count}} comment on this anchor",
+      "stackedCount_other": "{{count}} comments on this anchor"
     },
     "filter": {
       "label": "Show",
@@ -142,7 +144,13 @@
       "tooltipMore_one": "{{count}} comment",
       "tooltipMore_other": "{{count}} comments",
       "selectionAria": "Add comment for selected lines",
-      "expandAria": "Expand thread"
+      "expandAria": "Expand thread",
+      "expandAriaWithCount_one": "Expand thread ({{count}} comment)",
+      "expandAriaWithCount_other": "Expand thread ({{count}} comments)",
+      "countBadgeAria_one": "{{count}} comment on this anchor",
+      "countBadgeAria_other": "{{count}} comments on this anchor",
+      "countBadgeTooltip_one": "{{count}} comment — open in panel",
+      "countBadgeTooltip_other": "{{count}} comments — open in panel"
     },
     "thread": {
       "anonAuthor": "Someone",

--- a/src/shared/stores/useThreadsFilter.ts
+++ b/src/shared/stores/useThreadsFilter.ts
@@ -1,0 +1,35 @@
+import type { CommentState } from "@/shared/ipc/contract";
+import { create } from "zustand";
+
+export type FilterableState = Exclude<CommentState, "deleted">;
+
+export const DEFAULT_THREADS_FILTER: Record<FilterableState, boolean> = {
+  draft: true,
+  submitted: true,
+  resolved: false,
+  hidden: false,
+};
+
+interface ThreadsFilterState {
+  /** Map of state → whether the threads pane currently shows it. */
+  filter: Record<FilterableState, boolean>;
+  toggle: (state: FilterableState) => void;
+  setFilter: (filter: Record<FilterableState, boolean>) => void;
+  /** Force a state into the visible set (no-op if already enabled). */
+  ensureVisible: (state: FilterableState) => void;
+}
+
+/**
+ * Cross-feature store for the threads-pane filter chips. Lifted out of the
+ * pane's local state so other features (notably the inline count badge in the
+ * markdown preview) can pick a comment that's actually visible under the
+ * current filter — and, when a hidden state is required, flip the matching
+ * chip on so the selection becomes reachable.
+ */
+export const useThreadsFilter = create<ThreadsFilterState>((set) => ({
+  filter: { ...DEFAULT_THREADS_FILTER },
+  toggle: (state) => set((s) => ({ filter: { ...s.filter, [state]: !s.filter[state] } })),
+  setFilter: (filter) => set({ filter }),
+  ensureVisible: (state) =>
+    set((s) => (s.filter[state] ? s : { filter: { ...s.filter, [state]: true } })),
+}));


### PR DESCRIPTION
Closes #21.

## Summary
- Inline count badge on the expanded `InlineThreadCard` whenever an anchor has more than one comment, sharing the styling of the existing minimized badge so the visual cue is consistent across the preview.
- Clicking the count badge selects the head comment, scrolls the matching card into view in the threads pane, and switches that card into a stacked layout that renders every comment in full (author + body + relative time) instead of the compact "head + N replies" preview.
- The minimized badge now exposes the comment count in its `aria-label` / tooltip via i18n plurals so screen readers and hover-help match what the badge visually shows.
- New i18n keys under `comments.markers.*` (`expandAriaWithCount`, `countBadgeAria`, `countBadgeTooltip`) and `threads.row.stackedCount` — no hardcoded strings.

## Test plan
- [x] `bun test` — added `groupAnchors.test.ts` (8 tests) covering single-line vs range bucketing, deleted/resolved/hidden filtering, intra-group ordering, group ordering.
- [x] `bun run check` (Biome) and `bun run typecheck` (tsc) clean.
- [x] `bun run build:web` (Vite) succeeds.
- [ ] Manual: open a Markdown PR with two or more comments anchored to the same line, expand the inline card, confirm the count chip appears, click it, and verify the right-hand pane scrolls to and expands the corresponding card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)