### PR TITLE
feat(phase-4 #24): long range comments (10-15+ lines)

### DIFF
--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -16,6 +16,7 @@ import { CommentComposer } from "./CommentComposer";
 import { HiddenThreadMarker } from "./HiddenThreadMarker";
 import { InlineThreadCard } from "./InlineThreadCard";
 import { MinimizedThreadBadge } from "./MinimizedThreadBadge";
+import { RangeHeaderChip } from "./RangeHeaderChip";
 import { ResolvedThreadMarker } from "./ResolvedThreadMarker";
 
 interface InlineThreadsProps {
@@ -42,6 +43,8 @@ interface SlotMap {
   threads: Map<SlotKey, HTMLDivElement>;
   /** key → portal target span for the minimized "open" badge */
   badges: Map<SlotKey, HTMLSpanElement>;
+  /** key → portal target div for the sticky range header (multi-line ranges only) */
+  headers: Map<SlotKey, HTMLDivElement>;
   composerSlot: HTMLDivElement | null;
 }
 
@@ -171,6 +174,7 @@ export function InlineThreads({
   const slotsRef = useRef<SlotMap>({
     threads: new Map(),
     badges: new Map(),
+    headers: new Map(),
     composerSlot: null,
   });
   const [, setRevision] = useState(0);
@@ -245,7 +249,12 @@ export function InlineThreads({
       mutatingRef.current = true;
       try {
         removeAllSlots(container);
-        slotsRef.current = { threads: new Map(), badges: new Map(), composerSlot: null };
+        slotsRef.current = {
+          threads: new Map(),
+          badges: new Map(),
+          headers: new Map(),
+          composerSlot: null,
+        };
       } finally {
         queueMicrotask(() => {
           mutatingRef.current = false;
@@ -284,11 +293,51 @@ export function InlineThreads({
 
   return (
     <>
-      {groups.map((group) => {
+      {groups.flatMap((group) => {
         const slotKey = slotKeyFor(group.startLine, group.endLine);
         const minKey = minimizedKey(prNumber, filePath, group.startLine, group.endLine);
         const minimized = minimizedSet.has(minKey);
         const allHidden = allHiddenSet.has(slotKey);
+        const isResolvedCollapsedEarly = resolvedCollapsed.has(slotKey);
+        const headerSlot = slots.headers.get(slotKey);
+        const wantsHeader =
+          group.startLine !== group.endLine &&
+          !minimized &&
+          !allHidden &&
+          !isResolvedCollapsedEarly;
+        const headerNode =
+          wantsHeader && headerSlot
+            ? createPortal(
+                <RangeHeaderChip
+                  key={`hdr-${slotKey}`}
+                  startLine={group.startLine}
+                  endLine={group.endLine}
+                  count={group.comments.length}
+                  state={group.comments[0]?.state ?? "submitted"}
+                  onJump={() => {
+                    const head = group.comments[0];
+                    if (head) select(head.id);
+                    const cardSlot = slotsRef.current.threads.get(slotKey);
+                    if (cardSlot) {
+                      const reduce =
+                        typeof window !== "undefined" &&
+                        typeof window.matchMedia === "function" &&
+                        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+                      cardSlot.scrollIntoView({
+                        block: "center",
+                        behavior: reduce ? "auto" : "smooth",
+                      });
+                    }
+                  }}
+                />,
+                headerSlot,
+                `thread-header-${slotKey}`,
+              )
+            : null;
+
+        const isSelected = group.comments.some((c) => c.id === selectedId);
+        const isResolvedCollapsed = resolvedCollapsed.has(slotKey);
+        let body: React.ReactNode = null;
         if (allHidden) {
           // `Hidden` is a persistent comment state, not the session-only
           // minimize toggle — render a discreet `MessageSquareOff` marker in
@@ -297,103 +346,103 @@ export function InlineThreads({
           // `submitted`, otherwise to `draft`. The Rust transition table
           // (`Hidden → Draft | Submitted | Resolved | Deleted`) allows both.
           const badgeSlot = slots.badges.get(slotKey);
-          if (!badgeSlot) return null;
-          return createPortal(
-            <HiddenThreadMarker
-              key={slotKey}
-              count={group.comments.length}
-              onUnhide={() => {
-                for (const c of group.comments) {
-                  update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
-                }
-                const head = group.comments[0];
-                if (head) select(head.id);
-              }}
-            />,
-            badgeSlot,
-            `thread-hidden-${slotKey}`,
-          );
-        }
-        // `resolvedCollapsed` already excludes anchors that are all-hidden, so
-        // checking the set is enough — no need to recompute from the group.
-        const isSelected = group.comments.some((c) => c.id === selectedId);
-        const isResolvedCollapsed = resolvedCollapsed.has(slotKey);
-        if (minimized) {
+          body = badgeSlot
+            ? createPortal(
+                <HiddenThreadMarker
+                  key={slotKey}
+                  count={group.comments.length}
+                  onUnhide={() => {
+                    for (const c of group.comments) {
+                      update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
+                    }
+                    const head = group.comments[0];
+                    if (head) select(head.id);
+                  }}
+                />,
+                badgeSlot,
+                `thread-hidden-${slotKey}`,
+              )
+            : null;
+        } else if (minimized) {
           const badgeSlot = slots.badges.get(slotKey);
-          if (!badgeSlot) return null;
-          return createPortal(
-            <MinimizedThreadBadge
-              key={slotKey}
-              count={group.comments.length}
-              onExpand={() => {
-                expand(minKey);
-                const head = group.comments[0];
-                if (head) select(head.id);
-              }}
-            />,
-            badgeSlot,
-            `thread-badge-${slotKey}`,
-          );
-        }
-        if (isResolvedCollapsed) {
+          body = badgeSlot
+            ? createPortal(
+                <MinimizedThreadBadge
+                  key={slotKey}
+                  count={group.comments.length}
+                  onExpand={() => {
+                    expand(minKey);
+                    const head = group.comments[0];
+                    if (head) select(head.id);
+                  }}
+                />,
+                badgeSlot,
+                `thread-badge-${slotKey}`,
+              )
+            : null;
+        } else if (isResolvedCollapsed) {
           const badgeSlot = slots.badges.get(slotKey);
-          if (!badgeSlot) return null;
-          return createPortal(
-            <ResolvedThreadMarker
-              key={slotKey}
-              count={group.comments.length}
-              onExpand={() => {
-                const head = group.comments[0];
-                if (head) select(head.id);
-                triggerFlash(slotKey);
-              }}
-            />,
-            badgeSlot,
-            `thread-resolved-marker-${slotKey}`,
-          );
+          body = badgeSlot
+            ? createPortal(
+                <ResolvedThreadMarker
+                  key={slotKey}
+                  count={group.comments.length}
+                  onExpand={() => {
+                    const head = group.comments[0];
+                    if (head) select(head.id);
+                    triggerFlash(slotKey);
+                  }}
+                />,
+                badgeSlot,
+                `thread-resolved-marker-${slotKey}`,
+              )
+            : null;
+        } else {
+          const slot = slots.threads.get(slotKey);
+          body = slot
+            ? createPortal(
+                <InlineThreadCard
+                  key={slotKey}
+                  comments={group.comments}
+                  selected={isSelected}
+                  onResolve={(c) => {
+                    select(c.id);
+                    update.mutate({ id: c.id, patch: { state: "resolved" } });
+                  }}
+                  onReopen={(c) => {
+                    select(c.id);
+                    update.mutate({ id: c.id, patch: { state: "submitted" } });
+                  }}
+                  // `Hide` persists `state = hidden` via IPC so the choice survives
+                  // restart and a remote refresh. The session-only `minimize` store
+                  // still drives the count-badge expand UX (see #21) but it is no
+                  // longer wired to this button.
+                  onHide={(c) => {
+                    select(c.id);
+                    update.mutate({ id: c.id, patch: { state: "hidden" } });
+                  }}
+                  onUnhide={(c) => {
+                    select(c.id);
+                    update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
+                  }}
+                  onReply={(c) => select(c.id)}
+                  onDelete={(c) => remove.mutate(c.id)}
+                  onShowStack={(c) => {
+                    const target = pickPaneVisibleComment(group.comments, paneFilter, c);
+                    // If every comment in the group is filtered out of the pane,
+                    // flip on the chip for the head's state so the pane shows it.
+                    if (!isPaneVisible(target, paneFilter)) {
+                      ensurePaneVisible(target.state as FilterableState);
+                    }
+                    select(target.id);
+                  }}
+                />,
+                slot,
+                `thread-${slotKey}`,
+              )
+            : null;
         }
-        const slot = slots.threads.get(slotKey);
-        if (!slot) return null;
-        return createPortal(
-          <InlineThreadCard
-            key={slotKey}
-            comments={group.comments}
-            selected={isSelected}
-            onResolve={(c) => {
-              select(c.id);
-              update.mutate({ id: c.id, patch: { state: "resolved" } });
-            }}
-            onReopen={(c) => {
-              select(c.id);
-              update.mutate({ id: c.id, patch: { state: "submitted" } });
-            }}
-            // `Hide` persists `state = hidden` via IPC so the choice survives
-            // restart and a remote refresh. The session-only `minimize` store
-            // still drives the count-badge expand UX (see #21) but it is no
-            // longer wired to this button.
-            onHide={(c) => {
-              select(c.id);
-              update.mutate({ id: c.id, patch: { state: "hidden" } });
-            }}
-            onUnhide={(c) => {
-              select(c.id);
-              update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
-            }}
-            onReply={(c) => select(c.id)}
-            onDelete={(c) => remove.mutate(c.id)}
-            onShowStack={(c) => {
-              const target = pickPaneVisibleComment(group.comments, paneFilter, c);
-              // If every comment in the group is filtered out of the pane,
-              // flip on the chip for the head's state so the pane shows it.
-              if (!isPaneVisible(target, paneFilter)) {
-                ensurePaneVisible(target.state as FilterableState);
-              }
-              select(target.id);
-            }}
-          />,
-          slot,
-          `thread-${slotKey}`,
-        );
+        return [headerNode, body];
       })}
       {composerAnchor && slots.composerSlot
         ? createPortal(
@@ -537,6 +586,23 @@ function syncSlots(
       }
     }
 
+    // 1c. Remove obsolete header slots — only multi-line non-collapsed groups
+    //     keep one.
+    const wantsHeaderKeys = new Set<SlotKey>();
+    for (const g of groups) {
+      if (g.startLine === g.endLine) continue;
+      const key = slotKeyFor(g.startLine, g.endLine);
+      if (collapsed.has(key)) continue;
+      wantsHeaderKeys.add(key);
+    }
+    for (const [key, node] of current.headers) {
+      if (!wantsHeaderKeys.has(key) || !node.isConnected) {
+        node.remove();
+        current.headers.delete(key);
+        changed = true;
+      }
+    }
+
     // 2. Remove obsolete composer slot.
     if (
       current.composerSlot &&
@@ -552,6 +618,9 @@ function syncSlots(
     // 3. Clear and reapply the data-has-comment attribute on commented lines.
     for (const n of container.querySelectorAll<HTMLElement>("[data-has-comment]")) {
       delete n.dataset.hasComment;
+    }
+    for (const n of container.querySelectorAll<HTMLElement>("[data-comment-range]")) {
+      delete n.dataset.commentRange;
     }
     for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
       delete n.dataset.commentMinimized;
@@ -583,14 +652,28 @@ function syncSlots(
         current.badges.set(key, badge);
         changed = true;
       } else {
-        if (current.threads.has(key)) continue;
-        if (!anchor.parentNode) continue;
-        const slot = document.createElement("div");
-        slot.dataset.threadSlot = "thread";
-        slot.dataset.threadSlotLine = String(group.line);
-        anchor.parentNode.insertBefore(slot, anchor.nextSibling);
-        current.threads.set(key, slot);
-        changed = true;
+        if (!current.threads.has(key)) {
+          if (!anchor.parentNode) continue;
+          const slot = document.createElement("div");
+          slot.dataset.threadSlot = "thread";
+          slot.dataset.threadSlotLine = String(group.line);
+          anchor.parentNode.insertBefore(slot, anchor.nextSibling);
+          current.threads.set(key, slot);
+          changed = true;
+        }
+        // Multi-line ranges also get a sticky header chip mounted before the
+        // start-line node. Single-line ranges keep the existing wash only.
+        if (group.startLine !== group.endLine && !current.headers.has(key)) {
+          const startNode = lineNodes.get(group.startLine);
+          if (startNode?.parentNode) {
+            const header = document.createElement("div");
+            header.dataset.threadSlot = "header";
+            header.dataset.threadSlotLine = String(group.startLine);
+            startNode.parentNode.insertBefore(header, startNode);
+            current.headers.set(key, header);
+            changed = true;
+          }
+        }
       }
     }
 
@@ -642,10 +725,18 @@ function markRange(
   collapsed: boolean,
   resolved: boolean,
 ) {
+  const single = start === end;
   for (let line = start; line <= end; line++) {
     const el = lineNodes.get(line);
     if (!el) continue;
     el.dataset.hasComment = "true";
+    el.dataset.commentRange = single
+      ? "single"
+      : line === start
+        ? "head"
+        : line === end
+          ? "tail"
+          : "body";
     if (collapsed) el.dataset.commentMinimized = "true";
     if (resolved) el.dataset.commentResolved = "true";
   }
@@ -660,6 +751,9 @@ function removeAllSlots(container: HTMLElement) {
   }
   for (const n of container.querySelectorAll<HTMLElement>("[data-has-comment]")) {
     delete n.dataset.hasComment;
+  }
+  for (const n of container.querySelectorAll<HTMLElement>("[data-comment-range]")) {
+    delete n.dataset.commentRange;
   }
   for (const n of container.querySelectorAll<HTMLElement>("[data-comment-minimized]")) {
     delete n.dataset.commentMinimized;

--- a/src/features/comments/components/RangeHeaderChip.tsx
+++ b/src/features/comments/components/RangeHeaderChip.tsx
@@ -1,0 +1,52 @@
+import type { CommentState } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { CornerDownRightIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface RangeHeaderChipProps {
+  startLine: number;
+  endLine: number;
+  count: number;
+  state: CommentState;
+  onJump: () => void;
+}
+
+export function RangeHeaderChip({
+  startLine,
+  endLine,
+  count,
+  state,
+  onJump,
+}: RangeHeaderChipProps) {
+  const { t } = useTranslation();
+  const muted = state === "resolved" || state === "hidden";
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px]",
+        "border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",
+        "text-[hsl(var(--comment-marker-fg))] shadow-sm",
+        muted ? "opacity-70" : null,
+      )}
+      data-comment-range-header="true"
+    >
+      <span className="font-mono">
+        {t("comments.range.headerLabel", { count, start: startLine, end: endLine })}
+      </span>
+      <span className="ml-auto" />
+      <button
+        type="button"
+        onClick={onJump}
+        aria-label={t("comments.range.jumpAria")}
+        className={cn(
+          "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium",
+          "hover:bg-[hsl(var(--comment-marker-hover))]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        )}
+      >
+        <CornerDownRightIcon className="h-3 w-3" aria-hidden="true" />
+        <span>{t("comments.range.jump")}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/features/comments/hooks/useFileSource.ts
+++ b/src/features/comments/hooks/useFileSource.ts
@@ -1,0 +1,37 @@
+import { ipc } from "@/shared/ipc/client";
+import type { AppError } from "@/shared/ipc/contract";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+interface UseFileSourceResult {
+  lines: string[] | null;
+  isLoading: boolean;
+  error: AppError | null;
+}
+
+export function useFileSource(
+  repoPath: string | undefined,
+  sha: string | undefined,
+  filePath: string,
+): UseFileSourceResult {
+  const enabled = Boolean(repoPath && sha && filePath);
+  const query = useQuery<string, AppError>({
+    queryKey: ["file-source", repoPath, sha, filePath],
+    enabled,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 5 * 60_000,
+    queryFn: async () => {
+      const res = await ipc.files.readMarkdown(repoPath as string, sha as string, filePath);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+  });
+
+  const lines = useMemo(() => (query.data ? query.data.split("\n") : null), [query.data]);
+
+  return {
+    lines,
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+  };
+}

--- a/src/features/comments/lib/sliceSnippet.test.ts
+++ b/src/features/comments/lib/sliceSnippet.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { sliceSnippet } from "./sliceSnippet";
+
+const FIFTEEN_LINES = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`);
+
+describe("sliceSnippet", () => {
+  test("returns the full range when shorter than maxVisible", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 2, 4, 3);
+    expect(out.visible).toEqual(["line 2", "line 3", "line 4"]);
+    expect(out.more).toBe(0);
+  });
+
+  test("truncates ranges longer than maxVisible and reports the overflow", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 1, 15, 3);
+    expect(out.visible).toEqual(["line 1", "line 2", "line 3"]);
+    expect(out.more).toBe(12);
+  });
+
+  test("single-line range yields one visible line", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 7, 7, 3);
+    expect(out.visible).toEqual(["line 7"]);
+    expect(out.more).toBe(0);
+  });
+
+  test("clamps when endLine exceeds the file length", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 14, 20, 3);
+    expect(out.visible).toEqual(["line 14", "line 15"]);
+    expect(out.more).toBe(5);
+  });
+
+  test("returns empty when startLine is past the end of the file", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 99, 100, 3);
+    expect(out.visible).toEqual([]);
+    expect(out.more).toBe(2);
+  });
+
+  test("uses default maxVisible = 3 when omitted", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 1, 10);
+    expect(out.visible).toHaveLength(3);
+    expect(out.more).toBe(7);
+  });
+});

--- a/src/features/comments/lib/sliceSnippet.ts
+++ b/src/features/comments/lib/sliceSnippet.ts
@@ -1,0 +1,18 @@
+export interface SnippetSlice {
+  visible: string[];
+  more: number;
+}
+
+export function sliceSnippet(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  maxVisible = 3,
+): SnippetSlice {
+  const total = Math.max(0, endLine - startLine + 1);
+  const startIndex = Math.max(0, startLine - 1);
+  const stop = startIndex + Math.min(total, maxVisible);
+  const visible = lines.slice(startIndex, stop);
+  const more = total - visible.length;
+  return { visible, more };
+}

--- a/src/features/file-explorer/screens/PullRequestScreen/index.tsx
+++ b/src/features/file-explorer/screens/PullRequestScreen/index.tsx
@@ -113,7 +113,12 @@ export function PullRequestScreen() {
           />
         ) : null}
       </PreviewSlot>
-      <ThreadsPane prNumber={prNumber} filePath={selectedPath} />
+      <ThreadsPane
+        prNumber={prNumber}
+        filePath={selectedPath}
+        repoPath={repoPath.data ?? undefined}
+        sha={detail.data?.headSha}
+      />
     </>
   );
 }

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -17,11 +17,15 @@ import { ThreadList } from "./threads/ThreadList";
 interface ThreadsPaneProps {
   prNumber?: number;
   filePath?: string;
+  /** Repo absolute path — forwarded to ThreadList for the snippet read. */
+  repoPath?: string;
+  /** PR head sha — forwarded to ThreadList for the snippet cache key. */
+  sha?: string;
 }
 
 type Scope = "currentFile" | "allFiles";
 
-export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
+export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPaneProps) {
   const { t } = useTranslation();
   const query = usePullRequestComments(prNumber);
   const filter = useThreadsFilter((s) => s.filter);
@@ -154,6 +158,8 @@ export function ThreadsPane({ prNumber, filePath }: ThreadsPaneProps) {
               hiddenCount={hiddenCount}
               prNumber={prNumber}
               currentFilePath={filePath}
+              repoPath={repoPath}
+              sha={sha}
             />
           )}
         </div>

--- a/src/features/main/components/threads/ThreadCard.tsx
+++ b/src/features/main/components/threads/ThreadCard.tsx
@@ -1,10 +1,16 @@
-import type { ReviewComment } from "@/shared/ipc/contract";
+import type { CommentAnchor, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { RotateCcwIcon } from "lucide-react";
 import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { AnchorLabel } from "./AnchorLabel";
 import { StateBadge } from "./StateBadge";
+import { ThreadSnippet } from "./ThreadSnippet";
+
+function rangeOf(anchor: CommentAnchor): { startLine: number; endLine: number } {
+  if (anchor.kind === "singleLine") return { startLine: anchor.line, endLine: anchor.line };
+  return { startLine: anchor.startLine, endLine: anchor.endLine };
+}
 
 const PREVIEW_LIMIT = 120;
 
@@ -41,6 +47,10 @@ interface ThreadCardProps {
    * `role="tree"`. Outside that context the card is a plain button.
    */
   asTreeItem?: boolean;
+  /** Forwarded to ThreadSnippet's `useFileSource` — undefined disables the snippet. */
+  repoPath?: string;
+  /** Head sha for the snippet's cache key. */
+  sha?: string;
   /** Forwarded to the underlying row button — used to track roving-tabindex focus. */
   onFocus?: () => void;
   onSelect: (comment: ReviewComment) => void;
@@ -64,12 +74,17 @@ export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(functio
     hideAnchorLabel = false,
     tabIndex,
     asTreeItem = false,
+    repoPath,
+    sha,
     onFocus,
     onSelect,
     onReopen,
   },
   ref,
 ) {
+  const { startLine: snippetStart, endLine: snippetEnd } = group.comments[0]
+    ? rangeOf(group.comments[0].anchor)
+    : { startLine: 0, endLine: 0 };
   const head = group.comments[0];
   const { t } = useTranslation();
   if (!head) return null;
@@ -119,6 +134,13 @@ export const ThreadCard = forwardRef<HTMLButtonElement, ThreadCardProps>(functio
             <StateBadge state={head.state} className="shrink-0" />
           </div>
         )}
+        <ThreadSnippet
+          repoPath={repoPath}
+          sha={sha}
+          filePath={group.filePath}
+          startLine={snippetStart}
+          endLine={snippetEnd}
+        />
         {isStacked ? (
           <>
             <p className="text-[11px] font-medium text-[hsl(var(--muted-foreground))]">

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -19,6 +19,10 @@ interface ThreadListProps {
   prNumber?: number;
   /** File path of the currently open preview, when one is selected. */
   currentFilePath?: string;
+  /** Repo absolute path — forwarded to ThreadCard for the snippet read. */
+  repoPath?: string;
+  /** PR head sha — forwarded to ThreadCard for the snippet cache key. */
+  sha?: string;
 }
 
 /**
@@ -50,6 +54,8 @@ export function ThreadList({
   hiddenCount,
   prNumber,
   currentFilePath,
+  repoPath,
+  sha,
 }: ThreadListProps) {
   const { t } = useTranslation();
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
@@ -454,6 +460,8 @@ export function ThreadList({
                 asTreeItem
                 tabIndex={effectiveActiveId === cId ? 0 : -1}
                 onFocus={() => setActiveId(cId)}
+                repoPath={repoPath}
+                sha={sha}
                 onSelect={(comment) => {
                   setActiveId(cId);
                   select(comment.id);

--- a/src/features/main/components/threads/ThreadSnippet.tsx
+++ b/src/features/main/components/threads/ThreadSnippet.tsx
@@ -23,6 +23,11 @@ export function ThreadSnippet({ repoPath, sha, filePath, startLine, endLine }: T
     [lines, startLine, endLine],
   );
 
+  // Without repoPath/sha the query is disabled and never produces lines or an
+  // error, so the loading branch below would show a skeleton forever. Omit
+  // the snippet entirely instead.
+  if (!repoPath || !sha) return null;
+
   if (isLoading || (!lines && !error)) {
     return (
       <div className="my-1.5 flex flex-col gap-1">

--- a/src/features/main/components/threads/ThreadSnippet.tsx
+++ b/src/features/main/components/threads/ThreadSnippet.tsx
@@ -1,0 +1,55 @@
+import { useFileSource } from "@/features/comments/hooks/useFileSource";
+import { sliceSnippet } from "@/features/comments/lib/sliceSnippet";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+const MAX_VISIBLE = 3;
+
+interface ThreadSnippetProps {
+  repoPath: string | undefined;
+  sha: string | undefined;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+}
+
+export function ThreadSnippet({ repoPath, sha, filePath, startLine, endLine }: ThreadSnippetProps) {
+  const { t } = useTranslation();
+  const { lines, isLoading, error } = useFileSource(repoPath, sha, filePath);
+
+  const slice = useMemo(
+    () => (lines ? sliceSnippet(lines, startLine, endLine, MAX_VISIBLE) : null),
+    [lines, startLine, endLine],
+  );
+
+  if (isLoading || (!lines && !error)) {
+    return (
+      <div className="my-1.5 flex flex-col gap-1">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-5/6" />
+        <Skeleton className="h-3 w-4/6" />
+      </div>
+    );
+  }
+
+  if (!slice || slice.visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="my-1.5 rounded border-[hsl(var(--comment-marker-fg))] border-l-[1.5px] bg-[hsl(var(--muted))]/30 py-1 pl-2 font-mono text-[11px] leading-snug"
+      data-thread-snippet="true"
+    >
+      <pre className="overflow-hidden text-ellipsis whitespace-pre text-[hsl(var(--foreground))]/85">
+        {slice.visible.join("\n")}
+      </pre>
+      {slice.more > 0 ? (
+        <p className="mt-1 text-[10px] text-[hsl(var(--muted-foreground))]">
+          {t("threads.snippet.moreLines", { count: slice.more })}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -139,6 +139,10 @@
       "hidden": "Hidden",
       "resolved": "Resolved",
       "deleted": "Deleted"
+    },
+    "snippet": {
+      "moreLines_one": "… +{{count}} more line",
+      "moreLines_other": "… +{{count}} more lines"
     }
   },
   "comments": {
@@ -188,6 +192,12 @@
       "badgeResolved": "Resolved",
       "badgeHidden": "Hidden",
       "badgeDeleted": "Deleted"
+    },
+    "range": {
+      "headerLabel_one": "L{{start}}–L{{end}} · {{count}} comment",
+      "headerLabel_other": "L{{start}}–L{{end}} · {{count}} comments",
+      "jump": "Jump",
+      "jumpAria": "Jump to comment thread"
     }
   },
   "errors": {

--- a/src/shared/styles/index.css
+++ b/src/shared/styles/index.css
@@ -160,26 +160,62 @@ body {
 }
 
 /* Lines that already carry at least one comment get a soft persistent
-   highlight + 3px brand bar on the left, matching the `mrexSameLine` style. */
-.prose-styles [data-source-line][data-has-comment="true"] {
+   highlight + 3px brand bar on the left, matching the `mrexSameLine` style.
+   The full wash applies only to single-line anchors — multi-line ranges use
+   the lighter left-rail rules further below. */
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="single"] {
   background: hsl(var(--comment-selection-bg));
   border-left: 3px solid hsl(var(--comment-marker-fg));
   border-radius: 6px;
   padding-left: 0.6em;
   margin-left: -0.6em;
 }
-/* Minimized threads keep the anchor visible with a much softer wash so the
-   document content stays the focus. */
-.prose-styles [data-source-line][data-has-comment="true"][data-comment-minimized="true"] {
+/* Minimized single-line threads keep the anchor visible with a much softer
+   wash so the document content stays the focus. */
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="single"][data-comment-minimized="true"] {
   background: hsl(var(--comment-selection-bg) / 0.35);
   border-left-color: hsl(var(--comment-marker-fg) / 0.4);
 }
-/* Resolved threads collapse to a subtle gutter marker by default — drop the
-   line wash entirely and keep just a thin neutral bar so the anchor stays
-   traceable without competing with the document. */
+/* Resolved single-line threads collapse to a subtle gutter marker by default —
+   drop the line wash entirely and keep just a thin neutral bar. */
 .prose-styles
-  [data-source-line][data-has-comment="true"][data-comment-resolved="true"][data-comment-minimized="true"] {
+  [data-source-line][data-has-comment="true"][data-comment-range="single"][data-comment-resolved="true"][data-comment-minimized="true"] {
   background: transparent;
+  border-left-color: hsl(var(--border));
+}
+
+/* Multi-line range anchors get a continuous 3px left rail spanning every
+   covered line — much lighter visually than the per-line wash, scales from
+   2 lines to 50+ without dominating the document. The head line gets the
+   top corner rounded; the tail line gets the bottom corner rounded. */
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="head"],
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="body"],
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  padding-left: 0.6em;
+  margin-left: -0.6em;
+}
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="head"] {
+  border-top-left-radius: 6px;
+}
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-bottom-left-radius: 6px;
+}
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="head"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="body"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="tail"][data-comment-minimized="true"] {
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
+}
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="head"][data-comment-resolved="true"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="body"][data-comment-resolved="true"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="tail"][data-comment-resolved="true"][data-comment-minimized="true"] {
   border-left-color: hsl(var(--border));
 }
 
@@ -189,7 +225,7 @@ body {
 .prose-styles pre [data-code-line] {
   display: block;
 }
-.prose-styles pre [data-code-line][data-has-comment="true"] {
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="single"] {
   background: hsl(var(--comment-selection-bg));
   border-left: 3px solid hsl(var(--comment-marker-fg));
   /* Keep the highlight tight to the line — no rounded corners, no negative
@@ -199,17 +235,40 @@ body {
   margin-left: -0.5em;
   color: hsl(var(--comment-selection-fg));
 }
-.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-minimized="true"] {
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="single"][data-comment-minimized="true"] {
   background: hsl(var(--comment-selection-bg) / 0.35);
   border-left-color: hsl(var(--comment-marker-fg) / 0.4);
   color: inherit;
 }
 .prose-styles
   pre
-  [data-code-line][data-has-comment="true"][data-comment-resolved="true"][data-comment-minimized="true"] {
+  [data-code-line][data-has-comment="true"][data-comment-range="single"][data-comment-resolved="true"][data-comment-minimized="true"] {
   background: transparent;
   border-left-color: hsl(var(--border));
   color: inherit;
+}
+
+/* Mirror the rail on per-line code spans inside <pre> for multi-line ranges. */
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="head"],
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="body"],
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  border-radius: 0;
+  padding-left: 0.5em;
+  margin-left: -0.5em;
+}
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="head"][data-comment-minimized="true"],
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="body"][data-comment-minimized="true"],
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="tail"][data-comment-minimized="true"] {
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
 }
 
 /* Temporary highlight ring on the line(s) of a thread the user just expanded
@@ -254,6 +313,18 @@ body {
    flush in the document flow under the anchor line. */
 .prose-styles [data-thread-slot] {
   margin: 0;
+}
+
+/* Sticky range header chip mounted above the first line of a multi-line
+   range. Sticks to the top of the preview's scroll container so the reader
+   keeps a "there is a comment here" affordance even when scrolled into the
+   middle of a long range. */
+.prose-styles [data-thread-slot="header"] {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  margin: 0 0 4px;
+  background: hsl(var(--background));
 }
 
 /* Minimized "open" badge inserted at the end of the highlighted line. Pushed


### PR DESCRIPTION
## Summary
- Inline long-range anchors now render a thin left rail + sticky header chip instead of a per-line wash; single-line anchors are unchanged.
- Threads pane shows a 3-line source-snippet preview per thread, lazily loaded via React Query reusing `read_markdown_file`.
- `repoPath` + `sha` plumbed from `PullRequestScreen` → `ThreadsPane` → `ThreadList` → `ThreadCard` so the snippet has what it needs.

Closes #24.

## Test plan
- [x] `bun test` (14 pass — includes new `sliceSnippet` cases)
- [x] `bun run typecheck`
- [x] `bun run check`
- [ ] Manual smoke: long-range rail + sticky chip + jump action; threads-pane snippet preview; single-line wash still intact; resolve/reopen still desaturates/restores the rail.