### PR TITLE
ci: auto-publish GitHub Releases with Tauri bundles on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-sync:
+    name: Version sync (package.json, Cargo.toml, tauri.conf.json)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify all three version fields match
+        run: |
+          pkg=$(node -p "require('./package.json').version")
+          tauri=$(node -p "require('./src-tauri/tauri.conf.json').version")
+          cargo=$(awk '/^\[workspace\.package\]/{p=1; next} /^\[/{p=0} p && $1=="version"{gsub(/"/,"",$3); print $3; exit}' Cargo.toml)
+          echo "package.json=$pkg"
+          echo "Cargo.toml=$cargo"
+          echo "tauri.conf.json=$tauri"
+          if [ "$pkg" != "$tauri" ] || [ "$pkg" != "$cargo" ]; then
+            echo "::error::Version fields out of sync. Set the same value in package.json, Cargo.toml ([workspace.package].version), and src-tauri/tauri.conf.json."
+            exit 1
+          fi
+
   frontend:
     name: Frontend (lint, typecheck, build, test)
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    name: Check version
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+      tag: ${{ steps.read.outputs.tag }}
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: read
+        name: Read version from package.json
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=app-v$version" >> "$GITHUB_OUTPUT"
+
+      - id: check
+        name: Skip if release already exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "${{ steps.read.outputs.tag }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release ${{ steps.read.outputs.tag }} already exists; skipping."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Bundle (${{ matrix.platform }})
+    needs: check-version
+    if: needs.check-version.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: --target universal-apple-darwin
+            rust-targets: aarch64-apple-darwin,x86_64-apple-darwin
+          - platform: ubuntu-22.04
+            args: ""
+            rust-targets: ""
+          - platform: windows-latest
+            args: ""
+            rust-targets: ""
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Linux dependencies for Tauri
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.rust-targets }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: ". -> target"
+          key: release-${{ matrix.platform }}
+
+      - name: Install JS dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Tauri bundles and upload to release draft
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: ${{ needs.check-version.outputs.tag }}
+          releaseName: "Markdown Reviewer v${{ needs.check-version.outputs.version }}"
+          releaseBody: |
+            Auto-built bundles from `${{ github.sha }}`.
+
+            - macOS: universal `.dmg` (Apple Silicon + Intel)
+            - Windows: `.msi` and NSIS `.exe`
+            - Linux: `.AppImage` and `.deb`
+
+            These artifacts are not code-signed yet; macOS Gatekeeper and Windows SmartScreen will require an explicit "Open anyway" the first time.
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}
+
+  publish:
+    name: Publish release
+    needs: [check-version, release]
+    if: needs.check-version.outputs.should_release == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Promote draft to published release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ needs.check-version.outputs.tag }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,38 @@ jobs:
           echo "tag=app-v$version" >> "$GITHUB_OUTPUT"
 
       - id: check
-        name: Skip if release already exists
+        name: Skip if a published release already exists for this version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.read.outputs.tag }}
         run: |
-          if gh release view "${{ steps.read.outputs.tag }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "Release ${{ steps.read.outputs.tag }} already exists; skipping."
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_release=true" >> "$GITHUB_OUTPUT"
-          fi
+          set -euo pipefail
+          http=$(curl -sS -o /tmp/release.json -w "%{http_code}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$TAG")
+          case "$http" in
+            200)
+              draft=$(jq -r '.draft' /tmp/release.json)
+              if [ "$draft" = "true" ]; then
+                echo "Draft release $TAG exists (likely from a previous failed run); rebuilding to overwrite it."
+                echo "should_release=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Published release $TAG already exists; skipping."
+                echo "should_release=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            404)
+              echo "No release tagged $TAG yet; will build."
+              echo "should_release=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unexpected HTTP $http checking release $TAG; aborting so we don't double-publish."
+              cat /tmp/release.json || true
+              exit 1
+              ;;
+          esac
 
   release:
     name: Bundle (${{ matrix.platform }})
@@ -94,7 +116,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build Tauri bundles and upload to release draft
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ markdown-reviewer/
 
 [`ARCHITECTURE.md`](./ARCHITECTURE.md) is the document to read before adding a new feature, command, crate, or migration.
 
+## Releases
+
+Releases are produced automatically by `.github/workflows/release.yml` on every push to `main`. To cut a release, bump the version **in the same PR** that warrants it: update `package.json`, `Cargo.toml` (`[workspace.package].version`), and `src-tauri/tauri.conf.json` to the same value (e.g. `0.2.0`) alongside your feature/fix. After the PR merges, the workflow publishes a GitHub Release tagged `app-v<version>` with `.dmg` (macOS, universal), `.msi` and `.exe` (Windows), `.AppImage` and `.deb` (Linux) attached. If none of the three version fields changed, the workflow no-ops.
+
+The `version-sync` CI job fails any PR where the three version fields drift out of alignment.
+
+Bundles are not code-signed yet — macOS Gatekeeper and Windows SmartScreen will require an explicit "Open anyway" the first time. Signing and the in-app updater are tracked separately.
+
 ## Scripts
 
 ### JavaScript / TypeScript


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` triggers on every push to `main`. It reads the version from `package.json`, skips if a `app-v<version>` release already exists, otherwise builds Tauri bundles in a matrix (macOS universal `.dmg`, Windows `.msi` + NSIS `.exe`, ubuntu-22.04 `.AppImage` + `.deb`) via `tauri-apps/tauri-action`, uploads them to a draft release, and a final job promotes the draft to published.
- New `version-sync` job in `ci.yml` fails any PR where `package.json`, `Cargo.toml` (`[workspace.package].version`), and `src-tauri/tauri.conf.json` drift out of alignment — releases hinge on the three matching.
- README gets a "Releases" section explaining the flow: bump the version **in the same PR** that warrants a release; if no field changes, the workflow no-ops.

Decisions made up-front (can be revisited in follow-ups):

- No code signing yet — macOS Gatekeeper and Windows SmartScreen will require an explicit "Open anyway" the first time.
- No in-app updater (`latest.json` / signing keys) — distribution is GitHub Releases only.
- No conventional-commits auto-bumping — version bumps are manual and intentional.

## First release

Since tag `app-v0.1.0` does not exist yet, merging this PR will trigger the workflow and produce the first release automatically — giving us real bundles to smoke-test.

## Test plan

- [ ] CI passes on this PR (including the new `version-sync` job — all three fields are at `0.1.0`).
- [ ] After merge, `Release` workflow runs on `main`, `check-version` reports `should_release=true`.
- [ ] Matrix jobs produce artifacts on macOS / Linux / Windows runners.
- [ ] `publish` job promotes the draft `app-v0.1.0` to a published release.
- [ ] `.dmg` opens on macOS (with expected Gatekeeper warning).
- [ ] `.msi` installs on Windows (with expected SmartScreen warning).
- [ ] `.AppImage` runs on Linux after `chmod +x`.
- [ ] Subsequent merge that does **not** bump the version → workflow no-ops (no duplicate release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)