### PR TITLE
fix(macos): inherit shell PATH so gh/git resolve when launched from Finder (v0.1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,7 +600,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1317,11 +1317,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.12"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2930,7 +2930,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3292,7 +3292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3823,7 +3823,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4677,7 +4677,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs?rev=c4c45d503ea115a839aae718d02f79e7c7f0f673#c4c45d503ea115a839aae718d02f79e7c7f0f673"
+dependencies = [
+ "home",
+ "strip-ansi-escapes",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,6 +1314,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html5ever"
@@ -1843,7 +1862,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-reviewer-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -1856,8 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "fix-path-env",
  "markdown-reviewer-core",
  "markdown-reviewer-infra",
  "markdown-reviewer-ipc",
@@ -1872,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-infra"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "markdown-reviewer-core",
@@ -1890,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-ipc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "markdown-reviewer-core",
  "markdown-reviewer-infra",
@@ -3379,6 +3399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4362,6 +4391,15 @@ checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["src-tauri", "crates/core", "crates/infra", "crates/ipc"]
 [workspace.package]
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.81"
 license = "UNLICENSED"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/core", "crates/infra", "crates/ipc"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.77"
 license = "UNLICENSED"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-reviewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,9 +29,13 @@ tracing-appender = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 
-# Pinned fork of tauri-apps/fix-path-env-rs (not on crates.io). Spawns a login
-# shell at startup to inherit the user's real PATH so `Command::new("gh"|"git")`
-# works when the .app is launched from Finder/Dock instead of a terminal.
+# Pinned upstream tauri-apps/fix-path-env-rs (not published to crates.io;
+# `rev` keeps the build reproducible). On macOS/Linux it spawns a login shell
+# at startup to inherit the user's real PATH so `Command::new("gh"|"git")`
+# resolves when the .app is launched from Finder/Dock/`.desktop` instead of
+# a terminal. On Windows it refreshes inherited env vars to work around the
+# known std::process::Command PATH-inheritance bug, so the dep is wanted on
+# every supported target — no `cfg(target_os)` gate.
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
 
 [lints]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,5 +29,10 @@ tracing-appender = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 
+# Pinned fork of tauri-apps/fix-path-env-rs (not on crates.io). Spawns a login
+# shell at startup to inherit the user's real PATH so `Command::new("gh"|"git")`
+# works when the .app is launched from Finder/Dock instead of a terminal.
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "c4c45d503ea115a839aae718d02f79e7c7f0f673" }
+
 [lints]
 workspace = true

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -13,6 +13,14 @@ use markdown_reviewer_ipc::AppState;
 use tauri::Manager;
 
 pub(crate) fn run() {
+    // Inherit the user's real PATH from their login shell so `gh`/`git`
+    // installed via Homebrew/asdf/mise/nix are reachable when the .app is
+    // launched from Finder/Dock (where launchd's PATH is just /usr/bin:/bin).
+    // Best-effort: if reading the shell fails we keep going with whatever
+    // PATH we inherited — better to surface a "tool missing" error in-app
+    // than to abort startup.
+    let _ = fix_path_env::fix();
+
     let builder = tauri::Builder::default().plugin(tauri_plugin_dialog::init());
 
     let builder = markdown_reviewer_ipc::register(builder);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markdown Reviewer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.weqora.markdown-reviewer",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Summary

- Spawn a login shell at boot via `tauri-apps/fix-path-env-rs` (pinned to a SHA — the crate isn't on crates.io) so the app inherits the user's real `PATH` from `~/.zshrc` / asdf / mise / nix instead of the minimal `/usr/bin:/bin:/usr/sbin:/sbin` that launchd hands a `.app` launched from Finder/Dock. Without this, `gh` (typically `/opt/homebrew/bin/gh`) is invisible and every IPC command that calls it returns `MissingTool`.
- Bumps to `0.1.1` across `package.json`, `Cargo.toml` (`[workspace.package].version`), and `src-tauri/tauri.conf.json` so merging this PR triggers `app-v0.1.1` from `.github/workflows/release.yml`.

### Why this approach

- **`fix-path-env`** is the official Tauri-team crate (`tauri-apps/fix-path-env-rs`, pinned to `c4c45d50…`, last pushed 2025-08-25). Same shell-from-login trick VS Code/Cursor use; ~20 lines of equivalent inline code, but the upstream version handles edge cases (zsh quirks, ANSI stripping, Windows PATH inheritance bug) that we'd otherwise reinvent. Pinning to a SHA keeps the build reproducible since there are no published versions.
- **Best-effort** (`let _ = fix_path_env::fix();`): if reading the shell fails for some user, we keep the inherited PATH and the existing `check_tools` command surfaces the missing-tool error in-app — better than aborting startup.
- **Why bump in this PR**: the release workflow no-ops unless a version field changed, and a fix that only ships when a future feature happens to bump the version isn't a fix.

## Test plan

- [x] `cargo check -p markdown-reviewer-desktop` resolves the git dep and compiles
- [x] `cargo clippy -p markdown-reviewer-desktop --all-targets --locked -- -D warnings` clean
- [ ] `version-sync` job passes (three version fields all `0.1.1`)
- [ ] After merge, `Release` workflow produces `app-v0.1.1` with `.dmg` / `.msi` / `.AppImage` / `.deb` attached
- [ ] On macOS, open the new `.dmg`, drag to Applications, launch from Finder → "Select repository" → confirm `gh`/`git` resolve (no `MissingTool` error). Smoke-test loading a PR and creating a draft comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)