### PR TITLE
feat(phase-4 #23): collapse resolved threads + reopen

### DIFF
--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,7 +1,7 @@
 import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
-import { CheckIcon, EyeIcon, MessageSquareIcon, Trash2Icon } from "lucide-react";
+import { CheckIcon, EyeIcon, MessageSquareIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useGhUser } from "../hooks/useGhUser";
 
@@ -10,6 +10,7 @@ interface InlineThreadCardProps {
   /** When true, the thread is the currently selected one (clicked in pane). */
   selected?: boolean;
   onResolve?: (comment: ReviewComment) => void;
+  onReopen?: (comment: ReviewComment) => void;
   onHide?: (comment: ReviewComment) => void;
   /** Restores a hidden comment back to `submitted`/`draft` via the parent. */
   onUnhide?: (comment: ReviewComment) => void;
@@ -88,6 +89,7 @@ export function InlineThreadCard({
   comments,
   selected = false,
   onResolve,
+  onReopen,
   onHide,
   onUnhide,
   onReply,
@@ -220,7 +222,23 @@ export function InlineThreadCard({
           {t("comments.thread.reply")}
         </button>
         <div className="flex items-center gap-2">
-          {!isResolved ? (
+          {isResolved ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onReopen?.(head)}
+              aria-label={t("comments.thread.reopenAria")}
+              className={cn(
+                "h-7 gap-1.5 rounded-md border-[hsl(var(--border))] bg-transparent",
+                "px-2.5 text-[12px] font-medium text-[hsl(var(--foreground))]",
+                "hover:bg-[hsl(var(--accent))]",
+              )}
+            >
+              <RotateCcwIcon className="h-3 w-3" aria-hidden="true" />
+              <span>{t("comments.thread.reopen")}</span>
+            </Button>
+          ) : (
             <Button
               type="button"
               variant="outline"
@@ -235,7 +253,7 @@ export function InlineThreadCard({
               <CheckIcon className="h-3 w-3" aria-hidden="true" />
               <span>{t("comments.thread.resolve")}</span>
             </Button>
-          ) : null}
+          )}
           {isHidden ? (
             <Button
               type="button"

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -4,7 +4,7 @@ import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedT
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { type FilterableState, useThreadsFilter } from "@/shared/stores/useThreadsFilter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   type CommentGroup,
@@ -16,6 +16,7 @@ import { CommentComposer } from "./CommentComposer";
 import { HiddenThreadMarker } from "./HiddenThreadMarker";
 import { InlineThreadCard } from "./InlineThreadCard";
 import { MinimizedThreadBadge } from "./MinimizedThreadBadge";
+import { ResolvedThreadMarker } from "./ResolvedThreadMarker";
 
 interface InlineThreadsProps {
   prNumber: number;
@@ -133,15 +134,37 @@ export function InlineThreads({
     return out;
   }, [groups]);
 
-  // Slot allocation collapses both cases into "render an inline badge instead
-  // of the card" — the underlying DOM machinery treats them the same. The
-  // distinction (minimized vs. all-hidden) is restored when picking which
-  // React component to portal into the badge slot.
+  // Resolved threads also collapse to a (different, more muted) gutter marker
+  // — but only when the thread isn't the currently selected one. Clicking the
+  // marker selects the head, which flips this set and re-mounts the full card.
+  // Hidden takes precedence over resolved if both somehow apply (e.g. mixed
+  // states won't reach here, but a fully-hidden thread that was previously
+  // resolved should still render as Hidden, not Resolved).
+  const resolvedCollapsed = useMemo(() => {
+    const out = new Set<SlotKey>();
+    for (const g of groups) {
+      const slotKey = slotKeyFor(g.startLine, g.endLine);
+      if (allHiddenSet.has(slotKey)) continue;
+      const allResolved = g.comments.every((c) => c.state === "resolved");
+      if (!allResolved) continue;
+      const isSelected = g.comments.some((c) => c.id === selectedId);
+      if (isSelected) continue;
+      out.add(slotKey);
+    }
+    return out;
+  }, [groups, allHiddenSet, selectedId]);
+
+  // Slot allocation collapses every "show a badge instead of the card" case
+  // (minimized, all-hidden, all-resolved-and-unselected) into one set — the
+  // underlying DOM machinery treats them the same. The distinction is
+  // restored when picking which React component to portal into the badge
+  // slot below.
   const collapsedSet = useMemo(() => {
     const out = new Set<SlotKey>(localMinimized);
     for (const k of allHiddenSet) out.add(k);
+    for (const k of resolvedCollapsed) out.add(k);
     return out;
-  }, [localMinimized, allHiddenSet]);
+  }, [localMinimized, allHiddenSet, resolvedCollapsed]);
 
   // Slot map lives in a ref; we only bump `revision` when the slot identities
   // actually change so the React tree re-renders the portals minimally.
@@ -155,6 +178,36 @@ export function InlineThreads({
   // injections (so the MutationObserver below ignores it).
   const mutatingRef = useRef(false);
 
+  // One-shot highlight ring on the line(s) of a thread the user just expanded
+  // from its resolved gutter marker. Cleared after ~1.5s so the document goes
+  // back to its normal look. `prefers-reduced-motion` is honored in the
+  // companion CSS rule (the keyframe is suppressed there).
+  const [flashKey, setFlashKey] = useState<SlotKey | null>(null);
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerFlash = useCallback((key: SlotKey) => {
+    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    setFlashKey(key);
+    flashTimeoutRef.current = setTimeout(() => {
+      setFlashKey(null);
+      flashTimeoutRef.current = null;
+    }, 1500);
+  }, []);
+  useEffect(
+    () => () => {
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    },
+    [],
+  );
+
+  // Translate the flash slot key back into a (start, end) range for syncSlots
+  // to stamp on the right line nodes.
+  const flashRange = useMemo<{ start: number; end: number } | null>(() => {
+    if (!flashKey) return null;
+    const match = groups.find((g) => slotKeyFor(g.startLine, g.endLine) === flashKey);
+    if (!match) return null;
+    return { start: match.startLine, end: match.endLine };
+  }, [flashKey, groups]);
+
   useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -165,22 +218,41 @@ export function InlineThreads({
       collapsedSet,
       composerStart,
       composerEnd,
+      flashRange,
       mutatingRef,
     );
     if (changed) setRevision((r) => r + 1);
+    // NOTE: do NOT tear down all slots here on dep change. `syncSlots` is
+    // already incremental — when a single anchor flips from card to badge
+    // (or vice versa) it only mutates that one anchor's slots, leaving
+    // every other slot (including the draft `CommentComposer` slot) in
+    // place. A destructive cleanup on every render would unmount the
+    // composer's portal target whenever the user clicks a resolved thread
+    // marker (or any selection change that toggles `collapsedSet`),
+    // wiping the unsaved body text in `CommentComposer`'s local state.
+    // Final teardown lives in the unmount-only effect below.
+  }, [containerRef, groups, collapsedSet, composerStart, composerEnd, flashRange]);
+
+  // One-shot cleanup, tied only to the `containerRef`. React invokes this
+  // cleanup when the article element is swapped (different file rendered)
+  // or when `InlineThreads` itself unmounts — never on a routine state
+  // change. Keeps the slot DOM stable across selection / collapse flips
+  // so portals (and the composer's local body state) survive.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
     return () => {
       mutatingRef.current = true;
       try {
         removeAllSlots(container);
         slotsRef.current = { threads: new Map(), badges: new Map(), composerSlot: null };
       } finally {
-        // Allow the observer to see post-cleanup state.
         queueMicrotask(() => {
           mutatingRef.current = false;
         });
       }
     };
-  }, [containerRef, groups, collapsedSet, composerStart, composerEnd]);
+  }, [containerRef]);
 
   // Re-sync when the rendered article DOM changes (a markdown re-render).
   useEffect(() => {
@@ -199,13 +271,14 @@ export function InlineThreads({
         collapsedSet,
         composerStart,
         composerEnd,
+        flashRange,
         mutatingRef,
       );
       if (changed) setRevision((r) => r + 1);
     });
     observer.observe(container, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, [containerRef, groups, collapsedSet, composerStart, composerEnd]);
+  }, [containerRef, groups, collapsedSet, composerStart, composerEnd, flashRange]);
 
   const slots = slotsRef.current;
 
@@ -241,6 +314,10 @@ export function InlineThreads({
             `thread-hidden-${slotKey}`,
           );
         }
+        // `resolvedCollapsed` already excludes anchors that are all-hidden, so
+        // checking the set is enough — no need to recompute from the group.
+        const isSelected = group.comments.some((c) => c.id === selectedId);
+        const isResolvedCollapsed = resolvedCollapsed.has(slotKey);
         if (minimized) {
           const badgeSlot = slots.badges.get(slotKey);
           if (!badgeSlot) return null;
@@ -258,9 +335,25 @@ export function InlineThreads({
             `thread-badge-${slotKey}`,
           );
         }
+        if (isResolvedCollapsed) {
+          const badgeSlot = slots.badges.get(slotKey);
+          if (!badgeSlot) return null;
+          return createPortal(
+            <ResolvedThreadMarker
+              key={slotKey}
+              count={group.comments.length}
+              onExpand={() => {
+                const head = group.comments[0];
+                if (head) select(head.id);
+                triggerFlash(slotKey);
+              }}
+            />,
+            badgeSlot,
+            `thread-resolved-marker-${slotKey}`,
+          );
+        }
         const slot = slots.threads.get(slotKey);
         if (!slot) return null;
-        const isSelected = group.comments.some((c) => c.id === selectedId);
         return createPortal(
           <InlineThreadCard
             key={slotKey}
@@ -269,6 +362,10 @@ export function InlineThreads({
             onResolve={(c) => {
               select(c.id);
               update.mutate({ id: c.id, patch: { state: "resolved" } });
+            }}
+            onReopen={(c) => {
+              select(c.id);
+              update.mutate({ id: c.id, patch: { state: "submitted" } });
             }}
             // `Hide` persists `state = hidden` via IPC so the choice survives
             // restart and a remote refresh. The session-only `minimize` store
@@ -374,14 +471,20 @@ function mutationIsSignificant(record: MutationRecord): boolean {
  * Reconciles the DOM slots under each commented line and the optional draft
  * composer slot. Mutates the article in place. Returns `true` when the slot
  * identity map changed (callers re-render to update portal targets).
+ *
+ * `collapsed` covers both user-minimized threads (Hide) and resolved threads
+ * that are auto-collapsed to the gutter marker. The DOM treats them
+ * identically — a single badge slot under the anchor line — and only the
+ * React portal layer differentiates the two visuals.
  */
 function syncSlots(
   container: HTMLElement,
   current: SlotMap,
   groups: CommentGroup[],
-  minimized: Set<SlotKey>,
+  collapsed: Set<SlotKey>,
   composerStart: number | null,
   composerEnd: number | null,
+  flashRange: { start: number; end: number } | null,
   mutatingRef: { current: boolean },
 ): boolean {
   mutatingRef.current = true;
@@ -402,13 +505,13 @@ function syncSlots(
     }
     splitCodeBlocks(container, wantedLines);
 
-    // A group needs a card slot ONLY when it isn't minimized; otherwise it
+    // A group needs a card slot ONLY when it isn't collapsed; otherwise it
     // needs a badge slot inside the line element.
     const wantsCard = new Set<SlotKey>();
     const wantsBadge = new Set<SlotKey>();
     for (const g of groups) {
       const key = slotKeyFor(g.startLine, g.endLine);
-      if (minimized.has(key)) wantsBadge.add(key);
+      if (collapsed.has(key)) wantsBadge.add(key);
       else wantsCard.add(key);
     }
 
@@ -453,6 +556,12 @@ function syncSlots(
     for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
       delete n.dataset.commentMinimized;
     }
+    for (const n of container.querySelectorAll<HTMLElement>("[data-comment-resolved]")) {
+      delete n.dataset.commentResolved;
+    }
+    for (const n of container.querySelectorAll<HTMLElement>("[data-comment-flash]")) {
+      delete n.dataset.commentFlash;
+    }
 
     // 4. Insert missing slots and tag every commented line in the range.
     //    Card slot mounts AFTER `attachLine` (== endLine) so the expanded
@@ -460,11 +569,12 @@ function syncSlots(
     //    `attachLine` as a trailing inline element on that line.
     for (const group of groups) {
       const key = slotKeyFor(group.startLine, group.endLine);
-      const isMinimized = minimized.has(key);
-      markRange(lineNodes, group.startLine, group.endLine, isMinimized);
+      const isCollapsed = collapsed.has(key);
+      const allResolved = group.comments.every((c) => c.state === "resolved");
+      markRange(lineNodes, group.startLine, group.endLine, isCollapsed, allResolved);
       const anchor = lineNodes.get(group.attachLine);
       if (!anchor) continue;
-      if (isMinimized) {
+      if (isCollapsed) {
         if (current.badges.has(key)) continue;
         const badge = document.createElement("span");
         badge.dataset.threadBadge = "true";
@@ -484,9 +594,19 @@ function syncSlots(
       }
     }
 
+    // 4b. Stamp the temporary flash attribute so the CSS animation paints
+    //     the highlight ring on the user's freshly-expanded thread.
+    if (flashRange) {
+      for (let line = flashRange.start; line <= flashRange.end; line++) {
+        const el = lineNodes.get(line);
+        if (!el) continue;
+        el.dataset.commentFlash = "true";
+      }
+    }
+
     // 5. Insert the composer slot if needed.
     if (composerStart !== null && composerEnd !== null) {
-      markRange(lineNodes, composerStart, composerEnd, false);
+      markRange(lineNodes, composerStart, composerEnd, false, false);
       if (!current.composerSlot) {
         const anchor = lineNodes.get(composerEnd);
         if (anchor?.parentNode) {
@@ -510,20 +630,24 @@ function syncSlots(
 
 /**
  * Tags every line in `[start, end]` that has a rendered DOM element. When
- * `minimized` is true, also stamps `data-comment-minimized="true"` so the
- * highlight CSS can render a softer background.
+ * `collapsed` is true, also stamps `data-comment-minimized="true"` so the
+ * highlight CSS can render a softer background. `resolved` adds an extra
+ * `data-comment-resolved="true"` flag so the CSS can mute the strip even
+ * further for resolved threads regardless of why they collapsed.
  */
 function markRange(
   lineNodes: Map<number, HTMLElement>,
   start: number,
   end: number,
-  minimized: boolean,
+  collapsed: boolean,
+  resolved: boolean,
 ) {
   for (let line = start; line <= end; line++) {
     const el = lineNodes.get(line);
     if (!el) continue;
     el.dataset.hasComment = "true";
-    if (minimized) el.dataset.commentMinimized = "true";
+    if (collapsed) el.dataset.commentMinimized = "true";
+    if (resolved) el.dataset.commentResolved = "true";
   }
 }
 
@@ -539,6 +663,12 @@ function removeAllSlots(container: HTMLElement) {
   }
   for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
     delete n.dataset.commentMinimized;
+  }
+  for (const n of container.querySelectorAll<HTMLElement>("[data-comment-resolved]")) {
+    delete n.dataset.commentResolved;
+  }
+  for (const n of container.querySelectorAll<HTMLElement>("[data-comment-flash]")) {
+    delete n.dataset.commentFlash;
   }
 }
 

--- a/src/features/comments/components/ResolvedThreadMarker.tsx
+++ b/src/features/comments/components/ResolvedThreadMarker.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/shared/lib/cn";
+import { CheckIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface ResolvedThreadMarkerProps {
+  count: number;
+  onExpand: () => void;
+}
+
+/**
+ * Subtle gutter marker rendered at the end of a resolved thread's anchor
+ * line in place of the full inline card. Clicking it expands the thread
+ * and triggers a temporary highlight on the anchor line(s).
+ *
+ * Visually distinct from `MinimizedThreadBadge` (resolved threads use a
+ * check glyph + muted palette so they read as "settled" rather than "open
+ * but hidden").
+ */
+export function ResolvedThreadMarker({ count, onExpand }: ResolvedThreadMarkerProps) {
+  const { t } = useTranslation();
+  const ariaLabel =
+    count > 1
+      ? t("comments.markers.resolvedAriaWithCount", { count })
+      : t("comments.markers.resolvedAria");
+  return (
+    <button
+      type="button"
+      onClick={onExpand}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className={cn(
+        "inline-flex h-5 items-center gap-1 rounded-full px-1.5 align-middle text-[10px] font-medium",
+        "border border-[hsl(var(--border))] bg-transparent",
+        "text-[hsl(var(--muted-foreground))] transition-colors",
+        "hover:border-[hsl(var(--comment-marker-border))] hover:bg-[hsl(var(--comment-marker-hover))] hover:text-[hsl(var(--comment-marker-fg))]",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+      )}
+    >
+      <CheckIcon className="h-3 w-3" aria-hidden="true" />
+      {count > 1 ? <span aria-hidden="true">{count}</span> : null}
+    </button>
+  );
+}

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -152,6 +152,7 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
               isLoading={query.isLoading}
               hideFilePath={effectiveScope === "currentFile"}
               hiddenCount={hiddenCount}
+              prNumber={prNumber}
               currentFilePath={filePath}
             />
           )}

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -1,5 +1,6 @@
 import type { ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
+import { RotateCcwIcon } from "lucide-react";
 import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AnchorLabel } from "./AnchorLabel";
@@ -27,10 +28,15 @@ interface ThreadCardProps {
   /** When true, the card is showing comments from a single file context. */
   hideFilePath: boolean;
   onSelect: (comment: ReviewComment) => void;
+  /**
+   * Optional `Reopen` action — surfaced when the row's head is `resolved` so
+   * the user can flip it back without leaving the threads pane.
+   */
+  onReopen?: (comment: ReviewComment) => void;
 }
 
-export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(function ThreadCard(
-  { group, selected, hideFilePath, onSelect },
+export const ThreadCard = forwardRef<HTMLDivElement, ThreadCardProps>(function ThreadCard(
+  { group, selected, hideFilePath, onSelect, onReopen },
   ref,
 ) {
   const head = group.comments[0];
@@ -43,71 +49,98 @@ export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(functio
   // each comment fully rendered, top-down. Single-comment groups stay in the
   // compact preview shape.
   const isStacked = selected && total > 1;
+  // The row click target is a `<button>`, but resolved threads also surface a
+  // `Reopen` action — `<button>` can't legally nest another `<button>`, so we
+  // wrap the row in a positioned `<div>` and stack the action on top.
   return (
-    <button
-      ref={ref}
-      type="button"
-      onClick={() => onSelect(head)}
-      aria-expanded={isStacked || undefined}
-      className={cn(
-        "flex w-full flex-col gap-2.5 rounded-lg border bg-[hsl(var(--card))] p-3 text-left text-sm transition-colors",
-        "hover:border-[hsl(var(--foreground))]/30",
-        selected ? "border-[hsl(var(--foreground))]/40 shadow-sm" : "border-[hsl(var(--border))]",
-        isResolved ? "opacity-70" : null,
-      )}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[hsl(var(--foreground))]">
-          <AnchorLabel filePath={group.filePath} anchor={head.anchor} lineOnly={hideFilePath} />
-        </span>
-        <StateBadge state={head.state} className="shrink-0" />
-      </div>
-      {isStacked ? (
-        <>
-          <p className="text-[11px] font-medium text-[hsl(var(--muted-foreground))]">
-            {t("threads.row.stackedCount", { count: total })}
-          </p>
-          <ul className="flex flex-col gap-2">
-            {group.comments.map((c) => (
-              <li
-                key={c.id}
-                className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--background))] p-2"
-              >
-                <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
-                  <span className="truncate font-semibold text-[hsl(var(--foreground))]">
-                    {c.author ?? t("comments.thread.anonAuthor")}
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => onSelect(head)}
+        aria-expanded={isStacked || undefined}
+        className={cn(
+          "flex w-full flex-col gap-2.5 rounded-lg border bg-[hsl(var(--card))] p-3 text-left text-sm transition-colors",
+          "hover:border-[hsl(var(--foreground))]/30",
+          selected ? "border-[hsl(var(--foreground))]/40 shadow-sm" : "border-[hsl(var(--border))]",
+          isResolved ? "opacity-70" : null,
+        )}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-[hsl(var(--foreground))]">
+            <AnchorLabel filePath={group.filePath} anchor={head.anchor} lineOnly={hideFilePath} />
+          </span>
+          <StateBadge state={head.state} className="shrink-0" />
+        </div>
+        {isStacked ? (
+          <>
+            <p className="text-[11px] font-medium text-[hsl(var(--muted-foreground))]">
+              {t("threads.row.stackedCount", { count: total })}
+            </p>
+            <ul className="flex flex-col gap-2">
+              {group.comments.map((c) => (
+                <li
+                  key={c.id}
+                  className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--background))] p-2"
+                >
+                  <div className="mb-1 flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+                    <span className="truncate font-semibold text-[hsl(var(--foreground))]">
+                      {c.author ?? t("comments.thread.anonAuthor")}
+                    </span>
+                    <RelativeTime ms={c.createdAt} />
+                  </div>
+                  <p className="whitespace-pre-wrap text-[12px] leading-snug text-[hsl(var(--foreground))]/85">
+                    {c.body}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <>
+            <p className="text-[12px] leading-snug text-[hsl(var(--muted-foreground))]">
+              {truncateBody(head.body)}
+            </p>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+              <span className="truncate">{head.author ?? t("comments.thread.anonAuthor")}</span>
+              <span className="flex items-center gap-2">
+                {replyCount > 0 ? (
+                  <span>
+                    {t("threads.row.replyCount", {
+                      count: replyCount,
+                      defaultValue: replyCount === 1 ? "1 reply" : `${replyCount} replies`,
+                    })}
                   </span>
-                  <RelativeTime ms={c.createdAt} />
-                </div>
-                <p className="whitespace-pre-wrap text-[12px] leading-snug text-[hsl(var(--foreground))]/85">
-                  {c.body}
-                </p>
-              </li>
-            ))}
-          </ul>
-        </>
-      ) : (
-        <>
-          <p className="text-[12px] leading-snug text-[hsl(var(--muted-foreground))]">
-            {truncateBody(head.body)}
-          </p>
-          <div className="flex items-center justify-between gap-2 text-[11px] text-[hsl(var(--muted-foreground))]">
-            <span className="truncate">{head.author ?? t("comments.thread.anonAuthor")}</span>
-            <span className="flex items-center gap-2">
-              {replyCount > 0 ? (
-                <span>
-                  {t("threads.row.replyCount", {
-                    count: replyCount,
-                    defaultValue: replyCount === 1 ? "1 reply" : `${replyCount} replies`,
-                  })}
-                </span>
-              ) : null}
-              <RelativeTime ms={head.createdAt} />
-            </span>
-          </div>
-        </>
-      )}
-    </button>
+                ) : null}
+                <RelativeTime ms={head.createdAt} />
+              </span>
+            </div>
+          </>
+        )}
+        {/* Spacer so the absolutely-positioned Reopen action never overlaps
+            the row's text on small thread previews. */}
+        {isResolved && onReopen ? <div className="h-7" aria-hidden="true" /> : null}
+      </button>
+      {isResolved && onReopen ? (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onReopen(head);
+          }}
+          aria-label={t("comments.thread.reopenAria")}
+          className={cn(
+            "absolute right-3 bottom-3 inline-flex h-7 items-center gap-1.5 rounded-md",
+            "border border-[hsl(var(--border))] bg-[hsl(var(--card))]",
+            "px-2.5 text-[11px] font-medium text-[hsl(var(--foreground))]",
+            "transition-colors hover:bg-[hsl(var(--accent))]",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+          )}
+        >
+          <RotateCcwIcon className="h-3 w-3" aria-hidden="true" />
+          <span>{t("comments.thread.reopen")}</span>
+        </button>
+      ) : null}
+    </div>
   );
 });
 

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -1,6 +1,8 @@
-import type { ReviewComment } from "@/shared/ipc/contract";
+import { ipc } from "@/shared/ipc/client";
+import type { CommentUpdate, ReviewComment } from "@/shared/ipc/contract";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { Skeleton } from "@/shared/ui/skeleton";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { scrollToAnchorLine } from "../../lib/scrollToAnchor";
@@ -11,6 +13,8 @@ interface ThreadListProps {
   isLoading: boolean;
   hideFilePath: boolean;
   hiddenCount: number;
+  /** PR number, used to invalidate the comments queries after a Reopen. */
+  prNumber?: number;
   /** File path of the currently open preview, when one is selected. */
   currentFilePath?: string;
 }
@@ -20,27 +24,54 @@ export function ThreadList({
   isLoading,
   hideFilePath,
   hiddenCount,
+  prNumber,
   currentFilePath,
 }: ThreadListProps) {
   const { t } = useTranslation();
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
   const select = useSelectedThread((s) => s.select);
+  const queryClient = useQueryClient();
   const groups = useMemo(() => groupByAnchor(comments), [comments]);
-  const cardRefs = useRef(new Map<string, HTMLButtonElement>());
+  const cardRefs = useRef(new Map<string, HTMLDivElement>());
   // Per-key callback cache so the same group key always yields the same
   // callback ref across renders — avoids React calling the previous ref
   // with `null` and the new one with the node on every render of the list.
-  const refSetters = useRef(new Map<string, (node: HTMLButtonElement | null) => void>());
+  const refSetters = useRef(new Map<string, (node: HTMLDivElement | null) => void>());
   const setCardRef = useCallback((key: string) => {
     let cb = refSetters.current.get(key);
     if (cb) return cb;
-    cb = (node: HTMLButtonElement | null) => {
+    cb = (node: HTMLDivElement | null) => {
       if (node) cardRefs.current.set(key, node);
       else cardRefs.current.delete(key);
     };
     refSetters.current.set(key, cb);
     return cb;
   }, []);
+
+  // `Reopen` flips a `resolved` comment back to `submitted` via the same
+  // command the inline card uses. Lives here (not in ThreadCard) so we can
+  // share the React Query mutation + cache invalidation with the rest of
+  // the comments feature.
+  const reopen = useMutation({
+    mutationFn: ({ id, patch }: { id: number; patch: CommentUpdate }) =>
+      ipc.comments.update(id, patch).then((r) => {
+        if (!r.ok) throw r.error;
+        return r.value;
+      }),
+    onSuccess: (_data, vars) => {
+      if (prNumber !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      }
+      // Always refresh the per-file slice — the comment carries its own
+      // `filePath`, so we can target the exact list it belongs to.
+      const target = comments.find((c) => c.id === vars.id);
+      if (target && prNumber !== undefined) {
+        queryClient.invalidateQueries({
+          queryKey: ["local-comments", prNumber, target.filePath],
+        });
+      }
+    },
+  });
 
   // Prune cached ref-setters and node refs for groups that no longer exist
   // so the maps don't grow unbounded over a long review session.
@@ -112,6 +143,14 @@ export function ThreadList({
                 scrollToAnchorLine(getAnchorScrollLine(comment));
               }
             }}
+            onReopen={
+              prNumber !== undefined
+                ? (comment) => {
+                    select(comment.id);
+                    reopen.mutate({ id: comment.id, patch: { state: "submitted" } });
+                  }
+                : undefined
+            }
           />
         );
       })}

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -52,24 +52,25 @@ export function ThreadList({
   // command the inline card uses. Lives here (not in ThreadCard) so we can
   // share the React Query mutation + cache invalidation with the rest of
   // the comments feature.
+  //
+  // The mutation variables carry `filePath` so the per-file query
+  // invalidation uses the value captured at call time. Looking it up via
+  // `comments.find(...)` would race the user changing scope/filter while
+  // the mutation is in flight — by the time `onSuccess` runs, the
+  // reopened row may no longer be in `comments`, and the per-file slice
+  // would silently miss its refresh.
   const reopen = useMutation({
-    mutationFn: ({ id, patch }: { id: number; patch: CommentUpdate }) =>
+    mutationFn: ({ id, patch }: { id: number; patch: CommentUpdate; filePath: string }) =>
       ipc.comments.update(id, patch).then((r) => {
         if (!r.ok) throw r.error;
         return r.value;
       }),
     onSuccess: (_data, vars) => {
-      if (prNumber !== undefined) {
-        queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
-      }
-      // Always refresh the per-file slice — the comment carries its own
-      // `filePath`, so we can target the exact list it belongs to.
-      const target = comments.find((c) => c.id === vars.id);
-      if (target && prNumber !== undefined) {
-        queryClient.invalidateQueries({
-          queryKey: ["local-comments", prNumber, target.filePath],
-        });
-      }
+      if (prNumber === undefined) return;
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      queryClient.invalidateQueries({
+        queryKey: ["local-comments", prNumber, vars.filePath],
+      });
     },
   });
 
@@ -147,7 +148,11 @@ export function ThreadList({
               prNumber !== undefined
                 ? (comment) => {
                     select(comment.id);
-                    reopen.mutate({ id: comment.id, patch: { state: "submitted" } });
+                    reopen.mutate({
+                      id: comment.id,
+                      patch: { state: "submitted" },
+                      filePath: comment.filePath,
+                    });
                   }
                 : undefined
             }

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -158,7 +158,10 @@
       "countBadgeTooltip_other": "{{count}} comments — open in panel",
       "unhideAria": "Unhide thread",
       "unhideAriaWithCount_one": "Unhide {{count}} comment",
-      "unhideAriaWithCount_other": "Unhide {{count}} comments"
+      "unhideAriaWithCount_other": "Unhide {{count}} comments",
+      "resolvedAria": "Expand resolved thread",
+      "resolvedAriaWithCount_one": "Expand resolved thread ({{count}} comment)",
+      "resolvedAriaWithCount_other": "Expand resolved thread ({{count}} comments)"
     },
     "thread": {
       "anonAuthor": "Someone",
@@ -169,6 +172,8 @@
       "unhide": "Unhide",
       "unhideAria": "Restore this hidden thread",
       "resolve": "Resolve",
+      "reopen": "Reopen",
+      "reopenAria": "Reopen this thread",
       "delete": "Delete",
       "deleteAria": "Delete this comment",
       "badgeOpen": "Open",

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -235,6 +235,14 @@ body {
   animation: mr-comment-flash 1.4s ease-out 1;
   border-radius: 6px;
 }
+/* Inside `<pre>`, per-line spans live in a preformatted block — the rounded
+   corners of the regular-line flash would visibly punch out of the code
+   surface. Match the zero-radius rule used by the static highlight above
+   (`pre [data-code-line][data-has-comment]`) so the flash ring stays
+   flush with the rest of the code. */
+.prose-styles pre [data-code-line][data-comment-flash="true"] {
+  border-radius: 0;
+}
 @media (prefers-reduced-motion: reduce) {
   .prose-styles [data-source-line][data-comment-flash="true"],
   .prose-styles pre [data-code-line][data-comment-flash="true"] {

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -174,6 +174,14 @@ body {
   background: hsl(var(--comment-selection-bg) / 0.35);
   border-left-color: hsl(var(--comment-marker-fg) / 0.4);
 }
+/* Resolved threads collapse to a subtle gutter marker by default — drop the
+   line wash entirely and keep just a thin neutral bar so the anchor stays
+   traceable without competing with the document. */
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-resolved="true"][data-comment-minimized="true"] {
+  background: transparent;
+  border-left-color: hsl(var(--border));
+}
 
 /* Per-line spans inserted into `<pre>` by InlineThreads.splitCodeBlocks —
    they need block layout so the highlight strip spans the full code width
@@ -195,6 +203,43 @@ body {
   background: hsl(var(--comment-selection-bg) / 0.35);
   border-left-color: hsl(var(--comment-marker-fg) / 0.4);
   color: inherit;
+}
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-resolved="true"][data-comment-minimized="true"] {
+  background: transparent;
+  border-left-color: hsl(var(--border));
+  color: inherit;
+}
+
+/* Temporary highlight ring on the line(s) of a thread the user just expanded
+   from its resolved gutter marker. Fades over ~1.5s. Suppressed entirely for
+   users who prefer reduced motion — the static base styles still mark the
+   anchor, so functionality is preserved without animation. */
+@keyframes mr-comment-flash {
+  0% {
+    box-shadow: 0 0 0 0 hsl(var(--comment-marker-fg) / 0.55);
+    background: hsl(var(--comment-selection-bg));
+  }
+  60% {
+    box-shadow: 0 0 0 4px hsl(var(--comment-marker-fg) / 0);
+    background: hsl(var(--comment-selection-bg));
+  }
+  100% {
+    box-shadow: 0 0 0 0 hsl(var(--comment-marker-fg) / 0);
+    background: transparent;
+  }
+}
+.prose-styles [data-source-line][data-comment-flash="true"],
+.prose-styles pre [data-code-line][data-comment-flash="true"] {
+  animation: mr-comment-flash 1.4s ease-out 1;
+  border-radius: 6px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .prose-styles [data-source-line][data-comment-flash="true"],
+  .prose-styles pre [data-code-line][data-comment-flash="true"] {
+    animation: none;
+  }
 }
 
 /* Inline thread / composer slots inserted by InlineThreads — make them sit


### PR DESCRIPTION
Closes #23

## Summary
- Resolved inline threads collapse to a subtle gutter marker (CheckIcon) by default; clicking the marker selects the head, promotes the thread back to the full inline card, and triggers a one-shot highlight ring on the anchor line(s) that fades after ~1.5s. The animation is suppressed under `prefers-reduced-motion`.
- Adds a `Reopen` action that flips a resolved thread back to `submitted`. Available both inline (replacing `Resolve` when the head is resolved) and on the threads-pane card. Both surfaces call `comments.update { state: "submitted" }` — the Rust state machine already allows that transition, so this is frontend-only.
- New i18n keys under `comments.thread.*` (`reopen`, `reopenAria`) and `comments.markers.*` (`resolvedAria`, `resolvedAriaWithCount_one/_other`).

## Test plan
- [ ] Resolve an inline thread; confirm it collapses to a small CheckIcon marker on the anchor line, line wash drops to a thin neutral bar, and the full card disappears.
- [ ] Click the gutter marker; the thread expands back into the inline card and the anchor line(s) flash a fading highlight ring.
- [ ] Click outside the thread (or select another); the thread returns to its marker.
- [ ] Toggle the OS `prefers-reduced-motion` setting and click the marker again; line styling still updates but no animation plays.
- [ ] In the inline card, the action button reads `Reopen` (RotateCcw icon) when state is `resolved`. Clicking it flips the state back to `submitted` and the line wash returns to the regular open style.
- [ ] In the threads pane with the `Resolved` chip on, every resolved row shows a `Reopen` button in the bottom-right corner; clicking it does not toggle the row selection and the row updates to `submitted` after the mutation resolves.
- [ ] Multi-comment threads where every comment is resolved render the marker with a count badge; mixed-state threads (one open + one resolved) keep rendering the full card.
- [ ] `bun run check`, `bun run typecheck`, `bun test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)