### PR TITLE
feat(phase-4 #22): hide, hide all, show hidden

### DIFF
--- a/src/features/comments/components/HiddenThreadMarker.tsx
+++ b/src/features/comments/components/HiddenThreadMarker.tsx
@@ -4,25 +4,30 @@ import { useTranslation } from "react-i18next";
 
 interface HiddenThreadMarkerProps {
   count: number;
-  onReveal: () => void;
+  /**
+   * Restores the thread to a non-hidden state via IPC. The caller decides the
+   * target state (`submitted` when the comment has a `githubId`, otherwise
+   * `draft`) — this component only invokes the action.
+   */
+  onUnhide: () => void;
 }
 
 /**
  * Discreet gutter marker rendered in place of the inline thread card when
- * every comment on an anchor is in the `hidden` state. Clicking it expands
- * the thread back into view via the threads pane (the caller flips the
- * `hidden` filter on and selects the head comment).
+ * every comment on an anchor is in the `hidden` state. Clicking it unhides
+ * the thread (restores it to `submitted` or `draft` depending on whether it
+ * has a remote GitHub id) so the user can see and act on it again.
  */
-export function HiddenThreadMarker({ count, onReveal }: HiddenThreadMarkerProps) {
+export function HiddenThreadMarker({ count, onUnhide }: HiddenThreadMarkerProps) {
   const { t } = useTranslation();
   const ariaLabel =
     count > 1
-      ? t("comments.markers.hiddenAriaWithCount", { count })
-      : t("comments.markers.hiddenAria");
+      ? t("comments.markers.unhideAriaWithCount", { count })
+      : t("comments.markers.unhideAria");
   return (
     <button
       type="button"
-      onClick={onReveal}
+      onClick={onUnhide}
       aria-label={ariaLabel}
       title={ariaLabel}
       className={cn(

--- a/src/features/comments/components/HiddenThreadMarker.tsx
+++ b/src/features/comments/components/HiddenThreadMarker.tsx
@@ -1,0 +1,40 @@
+import { cn } from "@/shared/lib/cn";
+import { MessageSquareOffIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface HiddenThreadMarkerProps {
+  count: number;
+  onReveal: () => void;
+}
+
+/**
+ * Discreet gutter marker rendered in place of the inline thread card when
+ * every comment on an anchor is in the `hidden` state. Clicking it expands
+ * the thread back into view via the threads pane (the caller flips the
+ * `hidden` filter on and selects the head comment).
+ */
+export function HiddenThreadMarker({ count, onReveal }: HiddenThreadMarkerProps) {
+  const { t } = useTranslation();
+  const ariaLabel =
+    count > 1
+      ? t("comments.markers.hiddenAriaWithCount", { count })
+      : t("comments.markers.hiddenAria");
+  return (
+    <button
+      type="button"
+      onClick={onReveal}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className={cn(
+        "inline-flex h-6 items-center gap-1 rounded-full px-1.5 align-middle text-[11px] font-medium",
+        "border border-[hsl(var(--comment-marker-border))] bg-transparent",
+        "text-[hsl(var(--muted-foreground))] transition-colors",
+        "hover:bg-[hsl(var(--comment-marker-hover))] hover:text-[hsl(var(--comment-marker-fg))]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+      )}
+    >
+      <MessageSquareOffIcon className="h-3 w-3" aria-hidden="true" />
+      {count > 1 ? <span aria-hidden="true">{count}</span> : null}
+    </button>
+  );
+}

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,7 +1,7 @@
 import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { CheckIcon, MessageSquareIcon, Trash2Icon } from "lucide-react";
+import { CheckIcon, EyeIcon, MessageSquareIcon, Trash2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useGhUser } from "../hooks/useGhUser";
 
@@ -11,6 +11,8 @@ interface InlineThreadCardProps {
   selected?: boolean;
   onResolve?: (comment: ReviewComment) => void;
   onHide?: (comment: ReviewComment) => void;
+  /** Restores a hidden comment back to `submitted`/`draft` via the parent. */
+  onUnhide?: (comment: ReviewComment) => void;
   onReply?: (head: ReviewComment) => void;
   onDelete?: (comment: ReviewComment) => void;
   /** Click on the count badge — opens the stacked view in the threads panel. */
@@ -87,6 +89,7 @@ export function InlineThreadCard({
   selected = false,
   onResolve,
   onHide,
+  onUnhide,
   onReply,
   onDelete,
   onShowStack,
@@ -233,7 +236,19 @@ export function InlineThreadCard({
               <span>{t("comments.thread.resolve")}</span>
             </Button>
           ) : null}
-          {!isHidden ? (
+          {isHidden ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onUnhide?.(head)}
+              aria-label={t("comments.thread.unhideAria")}
+              className="h-7 gap-1.5 rounded-md px-2.5 text-[12px] font-medium"
+            >
+              <EyeIcon className="h-3 w-3" aria-hidden="true" />
+              <span>{t("comments.thread.unhide")}</span>
+            </Button>
+          ) : (
             <Button
               type="button"
               size="sm"
@@ -242,7 +257,7 @@ export function InlineThreadCard({
             >
               {t("comments.thread.hide")}
             </Button>
-          ) : null}
+          )}
         </div>
       </div>
     </div>

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -13,6 +13,7 @@ import {
   groupCommentsByStartLine,
 } from "../lib/groupAnchors";
 import { CommentComposer } from "./CommentComposer";
+import { HiddenThreadMarker } from "./HiddenThreadMarker";
 import { InlineThreadCard } from "./InlineThreadCard";
 import { MinimizedThreadBadge } from "./MinimizedThreadBadge";
 
@@ -60,8 +61,10 @@ export function InlineThreads({
 }: InlineThreadsProps) {
   const select = useSelectedThread((s) => s.select);
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
+  // `useMinimizedThreads` still drives the multi-comment "expand stack" badge
+  // (#21). The persistent `Hide` button no longer touches this store — it
+  // updates `state = hidden` via IPC instead (see Issue #22).
   const minimizedSet = useMinimizedThreads((s) => s.minimized);
-  const minimize = useMinimizedThreads((s) => s.minimize);
   const expand = useMinimizedThreads((s) => s.expand);
   const paneFilter = useThreadsFilter((s) => s.filter);
   const ensurePaneVisible = useThreadsFilter((s) => s.ensureVisible);
@@ -116,6 +119,30 @@ export function InlineThreads({
     return out;
   }, [groups, minimizedSet, prNumber, filePath]);
 
+  // Groups whose every (non-deleted) comment is in the `hidden` state — the
+  // inline preview renders only a discreet gutter marker for these so the
+  // document content stays the focus, while the comment row itself still
+  // exists and shows up in the pane when the user enables the `hidden` chip.
+  const allHiddenSet = useMemo(() => {
+    const out = new Set<SlotKey>();
+    for (const g of groups) {
+      if (g.comments.length > 0 && g.comments.every((c) => c.state === "hidden")) {
+        out.add(slotKeyFor(g.startLine, g.endLine));
+      }
+    }
+    return out;
+  }, [groups]);
+
+  // Slot allocation collapses both cases into "render an inline badge instead
+  // of the card" — the underlying DOM machinery treats them the same. The
+  // distinction (minimized vs. all-hidden) is restored when picking which
+  // React component to portal into the badge slot.
+  const collapsedSet = useMemo(() => {
+    const out = new Set<SlotKey>(localMinimized);
+    for (const k of allHiddenSet) out.add(k);
+    return out;
+  }, [localMinimized, allHiddenSet]);
+
   // Slot map lives in a ref; we only bump `revision` when the slot identities
   // actually change so the React tree re-renders the portals minimally.
   const slotsRef = useRef<SlotMap>({
@@ -135,7 +162,7 @@ export function InlineThreads({
       container,
       slotsRef.current,
       groups,
-      localMinimized,
+      collapsedSet,
       composerStart,
       composerEnd,
       mutatingRef,
@@ -153,7 +180,7 @@ export function InlineThreads({
         });
       }
     };
-  }, [containerRef, groups, localMinimized, composerStart, composerEnd]);
+  }, [containerRef, groups, collapsedSet, composerStart, composerEnd]);
 
   // Re-sync when the rendered article DOM changes (a markdown re-render).
   useEffect(() => {
@@ -169,7 +196,7 @@ export function InlineThreads({
         container,
         slotsRef.current,
         groups,
-        localMinimized,
+        collapsedSet,
         composerStart,
         composerEnd,
         mutatingRef,
@@ -178,7 +205,7 @@ export function InlineThreads({
     });
     observer.observe(container, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, [containerRef, groups, localMinimized, composerStart, composerEnd]);
+  }, [containerRef, groups, collapsedSet, composerStart, composerEnd]);
 
   const slots = slotsRef.current;
 
@@ -188,6 +215,29 @@ export function InlineThreads({
         const slotKey = slotKeyFor(group.startLine, group.endLine);
         const minKey = minimizedKey(prNumber, filePath, group.startLine, group.endLine);
         const minimized = minimizedSet.has(minKey);
+        const allHidden = allHiddenSet.has(slotKey);
+        if (allHidden) {
+          // `Hidden` is a persistent comment state, not the session-only
+          // minimize toggle — render a discreet `MessageSquareOff` marker in
+          // the gutter instead of the full card. Clicking it flips the
+          // pane's `hidden` chip on and selects the head, so the user can
+          // unhide / reply from there.
+          const badgeSlot = slots.badges.get(slotKey);
+          if (!badgeSlot) return null;
+          return createPortal(
+            <HiddenThreadMarker
+              key={slotKey}
+              count={group.comments.length}
+              onReveal={() => {
+                ensurePaneVisible("hidden");
+                const head = group.comments[0];
+                if (head) select(head.id);
+              }}
+            />,
+            badgeSlot,
+            `thread-hidden-${slotKey}`,
+          );
+        }
         if (minimized) {
           const badgeSlot = slots.badges.get(slotKey);
           if (!badgeSlot) return null;
@@ -217,7 +267,14 @@ export function InlineThreads({
               select(c.id);
               update.mutate({ id: c.id, patch: { state: "resolved" } });
             }}
-            onHide={() => minimize(minKey)}
+            // `Hide` persists `state = hidden` via IPC so the choice survives
+            // restart and a remote refresh. The session-only `minimize` store
+            // still drives the count-badge expand UX (see #21) but it is no
+            // longer wired to this button.
+            onHide={(c) => {
+              select(c.id);
+              update.mutate({ id: c.id, patch: { state: "hidden" } });
+            }}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
             onShowStack={(c) => {

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -219,17 +219,20 @@ export function InlineThreads({
         if (allHidden) {
           // `Hidden` is a persistent comment state, not the session-only
           // minimize toggle — render a discreet `MessageSquareOff` marker in
-          // the gutter instead of the full card. Clicking it flips the
-          // pane's `hidden` chip on and selects the head, so the user can
-          // unhide / reply from there.
+          // the gutter instead of the full card. Clicking it unhides every
+          // comment in the group: rows with a `githubId` go back to
+          // `submitted`, otherwise to `draft`. The Rust transition table
+          // (`Hidden → Draft | Submitted | Resolved | Deleted`) allows both.
           const badgeSlot = slots.badges.get(slotKey);
           if (!badgeSlot) return null;
           return createPortal(
             <HiddenThreadMarker
               key={slotKey}
               count={group.comments.length}
-              onReveal={() => {
-                ensurePaneVisible("hidden");
+              onUnhide={() => {
+                for (const c of group.comments) {
+                  update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
+                }
                 const head = group.comments[0];
                 if (head) select(head.id);
               }}
@@ -275,6 +278,10 @@ export function InlineThreads({
               select(c.id);
               update.mutate({ id: c.id, patch: { state: "hidden" } });
             }}
+            onUnhide={(c) => {
+              select(c.id);
+              update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
+            }}
             onReply={(c) => select(c.id)}
             onDelete={(c) => remove.mutate(c.id)}
             onShowStack={(c) => {
@@ -308,6 +315,16 @@ export function InlineThreads({
         : null}
     </>
   );
+}
+
+/**
+ * Picks the unhide target for a comment. Submitted comments came back from
+ * the remote (have a `githubId`) so they go back to `submitted`; locally
+ * authored ones never hit GitHub yet, so they go back to `draft`. Both
+ * transitions are allowed by `CommentState::can_transition_to`.
+ */
+function targetUnhideState(comment: ReviewComment): "submitted" | "draft" {
+  return comment.githubId !== null ? "submitted" : "draft";
 }
 
 /**

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -26,7 +26,6 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
   const query = usePullRequestComments(prNumber);
   const filter = useThreadsFilter((s) => s.filter);
   const toggleFilter = useThreadsFilter((s) => s.toggle);
-  const ensureFilterVisible = useThreadsFilter((s) => s.ensureVisible);
   const [scope, setScope] = useState<Scope>("currentFile");
   const queryClient = useQueryClient();
 
@@ -51,7 +50,8 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
   // "Hide all" applies to the threads currently surfaced in the pane (under
   // the active scope + filter). Comments already `hidden`, `resolved`, or
   // `deleted` are skipped — only `draft`/`submitted` are valid sources for
-  // the `Submitted → Hidden` transition that the Rust store allows.
+  // the `Draft → Hidden` and `Submitted → Hidden` transitions that the Rust
+  // `CommentState::can_transition_to` allows.
   const hideAll = useMutation({
     mutationFn: async (ids: number[]) => {
       const results = await Promise.all(
@@ -61,7 +61,10 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
       if (failure && !failure.ok) throw failure.error;
       return results.length;
     },
-    onSuccess: () => {
+    // Use `onSettled` so partial successes still trigger a refetch — even if
+    // some IDs failed, the rows that succeeded need to be reflected in the
+    // pane.
+    onSettled: () => {
       if (prNumber !== undefined) {
         queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
         if (filePath) {
@@ -115,7 +118,7 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => ensureFilterVisible("hidden")}
+            onClick={() => toggleFilter("hidden")}
             aria-pressed={filter.hidden}
             aria-label={t("main.threads.showHiddenAria")}
             className={cn(

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -1,10 +1,14 @@
 import { usePullRequestComments } from "@/features/comments/hooks/usePullRequestComments";
+import { ipc } from "@/shared/ipc/client";
 import type { CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { describeError } from "@/shared/ipc/errors";
 import { cn } from "@/shared/lib/cn";
 import { useThreadsFilter } from "@/shared/stores/useThreadsFilter";
 import { Alert, AlertDescription, AlertTitle } from "@/shared/ui/alert";
+import { Button } from "@/shared/ui/button";
 import { ScrollArea } from "@/shared/ui/scroll-area";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { type FilterableState, ThreadFilterBar } from "./threads/ThreadFilterBar";
@@ -22,7 +26,9 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
   const query = usePullRequestComments(prNumber);
   const filter = useThreadsFilter((s) => s.filter);
   const toggleFilter = useThreadsFilter((s) => s.toggle);
+  const ensureFilterVisible = useThreadsFilter((s) => s.ensureVisible);
   const [scope, setScope] = useState<Scope>("currentFile");
+  const queryClient = useQueryClient();
 
   const allComments = query.data ?? [];
 
@@ -41,6 +47,36 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
     () => partitionByFilter(scopedComments, filter),
     [scopedComments, filter],
   );
+
+  // "Hide all" applies to the threads currently surfaced in the pane (under
+  // the active scope + filter). Comments already `hidden`, `resolved`, or
+  // `deleted` are skipped — only `draft`/`submitted` are valid sources for
+  // the `Submitted → Hidden` transition that the Rust store allows.
+  const hideAll = useMutation({
+    mutationFn: async (ids: number[]) => {
+      const results = await Promise.all(
+        ids.map((id) => ipc.comments.update(id, { state: "hidden" })),
+      );
+      const failure = results.find((r) => !r.ok);
+      if (failure && !failure.ok) throw failure.error;
+      return results.length;
+    },
+    onSuccess: () => {
+      if (prNumber !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+        if (filePath) {
+          queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber, filePath] });
+        }
+      }
+    },
+  });
+
+  const hideableIds = useMemo(
+    () => visible.filter((c) => c.state === "draft" || c.state === "submitted").map((c) => c.id),
+    [visible],
+  );
+
+  const canHideAll = !hideAll.isPending && hideableIds.length > 0;
 
   return (
     <aside className="flex h-full w-[336px] shrink-0 flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--muted))]">
@@ -62,6 +98,37 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
           />
         ) : null}
         <ThreadFilterBar enabled={filter} onToggle={toggleFilter} />
+        <div className="flex items-center gap-1.5">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={!canHideAll}
+            onClick={() => hideAll.mutate(hideableIds)}
+            aria-label={t("main.threads.hideAllAria", { count: hideableIds.length })}
+            className="h-7 flex-1 gap-1.5 px-2.5 text-[12px] font-medium"
+          >
+            <EyeOffIcon className="h-3 w-3" aria-hidden="true" />
+            <span>{t("main.threads.hideAll")}</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => ensureFilterVisible("hidden")}
+            aria-pressed={filter.hidden}
+            aria-label={t("main.threads.showHiddenAria")}
+            className={cn(
+              "h-7 flex-1 gap-1.5 px-2.5 text-[12px] font-medium",
+              filter.hidden
+                ? "border-[hsl(var(--foreground))] bg-[hsl(var(--card))] text-[hsl(var(--foreground))]"
+                : null,
+            )}
+          >
+            <EyeIcon className="h-3 w-3" aria-hidden="true" />
+            <span>{t("main.threads.showHidden")}</span>
+          </Button>
+        </div>
       </header>
       <ScrollArea className="flex-1">
         <div className="px-3 pb-4 pt-1">

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -91,7 +91,12 @@
       "empty": "No threads yet — select text in the preview to start one.",
       "errorTitle": "Couldn't load comments",
       "hiddenCount_one": "+ {{count}} hidden thread",
-      "hiddenCount_other": "+ {{count}} hidden threads"
+      "hiddenCount_other": "+ {{count}} hidden threads",
+      "hideAll": "Hide all",
+      "hideAllAria_one": "Hide all {{count}} visible thread",
+      "hideAllAria_other": "Hide all {{count}} visible threads",
+      "showHidden": "Show hidden",
+      "showHiddenAria": "Show hidden threads in this pane"
     },
     "toolbar": {
       "backToRepositoriesAria": "Back to repositories"
@@ -150,7 +155,10 @@
       "countBadgeAria_one": "{{count}} comment on this anchor",
       "countBadgeAria_other": "{{count}} comments on this anchor",
       "countBadgeTooltip_one": "{{count}} comment — open in panel",
-      "countBadgeTooltip_other": "{{count}} comments — open in panel"
+      "countBadgeTooltip_other": "{{count}} comments — open in panel",
+      "hiddenAria": "Hidden thread — show in panel",
+      "hiddenAriaWithCount_one": "{{count}} hidden comment — show in panel",
+      "hiddenAriaWithCount_other": "{{count}} hidden comments — show in panel"
     },
     "thread": {
       "anonAuthor": "Someone",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -156,9 +156,9 @@
       "countBadgeAria_other": "{{count}} comments on this anchor",
       "countBadgeTooltip_one": "{{count}} comment — open in panel",
       "countBadgeTooltip_other": "{{count}} comments — open in panel",
-      "hiddenAria": "Hidden thread — show in panel",
-      "hiddenAriaWithCount_one": "{{count}} hidden comment — show in panel",
-      "hiddenAriaWithCount_other": "{{count}} hidden comments — show in panel"
+      "unhideAria": "Unhide thread",
+      "unhideAriaWithCount_one": "Unhide {{count}} comment",
+      "unhideAriaWithCount_other": "Unhide {{count}} comments"
     },
     "thread": {
       "anonAuthor": "Someone",
@@ -166,6 +166,8 @@
       "metaRange": "{{author}} on lines {{start}}–{{end}}",
       "reply": "Reply",
       "hide": "Hide",
+      "unhide": "Unhide",
+      "unhideAria": "Restore this hidden thread",
       "resolve": "Resolve",
       "delete": "Delete",
       "deleteAria": "Delete this comment",

--- a/src/shared/stores/useThreadsFilter.ts
+++ b/src/shared/stores/useThreadsFilter.ts
@@ -1,5 +1,6 @@
 import type { CommentState } from "@/shared/ipc/contract";
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 export type FilterableState = Exclude<CommentState, "deleted">;
 
@@ -19,17 +20,41 @@ interface ThreadsFilterState {
   ensureVisible: (state: FilterableState) => void;
 }
 
+const STORAGE_KEY = "markdown-reviewer:threads-filter";
+
 /**
  * Cross-feature store for the threads-pane filter chips. Lifted out of the
  * pane's local state so other features (notably the inline count badge in the
  * markdown preview) can pick a comment that's actually visible under the
  * current filter — and, when a hidden state is required, flip the matching
  * chip on so the selection becomes reachable.
+ *
+ * TODO(phase-4 #22): persist via the Rust `ui_state` store once that adapter
+ * lands. Keeping it in `localStorage` for now keeps this PR frontend-only.
  */
-export const useThreadsFilter = create<ThreadsFilterState>((set) => ({
-  filter: { ...DEFAULT_THREADS_FILTER },
-  toggle: (state) => set((s) => ({ filter: { ...s.filter, [state]: !s.filter[state] } })),
-  setFilter: (filter) => set({ filter }),
-  ensureVisible: (state) =>
-    set((s) => (s.filter[state] ? s : { filter: { ...s.filter, [state]: true } })),
-}));
+export const useThreadsFilter = create<ThreadsFilterState>()(
+  persist(
+    (set) => ({
+      filter: { ...DEFAULT_THREADS_FILTER },
+      toggle: (state) => set((s) => ({ filter: { ...s.filter, [state]: !s.filter[state] } })),
+      setFilter: (filter) => set({ filter }),
+      ensureVisible: (state) =>
+        set((s) => (s.filter[state] ? s : { filter: { ...s.filter, [state]: true } })),
+    }),
+    {
+      name: STORAGE_KEY,
+      // Only persist the filter map; methods are reconstructed at boot.
+      partialize: (s) => ({ filter: s.filter }),
+      // Defensive merge in case a future revision adds a new `CommentState`
+      // — fall back to the default for any missing key so the chip never
+      // becomes `undefined` (which would break the truthy check above).
+      merge: (persisted, current) => {
+        const stored = (persisted as Partial<ThreadsFilterState> | undefined)?.filter;
+        return {
+          ...current,
+          filter: { ...DEFAULT_THREADS_FILTER, ...(stored ?? {}) },
+        };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- Per-comment **Hide** now persists the comment's `state` to `hidden` via the existing `comments.update` IPC instead of the session-only `useMinimizedThreads` store, so it survives restart and a remote refresh. The minimize store is kept for the Phase 4 #21 stacked-thread expand UX.
- Threads pane gains **Hide all** and **Show hidden** controls. *Hide all* hides every currently-visible `draft`/`submitted` thread under the active scope (current file vs. all files) + filter. *Show hidden* flips the existing `hidden` filter chip on via `ensureVisible`.
- A discreet `MessageSquareOff` marker now renders in the gutter of the anchored line(s) when **every** comment at that anchor is `hidden` — the inline card is replaced with the marker. Clicking the marker enables the `hidden` chip and selects the head, so the user can unhide / reply from the pane.

## Deviation from the issue brief
The acceptance criteria call for the **Show hidden** preference to live in the SQLite `ui_state` table. The Rust port/store for that table hasn't been wired yet, so this PR persists the entire `useThreadsFilter` slice via `zustand/middleware`'s `persist` to `localStorage`. A `TODO(phase-4 #22)` comment in `useThreadsFilter.ts` notes the migration path. The PR stays frontend-only as requested.

## Test plan
- [ ] Open a PR, comment on a line, click **Hide** on the inline card → card disappears and a small `MessageSquareOff` icon appears in the gutter on that line. Restart the app → still hidden.
- [ ] Click the gutter marker → the `Hidden` chip in the threads pane toggles on; the thread becomes selected and visible in the pane.
- [ ] With several open threads in the pane, click **Hide all** → every visible draft/submitted thread becomes hidden; the gutter shows a marker on each line; the pane shows a `+ N hidden threads` footer.
- [ ] Toggle **Show hidden** → hidden threads reappear in the pane. Toggle off again → they collapse back.
- [ ] Reload the app → the `Show hidden` toggle preserves its previous value (currently via `localStorage`).
- [ ] `bun run check:fix`, `bun run typecheck`, and `bun test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #22