### PR TITLE
feat(phase-6): GitHub sync — refresh, mutations, cache, unmapped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-reviewer-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-desktop"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "fix-path-env",
  "markdown-reviewer-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-infra"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "markdown-reviewer-core",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-ipc"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "markdown-reviewer-core",
  "markdown-reviewer-infra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/core", "crates/infra", "crates/ipc"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.81"
 license = "UNLICENSED"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = { workspace = true }
 async-trait = { workspace = true }
 url = { workspace = true }
 time = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/core/src/application/mod.rs
+++ b/crates/core/src/application/mod.rs
@@ -2,3 +2,4 @@ pub mod comments;
 pub mod files;
 pub mod pull_requests;
 pub mod repo_selection;
+pub mod sync;

--- a/crates/core/src/application/sync/cache.rs
+++ b/crates/core/src/application/sync/cache.rs
@@ -1,1 +1,15 @@
-//! Cache hydration read path. Implemented in Task 7.
+//! Read-only hydration helper for the per-PR remote-thread cache.
+
+use crate::domain::RefreshResult;
+use crate::AppResult;
+
+use super::Sync;
+
+pub async fn get_cached(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+) -> AppResult<Option<RefreshResult>> {
+    let row = svc.store.get(repo_path, pr_number).await?;
+    Ok(row.map(|c| c.into_refresh_result()))
+}

--- a/crates/core/src/application/sync/cache.rs
+++ b/crates/core/src/application/sync/cache.rs
@@ -11,5 +11,5 @@ pub async fn get_cached(
     pr_number: u64,
 ) -> AppResult<Option<RefreshResult>> {
     let row = svc.store.get(repo_path, pr_number).await?;
-    Ok(row.map(|c| c.into_refresh_result()))
+    Ok(row.map(crate::ports::remote_threads_store::CachedRefresh::into_refresh_result))
 }

--- a/crates/core/src/application/sync/cache.rs
+++ b/crates/core/src/application/sync/cache.rs
@@ -1,0 +1,1 @@
+//! Cache hydration read path. Implemented in Task 7.

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -1,0 +1,1 @@
+//! Pure anchor-mapping algorithm. Implemented in Task 5.

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -40,18 +40,16 @@ pub async fn map_anchor(
         Ok(text) => text,
         // The original blob is unreachable — treat as unmapped, not as a
         // hard error. The thread is still surfaced under "Unmapped".
-        Err(AppError::FileNotFound { .. }) | Err(_) => {
+        Err(AppError::FileNotFound { .. } | _) => {
             return (None, MappingStatus::FileMissing);
         }
     };
-    let new = match files.read(repo_path, head_sha, &thread.path).await {
-        Ok(text) => text,
-        Err(_) => return (None, MappingStatus::FileMissing),
+    let Ok(new) = files.read(repo_path, head_sha, &thread.path).await else {
+        return (None, MappingStatus::FileMissing);
     };
 
-    let snippet = match extract_lines(&original, start_line, end_line) {
-        Some(s) => s,
-        None => return (None, MappingStatus::LineMoved),
+    let Some(snippet) = extract_lines(&original, start_line, end_line) else {
+        return (None, MappingStatus::LineMoved);
     };
 
     let matches = find_snippet_positions(&new, &snippet);
@@ -104,7 +102,7 @@ fn find_snippet_positions(haystack: &str, snippet: &str) -> Vec<u32> {
     let last_start = hay.len() - needle.len();
     for start in 0..=last_start {
         if hay[start..start + needle.len()] == needle[..] {
-            out.push((start as u32) + 1);
+            out.push(u32::try_from(start).unwrap_or(u32::MAX) + 1);
         }
     }
     out

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -1,1 +1,111 @@
-//! Pure anchor-mapping algorithm. Implemented in Task 5.
+//! Pure anchor-mapping algorithm — decides whether a remote thread can be
+//! anchored to the current head, and why if not.
+
+use crate::domain::{CommentAnchor, MappingStatus, RemoteThread};
+use crate::ports::FileResolver;
+use crate::AppError;
+
+/// Maps a remote thread onto an anchor against `head_sha`. Returns the
+/// anchor + status pair so callers can re-set both on the thread.
+pub async fn map_anchor(
+    thread: &RemoteThread,
+    head_sha: &str,
+    repo_path: &str,
+    files: &dyn FileResolver,
+) -> (Option<CommentAnchor>, MappingStatus) {
+    // 1. GitHub-flagged outdated short-circuit.
+    if thread.is_outdated || thread.line.is_none() {
+        return (
+            None,
+            MappingStatus::Outdated {
+                reason: "github_outdated".into(),
+            },
+        );
+    }
+    let end_line = thread
+        .line
+        .expect("checked is_some() in the guard above");
+    let start_line = thread.start_line.unwrap_or(end_line);
+
+    // 2. Same-commit fast path.
+    if thread.original_commit_id == head_sha {
+        return (Some(build_anchor(start_line, end_line)), MappingStatus::Mapped);
+    }
+
+    // 3. Cross-commit — find the original snippet in the new head.
+    let original = match files
+        .read(repo_path, &thread.original_commit_id, &thread.path)
+        .await
+    {
+        Ok(text) => text,
+        // The original blob is unreachable — treat as unmapped, not as a
+        // hard error. The thread is still surfaced under "Unmapped".
+        Err(AppError::FileNotFound { .. }) | Err(_) => {
+            return (None, MappingStatus::FileMissing);
+        }
+    };
+    let new = match files.read(repo_path, head_sha, &thread.path).await {
+        Ok(text) => text,
+        Err(_) => return (None, MappingStatus::FileMissing),
+    };
+
+    let snippet = match extract_lines(&original, start_line, end_line) {
+        Some(s) => s,
+        None => return (None, MappingStatus::LineMoved),
+    };
+
+    let matches = find_snippet_positions(&new, &snippet);
+    match matches.len() {
+        1 => {
+            let new_start = matches[0];
+            let span = end_line - start_line;
+            (
+                Some(build_anchor(new_start, new_start + span)),
+                MappingStatus::Mapped,
+            )
+        }
+        0 => (None, MappingStatus::LineMoved),
+        _ => (None, MappingStatus::Ambiguous),
+    }
+}
+
+fn build_anchor(start: u32, end: u32) -> CommentAnchor {
+    if start == end {
+        CommentAnchor::SingleLine { line: start }
+    } else {
+        CommentAnchor::LineRange {
+            start_line: start,
+            end_line: end,
+        }
+    }
+}
+
+/// Returns the contiguous lines `[start..=end]` (1-indexed) of `text` joined
+/// by `\n`, or `None` when the range falls outside the file.
+fn extract_lines(text: &str, start: u32, end: u32) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let s = (start as usize).checked_sub(1)?;
+    let e = (end as usize).checked_sub(1)?;
+    if e >= lines.len() {
+        return None;
+    }
+    Some(lines[s..=e].join("\n"))
+}
+
+/// Returns every 1-indexed starting line in `haystack` where `snippet` is
+/// found as a contiguous block of full lines.
+fn find_snippet_positions(haystack: &str, snippet: &str) -> Vec<u32> {
+    let hay: Vec<&str> = haystack.lines().collect();
+    let needle: Vec<&str> = snippet.split('\n').collect();
+    if needle.is_empty() || hay.len() < needle.len() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let last_start = hay.len() - needle.len();
+    for start in 0..=last_start {
+        if hay[start..start + needle.len()] == needle[..] {
+            out.push((start as u32) + 1);
+        }
+    }
+    out
+}

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -42,8 +42,7 @@ pub async fn map_anchor(
     let original_end = thread.original_line;
     let original_start = thread.original_start_line.unwrap_or(original_end);
 
-    let original = match read_blob(files, repo_path, &thread.original_commit_id, &thread.path)
-        .await
+    let original = match read_blob(files, repo_path, &thread.original_commit_id, &thread.path).await
     {
         Ok(text) => text,
         Err(status) => return (None, status),

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -34,22 +34,26 @@ pub async fn map_anchor(
     }
 
     // 3. Cross-commit — find the original snippet in the new head.
-    let original = match files
-        .read(repo_path, &thread.original_commit_id, &thread.path)
+    // Snippet extraction uses the *original* commit's line positions
+    // (`original_line` / `original_start_line`); the current head positions
+    // (`line` / `start_line`) describe where GitHub thinks the line is in
+    // the head — but we have to first read the snippet from the historical
+    // file before searching for it in the new head.
+    let original_end = thread.original_line;
+    let original_start = thread.original_start_line.unwrap_or(original_end);
+
+    let original = match read_blob(files, repo_path, &thread.original_commit_id, &thread.path)
         .await
     {
         Ok(text) => text,
-        // The original blob is unreachable — treat as unmapped, not as a
-        // hard error. The thread is still surfaced under "Unmapped".
-        Err(AppError::FileNotFound { .. } | _) => {
-            return (None, MappingStatus::FileMissing);
-        }
+        Err(status) => return (None, status),
     };
-    let Ok(new) = files.read(repo_path, head_sha, &thread.path).await else {
-        return (None, MappingStatus::FileMissing);
+    let new = match read_blob(files, repo_path, head_sha, &thread.path).await {
+        Ok(text) => text,
+        Err(status) => return (None, status),
     };
 
-    let Some(snippet) = extract_lines(&original, start_line, end_line) else {
+    let Some(snippet) = extract_lines(&original, original_start, original_end) else {
         return (None, MappingStatus::LineMoved);
     };
 
@@ -57,7 +61,7 @@ pub async fn map_anchor(
     match matches.len() {
         1 => {
             let new_start = matches[0];
-            let span = end_line - start_line;
+            let span = original_end - original_start;
             (
                 Some(build_anchor(new_start, new_start + span)),
                 MappingStatus::Mapped,
@@ -65,6 +69,30 @@ pub async fn map_anchor(
         }
         0 => (None, MappingStatus::LineMoved),
         _ => (None, MappingStatus::Ambiguous),
+    }
+}
+
+/// Reads `(sha, path)` for the mapping pipeline. `FileNotFound` is the only
+/// "expected" failure (the file truly doesn't exist at that ref) and maps to
+/// `MappingStatus::FileMissing`. Anything else (IO, gh/git process errors)
+/// is logged and surfaced as `Outdated { reason }` so the thread still
+/// reaches the unmapped panel with a useful message instead of being
+/// silently turned into "file missing".
+async fn read_blob(
+    files: &dyn FileResolver,
+    repo_path: &str,
+    sha: &str,
+    path: &str,
+) -> Result<String, MappingStatus> {
+    match files.read(repo_path, sha, path).await {
+        Ok(text) => Ok(text),
+        Err(AppError::FileNotFound { .. }) => Err(MappingStatus::FileMissing),
+        Err(err) => {
+            tracing::warn!(error = %err, sha, path, "mapping: failed to read blob");
+            Err(MappingStatus::Outdated {
+                reason: format!("read failed: {err}"),
+            })
+        }
     }
 }
 

--- a/crates/core/src/application/sync/mapping.rs
+++ b/crates/core/src/application/sync/mapping.rs
@@ -22,14 +22,15 @@ pub async fn map_anchor(
             },
         );
     }
-    let end_line = thread
-        .line
-        .expect("checked is_some() in the guard above");
+    let end_line = thread.line.expect("checked is_some() in the guard above");
     let start_line = thread.start_line.unwrap_or(end_line);
 
     // 2. Same-commit fast path.
     if thread.original_commit_id == head_sha {
-        return (Some(build_anchor(start_line, end_line)), MappingStatus::Mapped);
+        return (
+            Some(build_anchor(start_line, end_line)),
+            MappingStatus::Mapped,
+        );
     }
 
     // 3. Cross-commit — find the original snippet in the new head.

--- a/crates/core/src/application/sync/mod.rs
+++ b/crates/core/src/application/sync/mod.rs
@@ -1,0 +1,18 @@
+pub mod cache;
+pub mod mapping;
+pub mod mutations;
+pub mod refresh;
+
+use std::sync::Arc;
+
+use crate::ports::{Clock, FileResolver, GhClient, RemoteThreadsStore};
+
+/// Ports bundle for every sync use case. Cloned from `AppState`; every field
+/// is `Arc<dyn …>` so cloning is cheap.
+#[derive(Clone)]
+pub struct Sync {
+    pub gh: Arc<dyn GhClient>,
+    pub store: Arc<dyn RemoteThreadsStore>,
+    pub files: Arc<dyn FileResolver>,
+    pub clock: Arc<dyn Clock>,
+}

--- a/crates/core/src/application/sync/mutations.rs
+++ b/crates/core/src/application/sync/mutations.rs
@@ -1,1 +1,43 @@
-//! Reply/edit/delete/resolve/reopen use cases. Implemented in Task 9.
+//! Reply / edit / delete / resolve / reopen use cases. Each one is a thin
+//! delegation to the `GhClient` port; the only logic here is choosing
+//! between the resolve and unresolve mutations.
+
+use crate::domain::{RemoteComment, RemoteThread};
+use crate::AppResult;
+
+use super::Sync;
+
+pub async fn reply(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+    in_reply_to_comment_id: i64,
+    body: &str,
+) -> AppResult<RemoteComment> {
+    svc.gh
+        .reply_review_comment(repo_path, pr_number, in_reply_to_comment_id, body)
+        .await
+}
+
+pub async fn edit(
+    svc: &Sync,
+    repo_path: &str,
+    comment_id: i64,
+    body: &str,
+) -> AppResult<RemoteComment> {
+    svc.gh
+        .edit_review_comment(repo_path, comment_id, body)
+        .await
+}
+
+pub async fn delete(svc: &Sync, repo_path: &str, comment_id: i64) -> AppResult<()> {
+    svc.gh.delete_review_comment(repo_path, comment_id).await
+}
+
+pub async fn resolve(svc: &Sync, repo_path: &str, thread_id: &str) -> AppResult<RemoteThread> {
+    svc.gh.resolve_review_thread(repo_path, thread_id).await
+}
+
+pub async fn reopen(svc: &Sync, repo_path: &str, thread_id: &str) -> AppResult<RemoteThread> {
+    svc.gh.unresolve_review_thread(repo_path, thread_id).await
+}

--- a/crates/core/src/application/sync/mutations.rs
+++ b/crates/core/src/application/sync/mutations.rs
@@ -1,0 +1,1 @@
+//! Reply/edit/delete/resolve/reopen use cases. Implemented in Task 9.

--- a/crates/core/src/application/sync/refresh.rs
+++ b/crates/core/src/application/sync/refresh.rs
@@ -18,8 +18,7 @@ pub async fn run(
     let mut unmapped: Vec<RemoteThread> = Vec::new();
 
     for mut thread in fetched.threads {
-        let (anchor, status) =
-            map_anchor(&thread, head_sha, repo_path, svc.files.as_ref()).await;
+        let (anchor, status) = map_anchor(&thread, head_sha, repo_path, svc.files.as_ref()).await;
         thread.anchor = anchor;
         thread.mapping_status = status.clone();
         if matches!(status, MappingStatus::Mapped) && thread.anchor.is_some() {
@@ -31,8 +30,14 @@ pub async fn run(
 
     // Deterministic ordering: file path, then start line, then thread id.
     mapped.sort_by(|a, b| {
-        let a_line = a.anchor.as_ref().map_or(0, crate::domain::comment::CommentAnchor::start_line);
-        let b_line = b.anchor.as_ref().map_or(0, crate::domain::comment::CommentAnchor::start_line);
+        let a_line = a
+            .anchor
+            .as_ref()
+            .map_or(0, crate::domain::comment::CommentAnchor::start_line);
+        let b_line = b
+            .anchor
+            .as_ref()
+            .map_or(0, crate::domain::comment::CommentAnchor::start_line);
         a.path
             .cmp(&b.path)
             .then(a_line.cmp(&b_line))

--- a/crates/core/src/application/sync/refresh.rs
+++ b/crates/core/src/application/sync/refresh.rs
@@ -1,0 +1,1 @@
+//! Refresh-and-cache orchestration. Implemented in Task 6.

--- a/crates/core/src/application/sync/refresh.rs
+++ b/crates/core/src/application/sync/refresh.rs
@@ -1,1 +1,66 @@
-//! Refresh-and-cache orchestration. Implemented in Task 6.
+//! Refresh + map + cache pipeline. Always hits the network — caller is
+//! responsible for invalidating React Query / SQLite cache as needed.
+
+use crate::domain::{MappingStatus, RefreshResult, RemoteThread};
+use crate::ports::CachedRefresh;
+use crate::AppResult;
+
+use super::{mapping::map_anchor, Sync};
+
+pub async fn run(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+    head_sha: &str,
+) -> AppResult<RefreshResult> {
+    let fetched = svc.gh.list_review_threads(repo_path, pr_number).await?;
+    let mut mapped: Vec<RemoteThread> = Vec::new();
+    let mut unmapped: Vec<RemoteThread> = Vec::new();
+
+    for mut thread in fetched.threads {
+        let (anchor, status) =
+            map_anchor(&thread, head_sha, repo_path, svc.files.as_ref()).await;
+        thread.anchor = anchor;
+        thread.mapping_status = status.clone();
+        if matches!(status, MappingStatus::Mapped) && thread.anchor.is_some() {
+            mapped.push(thread);
+        } else {
+            unmapped.push(thread);
+        }
+    }
+
+    // Deterministic ordering: file path, then start line, then thread id.
+    mapped.sort_by(|a, b| {
+        let a_line = a.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
+        let b_line = b.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
+        a.path
+            .cmp(&b.path)
+            .then(a_line.cmp(&b_line))
+            .then(a.thread_id.cmp(&b.thread_id))
+    });
+    unmapped.sort_by(|a, b| a.path.cmp(&b.path).then(a.thread_id.cmp(&b.thread_id)));
+
+    let refreshed_at_ms = svc.clock.now_unix_ms();
+    let cached = CachedRefresh {
+        head_sha: head_sha.to_string(),
+        refreshed_at_ms,
+        threads: mapped.clone(),
+        unmapped: unmapped.clone(),
+    };
+    svc.store
+        .put(repo_path, pr_number, head_sha, &cached)
+        .await?;
+
+    if fetched.truncated {
+        tracing::warn!(
+            pr_number,
+            "list_review_threads truncated at 100 threads — pagination not yet implemented"
+        );
+    }
+
+    Ok(RefreshResult {
+        threads: mapped,
+        unmapped,
+        refreshed_at_ms,
+    })
+}

--- a/crates/core/src/application/sync/refresh.rs
+++ b/crates/core/src/application/sync/refresh.rs
@@ -1,5 +1,5 @@
 //! Refresh + map + cache pipeline. Always hits the network — caller is
-//! responsible for invalidating React Query / SQLite cache as needed.
+//! responsible for invalidating React Query / `SQLite` cache as needed.
 
 use crate::domain::{MappingStatus, RefreshResult, RemoteThread};
 use crate::ports::CachedRefresh;
@@ -31,8 +31,8 @@ pub async fn run(
 
     // Deterministic ordering: file path, then start line, then thread id.
     mapped.sort_by(|a, b| {
-        let a_line = a.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
-        let b_line = b.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
+        let a_line = a.anchor.as_ref().map_or(0, crate::domain::comment::CommentAnchor::start_line);
+        let b_line = b.anchor.as_ref().map_or(0, crate::domain::comment::CommentAnchor::start_line);
         a.path
             .cmp(&b.path)
             .then(a_line.cmp(&b_line))

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -2,6 +2,7 @@ pub mod changed_file;
 pub mod comment;
 pub mod file_diff;
 pub mod pull_request;
+pub mod remote_thread;
 pub mod repository;
 pub mod tool_status;
 
@@ -9,5 +10,8 @@ pub use changed_file::{ChangeStatus, ChangedFile};
 pub use comment::{CommentAnchor, CommentState, CommentUpdate, ReviewComment};
 pub use file_diff::{DiffHunk, FileDiff, HunkKind};
 pub use pull_request::{PullRequestDetail, PullRequestState, PullRequestSummary};
+pub use remote_thread::{
+    MappingStatus, RefreshResult, RemoteComment, RemoteThread, ThreadState,
+};
 pub use repository::{RemoteUrl, Repository};
 pub use tool_status::{ToolCheck, ToolStatus};

--- a/crates/core/src/domain/mod.rs
+++ b/crates/core/src/domain/mod.rs
@@ -10,8 +10,6 @@ pub use changed_file::{ChangeStatus, ChangedFile};
 pub use comment::{CommentAnchor, CommentState, CommentUpdate, ReviewComment};
 pub use file_diff::{DiffHunk, FileDiff, HunkKind};
 pub use pull_request::{PullRequestDetail, PullRequestState, PullRequestSummary};
-pub use remote_thread::{
-    MappingStatus, RefreshResult, RemoteComment, RemoteThread, ThreadState,
-};
+pub use remote_thread::{MappingStatus, RefreshResult, RemoteComment, RemoteThread, ThreadState};
 pub use repository::{RemoteUrl, Repository};
 pub use tool_status::{ToolCheck, ToolStatus};

--- a/crates/core/src/domain/remote_thread.rs
+++ b/crates/core/src/domain/remote_thread.rs
@@ -1,0 +1,93 @@
+//! Domain types for remote-originating PR review threads (Phase 6).
+//! GitHub returns line numbers as a mix of `int?` (current position) and
+//! `int!` (original position). We mirror that here so the mapping layer
+//! can decide what to do without re-fetching.
+
+use serde::{Deserialize, Serialize};
+
+use super::CommentAnchor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThreadState {
+    Open,
+    Resolved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum MappingStatus {
+    Mapped,
+    Outdated { reason: String },
+    FileMissing,
+    LineMoved,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteComment {
+    pub comment_id: i64,
+    pub author: String,
+    pub author_avatar_url: Option<String>,
+    pub body: String,
+    /// RFC3339 strings; the UI does its own formatting.
+    pub created_at: String,
+    pub updated_at: String,
+    pub viewer_can_update: bool,
+    pub viewer_can_delete: bool,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteThread {
+    /// GraphQL node id of the review thread. Required by resolve/unresolve.
+    pub thread_id: String,
+    pub path: String,
+    pub original_commit_id: String,
+    pub line: Option<u32>,
+    pub start_line: Option<u32>,
+    pub original_line: u32,
+    pub original_start_line: Option<u32>,
+    pub state: ThreadState,
+    pub is_outdated: bool,
+    pub viewer_can_resolve: bool,
+    pub viewer_can_unresolve: bool,
+    pub comments: Vec<RemoteComment>,
+    pub anchor: Option<CommentAnchor>,
+    pub mapping_status: MappingStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshResult {
+    /// Threads with `mapping_status == Mapped` and `anchor.is_some()`.
+    pub threads: Vec<RemoteThread>,
+    /// Threads we couldn't safely anchor; preserved for the #34 panel.
+    pub unmapped: Vec<RemoteThread>,
+    pub refreshed_at_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapping_status_serializes_with_kind_tag() {
+        let json = serde_json::to_string(&MappingStatus::Outdated {
+            reason: "github_outdated".into(),
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"outdated\""));
+        assert!(json.contains("\"reason\":\"github_outdated\""));
+    }
+
+    #[test]
+    fn thread_state_round_trips() {
+        let raw = serde_json::to_string(&ThreadState::Resolved).unwrap();
+        assert_eq!(raw, "\"resolved\"");
+        let back: ThreadState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back, ThreadState::Resolved);
+    }
+}

--- a/crates/core/src/domain/remote_thread.rs
+++ b/crates/core/src/domain/remote_thread.rs
@@ -15,7 +15,11 @@ pub enum ThreadState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum MappingStatus {
     Mapped,
     Outdated { reason: String },

--- a/crates/core/src/ports/file_resolver.rs
+++ b/crates/core/src/ports/file_resolver.rs
@@ -2,8 +2,17 @@ use async_trait::async_trait;
 
 use crate::AppResult;
 
-/// Reads a file's contents at a specific commit. Implementations may fall
-/// back to `gh` when the ref isn't in the local clone.
+/// Reads a file's contents at a specific commit. Used by the sync layer
+/// to fetch the original snippet a remote thread was anchored to so it
+/// can be re-located in the current head.
+///
+/// Implementations are expected to be transparent about *where* the
+/// content came from — if the local clone doesn't have `sha`, the
+/// adapter may delegate to `gh` (or another fallback) and return the
+/// content as if it were local. Errors propagate (`AppError::FileNotFound`
+/// when the path doesn't exist at the ref, other variants for IO /
+/// process failures); callers handle them rather than ask which source
+/// succeeded.
 #[async_trait]
 pub trait FileResolver: Send + Sync {
     async fn read(&self, repo_path: &str, sha: &str, file_path: &str) -> AppResult<String>;

--- a/crates/core/src/ports/file_resolver.rs
+++ b/crates/core/src/ports/file_resolver.rs
@@ -1,0 +1,10 @@
+use async_trait::async_trait;
+
+use crate::AppResult;
+
+/// Reads a file's contents at a specific commit. Implementations may fall
+/// back to `gh` when the ref isn't in the local clone.
+#[async_trait]
+pub trait FileResolver: Send + Sync {
+    async fn read(&self, repo_path: &str, sha: &str, file_path: &str) -> AppResult<String>;
+}

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::{ChangedFile, PullRequestDetail, PullRequestSummary, RemoteComment, RemoteThread};
+use crate::domain::{
+    ChangedFile, PullRequestDetail, PullRequestSummary, RemoteComment, RemoteThread,
+};
 use crate::AppResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use crate::domain::{ChangedFile, PullRequestDetail, PullRequestSummary};
+use crate::domain::{ChangedFile, PullRequestDetail, PullRequestSummary, RemoteComment, RemoteThread};
 use crate::AppResult;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -54,7 +54,7 @@ pub struct ReviewSubmissionResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FetchedReviewThreads {
-    pub threads: Vec<crate::domain::RemoteThread>,
+    pub threads: Vec<RemoteThread>,
     pub truncated: bool,
 }
 
@@ -123,7 +123,7 @@ pub trait GhClient: Send + Sync {
         pr_number: u64,
         in_reply_to_comment_id: i64,
         body: &str,
-    ) -> AppResult<crate::domain::RemoteComment>;
+    ) -> AppResult<RemoteComment>;
 
     /// `PATCH /repos/{owner}/{repo}/pulls/comments/{id}`.
     async fn edit_review_comment(
@@ -131,7 +131,7 @@ pub trait GhClient: Send + Sync {
         repo_path: &str,
         comment_id: i64,
         body: &str,
-    ) -> AppResult<crate::domain::RemoteComment>;
+    ) -> AppResult<RemoteComment>;
 
     /// `DELETE /repos/{owner}/{repo}/pulls/comments/{id}` — 204 on success.
     async fn delete_review_comment(&self, repo_path: &str, comment_id: i64) -> AppResult<()>;
@@ -142,12 +142,12 @@ pub trait GhClient: Send + Sync {
         &self,
         repo_path: &str,
         thread_id: &str,
-    ) -> AppResult<crate::domain::RemoteThread>;
+    ) -> AppResult<RemoteThread>;
 
     /// GraphQL `unresolveReviewThread(threadId: <node id>)`.
     async fn unresolve_review_thread(
         &self,
         repo_path: &str,
         thread_id: &str,
-    ) -> AppResult<crate::domain::RemoteThread>;
+    ) -> AppResult<RemoteThread>;
 }

--- a/crates/core/src/ports/gh.rs
+++ b/crates/core/src/ports/gh.rs
@@ -48,6 +48,16 @@ pub struct ReviewSubmissionResult {
     pub all_submitted: bool,
 }
 
+/// Raw GraphQL payload as returned by the adapter. The mapping use case is
+/// the only consumer; `truncated` lets the UI surface a banner when we
+/// stopped at the first page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchedReviewThreads {
+    pub threads: Vec<crate::domain::RemoteThread>,
+    pub truncated: bool,
+}
+
 /// Abstracts the GitHub CLI (`gh`).
 #[async_trait]
 pub trait GhClient: Send + Sync {
@@ -92,4 +102,52 @@ pub trait GhClient: Send + Sync {
         head_sha: &str,
         comment: &ReviewCommentInput,
     ) -> AppResult<i64>;
+
+    /// Fetches every review thread on a PR via the GraphQL endpoint
+    /// `repository.pullRequest.reviewThreads(first: 100)`. Includes the
+    /// thread node id (for resolve/unresolve), `isResolved`, `isOutdated`,
+    /// and every comment's `viewerCan*` flags. Truncation past 100 threads
+    /// is logged inside the adapter and surfaced via `truncated == true`.
+    async fn list_review_threads(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+    ) -> AppResult<FetchedReviewThreads>;
+
+    /// Posts a reply to an existing review thread via REST
+    /// `POST /repos/{owner}/{repo}/pulls/{n}/comments` with `in_reply_to`.
+    /// Returns the freshly-created `RemoteComment`.
+    async fn reply_review_comment(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        in_reply_to_comment_id: i64,
+        body: &str,
+    ) -> AppResult<crate::domain::RemoteComment>;
+
+    /// `PATCH /repos/{owner}/{repo}/pulls/comments/{id}`.
+    async fn edit_review_comment(
+        &self,
+        repo_path: &str,
+        comment_id: i64,
+        body: &str,
+    ) -> AppResult<crate::domain::RemoteComment>;
+
+    /// `DELETE /repos/{owner}/{repo}/pulls/comments/{id}` — 204 on success.
+    async fn delete_review_comment(&self, repo_path: &str, comment_id: i64) -> AppResult<()>;
+
+    /// GraphQL `resolveReviewThread(threadId: <node id>)`. Returns the
+    /// updated thread (refetched via `list_review_threads_by_id`).
+    async fn resolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<crate::domain::RemoteThread>;
+
+    /// GraphQL `unresolveReviewThread(threadId: <node id>)`.
+    async fn unresolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<crate::domain::RemoteThread>;
 }

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -1,13 +1,17 @@
 pub mod clock;
 pub mod comments_store;
+pub mod file_resolver;
 pub mod gh;
 pub mod git;
 pub mod recents_store;
+pub mod remote_threads_store;
 
 pub use clock::Clock;
 pub use comments_store::{CommentsStore, NewComment, SubmitOutcome};
+pub use file_resolver::FileResolver;
 pub use gh::{
     GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult, SubmittedReviewComment,
 };
 pub use git::GitClient;
 pub use recents_store::{RecentRepository, RecentsStore};
+pub use remote_threads_store::{CachedRefresh, RemoteThreadsStore};

--- a/crates/core/src/ports/mod.rs
+++ b/crates/core/src/ports/mod.rs
@@ -10,7 +10,8 @@ pub use clock::Clock;
 pub use comments_store::{CommentsStore, NewComment, SubmitOutcome};
 pub use file_resolver::FileResolver;
 pub use gh::{
-    GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult, SubmittedReviewComment,
+    FetchedReviewThreads, GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult,
+    SubmittedReviewComment,
 };
 pub use git::GitClient;
 pub use recents_store::{RecentRepository, RecentsStore};

--- a/crates/core/src/ports/remote_threads_store.rs
+++ b/crates/core/src/ports/remote_threads_store.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{RefreshResult, RemoteThread};
+use crate::AppResult;
+
+/// Snapshot returned by `RemoteThreadsStore::get`. Carries the head sha we
+/// were anchored to so the UI can warn when the cache predates the current
+/// head.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedRefresh {
+    pub head_sha: String,
+    pub refreshed_at_ms: i64,
+    pub threads: Vec<RemoteThread>,
+    pub unmapped: Vec<RemoteThread>,
+}
+
+impl CachedRefresh {
+    pub fn into_refresh_result(self) -> RefreshResult {
+        RefreshResult {
+            threads: self.threads,
+            unmapped: self.unmapped,
+            refreshed_at_ms: self.refreshed_at_ms,
+        }
+    }
+}
+
+#[async_trait]
+pub trait RemoteThreadsStore: Send + Sync {
+    /// Reads the cached payload for `(repo_path, pr_number)`. Returns
+    /// `Ok(None)` when no row exists yet.
+    async fn get(&self, repo_path: &str, pr_number: u64) -> AppResult<Option<CachedRefresh>>;
+
+    /// Writes the cache row, replacing any previous entry for the same
+    /// `(repo_path, pr_number)`. Called from `application::sync::refresh`
+    /// after a successful round-trip.
+    async fn put(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        cached: &CachedRefresh,
+    ) -> AppResult<()>;
+}

--- a/crates/core/tests/comments_submit.rs
+++ b/crates/core/tests/comments_submit.rs
@@ -237,6 +237,47 @@ impl GhClient for ScriptedGh {
             .remove(&comment.local_id)
             .unwrap_or_else(|| Err(AppError::process("comment not scripted")))
     }
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
 }
 
 // ---- clock --------------------------------------------------------------

--- a/crates/core/tests/files.rs
+++ b/crates/core/tests/files.rs
@@ -104,6 +104,47 @@ impl GhClient for FakeGh {
     ) -> AppResult<i64> {
         Err(AppError::process("not implemented in test fake"))
     }
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
 }
 
 fn svc(git_show: Option<String>, gh_fallback: AppResult<String>) -> Files {

--- a/crates/core/tests/pull_requests.rs
+++ b/crates/core/tests/pull_requests.rs
@@ -97,6 +97,47 @@ impl GhClient for FakeGh {
     ) -> AppResult<i64> {
         Err(AppError::process("not implemented in test fake"))
     }
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
 }
 
 fn summary(number: u64, title: &str) -> PullRequestSummary {

--- a/crates/core/tests/repo_selection.rs
+++ b/crates/core/tests/repo_selection.rs
@@ -133,7 +133,8 @@ impl GhClient for FakeGh {
         &self,
         _repo_path: &str,
         _pr_number: u64,
-    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads>
+    {
         unimplemented!("not used in this test")
     }
     async fn reply_review_comment(

--- a/crates/core/tests/repo_selection.rs
+++ b/crates/core/tests/repo_selection.rs
@@ -129,6 +129,51 @@ impl GhClient for FakeGh {
     ) -> markdown_reviewer_core::AppResult<i64> {
         Err(AppError::process("not implemented in test fake"))
     }
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+    ) -> markdown_reviewer_core::AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
 }
 
 #[derive(Default)]

--- a/crates/core/tests/sync_mapping.rs
+++ b/crates/core/tests/sync_mapping.rs
@@ -1,0 +1,153 @@
+//! Use-case tests for `application::sync::mapping::map_anchor`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::mapping::map_anchor;
+use markdown_reviewer_core::domain::{
+    CommentAnchor, MappingStatus, RemoteComment, RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::FileResolver;
+use markdown_reviewer_core::{AppError, AppResult};
+
+/// Resolves files by exact (sha, path) lookup.
+#[derive(Default)]
+struct FakeFiles {
+    files: Mutex<HashMap<(String, String), String>>,
+}
+
+impl FakeFiles {
+    fn insert(&self, sha: &str, path: &str, content: &str) {
+        self.files
+            .lock()
+            .unwrap()
+            .insert((sha.into(), path.into()), content.into());
+    }
+}
+
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _repo_path: &str, sha: &str, path: &str) -> AppResult<String> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(&(sha.into(), path.into()))
+            .cloned()
+            .ok_or_else(|| AppError::FileNotFound {
+                sha: sha.into(),
+                path: path.into(),
+            })
+    }
+}
+
+fn thread_with(
+    original_sha: &str,
+    path: &str,
+    original_line: u32,
+    original_start_line: Option<u32>,
+    line: Option<u32>,
+    is_outdated: bool,
+) -> RemoteThread {
+    RemoteThread {
+        thread_id: "T_kw1".into(),
+        path: path.into(),
+        original_commit_id: original_sha.into(),
+        line,
+        start_line: None,
+        original_line,
+        original_start_line,
+        state: ThreadState::Open,
+        is_outdated,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![RemoteComment {
+            comment_id: 1,
+            author: "alice".into(),
+            author_avatar_url: None,
+            body: "hi".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            viewer_can_update: false,
+            viewer_can_delete: false,
+            html_url: "https://example".into(),
+        }],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn maps_when_head_matches_original_commit() {
+    let files = FakeFiles::default();
+    let t = thread_with("abc", "README.md", 4, None, Some(4), false);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(anchor, Some(CommentAnchor::SingleLine { line: 4 }));
+}
+
+#[tokio::test]
+async fn maps_multi_line_range_when_head_matches() {
+    let files = FakeFiles::default();
+    let mut t = thread_with("abc", "doc.md", 7, Some(4), Some(7), false);
+    t.start_line = Some(4);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(
+        anchor,
+        Some(CommentAnchor::LineRange { start_line: 4, end_line: 7 })
+    );
+}
+
+#[tokio::test]
+async fn outdated_threads_stay_unmapped() {
+    let files = FakeFiles::default();
+    let t = thread_with("abc", "README.md", 4, None, None, true);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert!(matches!(status, MappingStatus::Outdated { .. }));
+}
+
+#[tokio::test]
+async fn snippet_relocated_in_new_head_remaps() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\ngamma\n"); // line 2 = "beta"
+    files.insert("new", "doc.md", "x\ny\nz\nbeta\n"); // line 4 = "beta"
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(anchor, Some(CommentAnchor::SingleLine { line: 4 }));
+}
+
+#[tokio::test]
+async fn snippet_missing_in_new_head_is_line_moved() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    files.insert("new", "doc.md", "alpha\nDELTA\n");
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::LineMoved);
+}
+
+#[tokio::test]
+async fn snippet_appears_twice_is_ambiguous() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    files.insert("new", "doc.md", "beta\nbeta\n");
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::Ambiguous);
+}
+
+#[tokio::test]
+async fn missing_file_at_new_head_is_file_missing() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    // new sha has no "doc.md" entry → resolver returns FileNotFound.
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::FileMissing);
+}

--- a/crates/core/tests/sync_mapping.rs
+++ b/crates/core/tests/sync_mapping.rs
@@ -95,7 +95,10 @@ async fn maps_multi_line_range_when_head_matches() {
     assert_eq!(status, MappingStatus::Mapped);
     assert_eq!(
         anchor,
-        Some(CommentAnchor::LineRange { start_line: 4, end_line: 7 })
+        Some(CommentAnchor::LineRange {
+            start_line: 4,
+            end_line: 7
+        })
     );
 }
 

--- a/crates/core/tests/sync_mutations.rs
+++ b/crates/core/tests/sync_mutations.rs
@@ -1,0 +1,182 @@
+//! Use-case tests for `sync::mutations`. Confirms each call delegates to the
+//! `GhClient` with the right arguments and propagates viewer-denied errors as
+//! `Validation` so the UI can map them to a read-only tooltip.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::{mutations, Sync};
+use markdown_reviewer_core::domain::{
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
+    RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::{
+    CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
+    RemoteThreadsStore, ReviewCommentInput,
+};
+use markdown_reviewer_core::{AppError, AppResult};
+
+#[derive(Default)]
+struct FakeFiles;
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _: &str, _: &str, _: &str) -> AppResult<String> {
+        unimplemented!()
+    }
+}
+
+#[derive(Default)]
+struct FakeStore;
+#[async_trait]
+impl RemoteThreadsStore for FakeStore {
+    async fn get(&self, _: &str, _: u64) -> AppResult<Option<CachedRefresh>> { Ok(None) }
+    async fn put(&self, _: &str, _: u64, _: &str, _: &CachedRefresh) -> AppResult<()> { Ok(()) }
+}
+
+struct FixedClock;
+impl Clock for FixedClock {
+    fn now(&self) -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp(0).unwrap()
+    }
+    fn now_unix_ms(&self) -> i64 { 0 }
+}
+
+#[derive(Default)]
+struct GhSpy {
+    pub reply_calls: Mutex<Vec<(i64, String)>>,
+    pub edit_calls: Mutex<Vec<(i64, String)>>,
+    pub delete_calls: Mutex<Vec<i64>>,
+    pub resolve_calls: Mutex<Vec<String>>,
+    pub unresolve_calls: Mutex<Vec<String>>,
+    pub fail_with: Mutex<Option<AppError>>,
+}
+
+fn sample_comment(id: i64) -> RemoteComment {
+    RemoteComment {
+        comment_id: id,
+        author: "alice".into(),
+        author_avatar_url: None,
+        body: "body".into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        updated_at: "2026-01-01T00:00:00Z".into(),
+        viewer_can_update: true,
+        viewer_can_delete: true,
+        html_url: "https://".into(),
+    }
+}
+
+fn sample_thread(id: &str) -> RemoteThread {
+    RemoteThread {
+        thread_id: id.into(),
+        path: "doc.md".into(),
+        original_commit_id: "abc".into(),
+        line: Some(4),
+        start_line: None,
+        original_line: 4,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![sample_comment(1)],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[async_trait]
+impl GhClient for GhSpy {
+    async fn version(&self) -> AppResult<String> { unimplemented!() }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
+    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
+    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
+    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> { unimplemented!() }
+
+    async fn reply_review_comment(&self, _: &str, _: u64, in_reply: i64, body: &str) -> AppResult<RemoteComment> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.reply_calls.lock().unwrap().push((in_reply, body.into()));
+        Ok(sample_comment(99))
+    }
+    async fn edit_review_comment(&self, _: &str, id: i64, body: &str) -> AppResult<RemoteComment> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.edit_calls.lock().unwrap().push((id, body.into()));
+        Ok(sample_comment(id))
+    }
+    async fn delete_review_comment(&self, _: &str, id: i64) -> AppResult<()> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.delete_calls.lock().unwrap().push(id);
+        Ok(())
+    }
+    async fn resolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.resolve_calls.lock().unwrap().push(id.into());
+        Ok(sample_thread(id))
+    }
+    async fn unresolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.unresolve_calls.lock().unwrap().push(id.into());
+        Ok(sample_thread(id))
+    }
+}
+
+fn svc_with(gh: Arc<GhSpy>) -> Sync {
+    Sync {
+        gh,
+        store: Arc::new(FakeStore),
+        files: Arc::new(FakeFiles),
+        clock: Arc::new(FixedClock),
+    }
+}
+
+#[tokio::test]
+async fn reply_delegates_to_gh() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    let out = mutations::reply(&svc, "/repo", 7, 42, "ok").await.unwrap();
+    assert_eq!(out.comment_id, 99);
+    assert_eq!(gh.reply_calls.lock().unwrap().as_slice(), &[(42, "ok".to_string())]);
+}
+
+#[tokio::test]
+async fn edit_passes_body() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::edit(&svc, "/repo", 11, "new body").await.unwrap();
+    assert_eq!(
+        gh.edit_calls.lock().unwrap().as_slice(),
+        &[(11, "new body".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn delete_passes_id() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::delete(&svc, "/repo", 11).await.unwrap();
+    assert_eq!(gh.delete_calls.lock().unwrap().as_slice(), &[11]);
+}
+
+#[tokio::test]
+async fn resolve_and_reopen_delegate() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::resolve(&svc, "/repo", "PRRT_1").await.unwrap();
+    mutations::reopen(&svc, "/repo", "PRRT_1").await.unwrap();
+    assert_eq!(gh.resolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
+    assert_eq!(gh.unresolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
+}
+
+#[tokio::test]
+async fn viewer_denied_surfaces_as_validation() {
+    let gh = Arc::new(GhSpy::default());
+    *gh.fail_with.lock().unwrap() = Some(AppError::Validation {
+        message: "read-only on GitHub".into(),
+    });
+    let svc = svc_with(gh.clone());
+    let err = mutations::edit(&svc, "/repo", 11, "x").await.unwrap_err();
+    assert!(matches!(err, AppError::Validation { .. }));
+}

--- a/crates/core/tests/sync_mutations.rs
+++ b/crates/core/tests/sync_mutations.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use markdown_reviewer_core::application::sync::{mutations, Sync};
 use markdown_reviewer_core::domain::{
-    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
-    RemoteThread, ThreadState,
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment, RemoteThread,
+    ThreadState,
 };
 use markdown_reviewer_core::ports::{
     CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
@@ -29,8 +29,12 @@ impl FileResolver for FakeFiles {
 struct FakeStore;
 #[async_trait]
 impl RemoteThreadsStore for FakeStore {
-    async fn get(&self, _: &str, _: u64) -> AppResult<Option<CachedRefresh>> { Ok(None) }
-    async fn put(&self, _: &str, _: u64, _: &str, _: &CachedRefresh) -> AppResult<()> { Ok(()) }
+    async fn get(&self, _: &str, _: u64) -> AppResult<Option<CachedRefresh>> {
+        Ok(None)
+    }
+    async fn put(&self, _: &str, _: u64, _: &str, _: &CachedRefresh) -> AppResult<()> {
+        Ok(())
+    }
 }
 
 struct FixedClock;
@@ -38,7 +42,9 @@ impl Clock for FixedClock {
     fn now(&self) -> time::OffsetDateTime {
         time::OffsetDateTime::from_unix_timestamp(0).unwrap()
     }
-    fn now_unix_ms(&self) -> i64 { 0 }
+    fn now_unix_ms(&self) -> i64 {
+        0
+    }
 }
 
 #[derive(Default)]
@@ -86,38 +92,87 @@ fn sample_thread(id: &str) -> RemoteThread {
 
 #[async_trait]
 impl GhClient for GhSpy {
-    async fn version(&self) -> AppResult<String> { unimplemented!() }
-    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
-    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
-    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
-    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
-    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
-    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
-    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
-    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> { unimplemented!() }
+    async fn version(&self) -> AppResult<String> {
+        unimplemented!()
+    }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> {
+        unimplemented!()
+    }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> {
+        unimplemented!()
+    }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> {
+        unimplemented!()
+    }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> {
+        unimplemented!()
+    }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> {
+        unimplemented!()
+    }
+    async fn submit_review_batch(
+        &self,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        unimplemented!()
+    }
+    async fn submit_review_comment(
+        &self,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        unimplemented!()
+    }
+    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> {
+        unimplemented!()
+    }
 
-    async fn reply_review_comment(&self, _: &str, _: u64, in_reply: i64, body: &str) -> AppResult<RemoteComment> {
-        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
-        self.reply_calls.lock().unwrap().push((in_reply, body.into()));
+    async fn reply_review_comment(
+        &self,
+        _: &str,
+        _: u64,
+        in_reply: i64,
+        body: &str,
+    ) -> AppResult<RemoteComment> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() {
+            return Err(err);
+        }
+        self.reply_calls
+            .lock()
+            .unwrap()
+            .push((in_reply, body.into()));
         Ok(sample_comment(99))
     }
     async fn edit_review_comment(&self, _: &str, id: i64, body: &str) -> AppResult<RemoteComment> {
-        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        if let Some(err) = self.fail_with.lock().unwrap().clone() {
+            return Err(err);
+        }
         self.edit_calls.lock().unwrap().push((id, body.into()));
         Ok(sample_comment(id))
     }
     async fn delete_review_comment(&self, _: &str, id: i64) -> AppResult<()> {
-        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        if let Some(err) = self.fail_with.lock().unwrap().clone() {
+            return Err(err);
+        }
         self.delete_calls.lock().unwrap().push(id);
         Ok(())
     }
     async fn resolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
-        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        if let Some(err) = self.fail_with.lock().unwrap().clone() {
+            return Err(err);
+        }
         self.resolve_calls.lock().unwrap().push(id.into());
         Ok(sample_thread(id))
     }
     async fn unresolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
-        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        if let Some(err) = self.fail_with.lock().unwrap().clone() {
+            return Err(err);
+        }
         self.unresolve_calls.lock().unwrap().push(id.into());
         Ok(sample_thread(id))
     }
@@ -138,14 +193,19 @@ async fn reply_delegates_to_gh() {
     let svc = svc_with(gh.clone());
     let out = mutations::reply(&svc, "/repo", 7, 42, "ok").await.unwrap();
     assert_eq!(out.comment_id, 99);
-    assert_eq!(gh.reply_calls.lock().unwrap().as_slice(), &[(42, "ok".to_string())]);
+    assert_eq!(
+        gh.reply_calls.lock().unwrap().as_slice(),
+        &[(42, "ok".to_string())]
+    );
 }
 
 #[tokio::test]
 async fn edit_passes_body() {
     let gh = Arc::new(GhSpy::default());
     let svc = svc_with(gh.clone());
-    mutations::edit(&svc, "/repo", 11, "new body").await.unwrap();
+    mutations::edit(&svc, "/repo", 11, "new body")
+        .await
+        .unwrap();
     assert_eq!(
         gh.edit_calls.lock().unwrap().as_slice(),
         &[(11, "new body".to_string())]
@@ -166,8 +226,14 @@ async fn resolve_and_reopen_delegate() {
     let svc = svc_with(gh.clone());
     mutations::resolve(&svc, "/repo", "PRRT_1").await.unwrap();
     mutations::reopen(&svc, "/repo", "PRRT_1").await.unwrap();
-    assert_eq!(gh.resolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
-    assert_eq!(gh.unresolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
+    assert_eq!(
+        gh.resolve_calls.lock().unwrap().as_slice(),
+        &["PRRT_1".to_string()]
+    );
+    assert_eq!(
+        gh.unresolve_calls.lock().unwrap().as_slice(),
+        &["PRRT_1".to_string()]
+    );
 }
 
 #[tokio::test]

--- a/crates/core/tests/sync_refresh.rs
+++ b/crates/core/tests/sync_refresh.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use markdown_reviewer_core::application::sync::{refresh, Sync};
 use markdown_reviewer_core::domain::{
-    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
-    RemoteThread, ThreadState,
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment, RemoteThread,
+    ThreadState,
 };
 use markdown_reviewer_core::ports::{
     CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
@@ -39,24 +39,68 @@ struct FakeGh {
 
 #[async_trait]
 impl GhClient for FakeGh {
-    async fn version(&self) -> AppResult<String> { unimplemented!() }
-    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
-    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
-    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
-    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
-    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
-    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
-    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
+    async fn version(&self) -> AppResult<String> {
+        unimplemented!()
+    }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> {
+        unimplemented!()
+    }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> {
+        unimplemented!()
+    }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> {
+        unimplemented!()
+    }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> {
+        unimplemented!()
+    }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> {
+        unimplemented!()
+    }
+    async fn submit_review_batch(
+        &self,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &[ReviewCommentInput],
+    ) -> AppResult<Vec<i64>> {
+        unimplemented!()
+    }
+    async fn submit_review_comment(
+        &self,
+        _: &str,
+        _: u64,
+        _: &str,
+        _: &ReviewCommentInput,
+    ) -> AppResult<i64> {
+        unimplemented!()
+    }
 
     async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> {
         Ok(self.payload.lock().unwrap().clone())
     }
 
-    async fn reply_review_comment(&self, _: &str, _: u64, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
-    async fn edit_review_comment(&self, _: &str, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
-    async fn delete_review_comment(&self, _: &str, _: i64) -> AppResult<()> { unimplemented!() }
-    async fn resolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
-    async fn unresolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
+    async fn reply_review_comment(
+        &self,
+        _: &str,
+        _: u64,
+        _: i64,
+        _: &str,
+    ) -> AppResult<RemoteComment> {
+        unimplemented!()
+    }
+    async fn edit_review_comment(&self, _: &str, _: i64, _: &str) -> AppResult<RemoteComment> {
+        unimplemented!()
+    }
+    async fn delete_review_comment(&self, _: &str, _: i64) -> AppResult<()> {
+        unimplemented!()
+    }
+    async fn resolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> {
+        unimplemented!()
+    }
+    async fn unresolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> {
+        unimplemented!()
+    }
 }
 
 #[derive(Default)]
@@ -82,7 +126,9 @@ impl Clock for FixedClock {
     fn now(&self) -> time::OffsetDateTime {
         time::OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap()
     }
-    fn now_unix_ms(&self) -> i64 { 1_700_000_000_000 }
+    fn now_unix_ms(&self) -> i64 {
+        1_700_000_000_000
+    }
 }
 
 fn thread(thread_id: &str, path: &str, line: u32, original_sha: &str) -> RemoteThread {

--- a/crates/core/tests/sync_refresh.rs
+++ b/crates/core/tests/sync_refresh.rs
@@ -1,0 +1,141 @@
+//! End-to-end tests for `application::sync::refresh::run`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::{refresh, Sync};
+use markdown_reviewer_core::domain::{
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
+    RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::{
+    CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
+    RemoteThreadsStore, ReviewCommentInput,
+};
+use markdown_reviewer_core::{AppError, AppResult};
+
+#[derive(Default)]
+struct FakeFiles(Mutex<HashMap<(String, String), String>>);
+
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _: &str, sha: &str, path: &str) -> AppResult<String> {
+        self.0
+            .lock()
+            .unwrap()
+            .get(&(sha.into(), path.into()))
+            .cloned()
+            .ok_or_else(|| AppError::FileNotFound {
+                sha: sha.into(),
+                path: path.into(),
+            })
+    }
+}
+
+struct FakeGh {
+    payload: Mutex<FetchedReviewThreads>,
+}
+
+#[async_trait]
+impl GhClient for FakeGh {
+    async fn version(&self) -> AppResult<String> { unimplemented!() }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
+    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
+    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
+
+    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> {
+        Ok(self.payload.lock().unwrap().clone())
+    }
+
+    async fn reply_review_comment(&self, _: &str, _: u64, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
+    async fn edit_review_comment(&self, _: &str, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
+    async fn delete_review_comment(&self, _: &str, _: i64) -> AppResult<()> { unimplemented!() }
+    async fn resolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
+    async fn unresolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
+}
+
+#[derive(Default)]
+struct FakeStore(Mutex<HashMap<(String, u64), CachedRefresh>>);
+
+#[async_trait]
+impl RemoteThreadsStore for FakeStore {
+    async fn get(&self, repo: &str, pr: u64) -> AppResult<Option<CachedRefresh>> {
+        Ok(self.0.lock().unwrap().get(&(repo.into(), pr)).cloned())
+    }
+    async fn put(&self, repo: &str, pr: u64, _head: &str, cached: &CachedRefresh) -> AppResult<()> {
+        self.0
+            .lock()
+            .unwrap()
+            .insert((repo.into(), pr), cached.clone());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FixedClock;
+impl Clock for FixedClock {
+    fn now(&self) -> time::OffsetDateTime {
+        time::OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap()
+    }
+    fn now_unix_ms(&self) -> i64 { 1_700_000_000_000 }
+}
+
+fn thread(thread_id: &str, path: &str, line: u32, original_sha: &str) -> RemoteThread {
+    RemoteThread {
+        thread_id: thread_id.into(),
+        path: path.into(),
+        original_commit_id: original_sha.into(),
+        line: Some(line),
+        start_line: None,
+        original_line: line,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn partitions_mapped_and_unmapped_and_writes_cache() {
+    let gh = Arc::new(FakeGh {
+        payload: Mutex::new(FetchedReviewThreads {
+            threads: vec![
+                thread("T1", "doc.md", 1, "abc"), // will map (same head)
+                {
+                    let mut t = thread("T2", "missing.md", 1, "abc");
+                    t.is_outdated = true;
+                    t.line = None;
+                    t
+                },
+            ],
+            truncated: false,
+        }),
+    });
+    let files = Arc::new(FakeFiles::default());
+    let store = Arc::new(FakeStore::default());
+    let svc = Sync {
+        gh: gh.clone(),
+        store: store.clone(),
+        files,
+        clock: Arc::new(FixedClock),
+    };
+
+    let result = refresh::run(&svc, "/repo", 7, "abc").await.unwrap();
+    assert_eq!(result.threads.len(), 1);
+    assert_eq!(result.unmapped.len(), 1);
+    assert_eq!(result.refreshed_at_ms, 1_700_000_000_000);
+
+    let cached = store.get("/repo", 7).await.unwrap().expect("cache row");
+    assert_eq!(cached.head_sha, "abc");
+    assert_eq!(cached.threads.len(), 1);
+    assert_eq!(cached.unmapped.len(), 1);
+}

--- a/crates/infra/src/gh/file_resolver.rs
+++ b/crates/infra/src/gh/file_resolver.rs
@@ -19,7 +19,7 @@ impl FileResolver for GitWithGhFallback {
             Ok(Some(text)) => Ok(text),
             // Local clone doesn't have the ref or file — fall back to the GitHub API.
             Ok(None) => self.gh.get_file_content(repo_path, sha, path).await,
-            Err(AppError::FileNotFound { .. }) | Err(AppError::Process { .. }) => {
+            Err(AppError::FileNotFound { .. } | AppError::Process { .. }) => {
                 self.gh.get_file_content(repo_path, sha, path).await
             }
             Err(other) => Err(other),

--- a/crates/infra/src/gh/file_resolver.rs
+++ b/crates/infra/src/gh/file_resolver.rs
@@ -1,0 +1,28 @@
+//! Production `FileResolver`. Tries the local clone first (via `git show`);
+//! falls back to `gh api contents` when the ref isn't in the working tree.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use markdown_reviewer_core::ports::{FileResolver, GhClient, GitClient};
+use markdown_reviewer_core::{AppError, AppResult};
+
+pub struct GitWithGhFallback {
+    pub git: Arc<dyn GitClient>,
+    pub gh: Arc<dyn GhClient>,
+}
+
+#[async_trait]
+impl FileResolver for GitWithGhFallback {
+    async fn read(&self, repo_path: &str, sha: &str, path: &str) -> AppResult<String> {
+        match self.git.show_file(repo_path, sha, path).await {
+            Ok(Some(text)) => Ok(text),
+            // Local clone doesn't have the ref or file — fall back to the GitHub API.
+            Ok(None) => self.gh.get_file_content(repo_path, sha, path).await,
+            Err(AppError::FileNotFound { .. }) | Err(AppError::Process { .. }) => {
+                self.gh.get_file_content(repo_path, sha, path).await
+            }
+            Err(other) => Err(other),
+        }
+    }
+}

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -504,6 +504,11 @@ impl GhClient for GhCli {
         in_reply_to_comment_id: i64,
         body: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        tracing::info!(
+            in_reply_to = in_reply_to_comment_id,
+            body_len = body.len(),
+            "reply_review_comment"
+        );
         let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments");
         let in_reply_arg = format!("in_reply_to={in_reply_to_comment_id}");
         let body_arg = format!("body={body}");
@@ -518,6 +523,12 @@ impl GhClient for GhCli {
             &body_arg,
         ];
         let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        tracing::info!(
+            status = out.status,
+            stdout_preview = %out.stdout.chars().take(200).collect::<String>(),
+            stderr = %redact(&out.stderr),
+            "reply_review_comment result"
+        );
         if !out.ok() {
             return Err(classify_rest_error(&out.stderr));
         }
@@ -643,6 +654,7 @@ fn parse_review_comment(raw: &str) -> AppResult<markdown_reviewer_core::domain::
 }
 
 async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -> AppResult<()> {
+    tracing::info!(thread_id, "run_thread_mutation start");
     let query_arg = format!("query={mutation}");
     let id_arg = format!("id={thread_id}");
     let args = vec![
@@ -654,6 +666,12 @@ async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -
         &id_arg,
     ];
     let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+    tracing::info!(
+        status = out.status,
+        stdout = %out.stdout.trim(),
+        stderr = %redact(&out.stderr),
+        "run_thread_mutation result"
+    );
     if !out.ok() {
         return Err(classify_rest_error(&out.stderr));
     }

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -470,10 +470,31 @@ impl GhClient for GhCli {
 
     async fn list_review_threads(
         &self,
-        _repo_path: &str,
-        _pr_number: u64,
+        repo_path: &str,
+        pr_number: u64,
     ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
-        unimplemented!("Phase 6 — implemented in later task")
+        let query_arg = format!("query={}", crate::gh::review_threads::REVIEW_THREADS_QUERY);
+        let pr_arg = format!("-F=pr={pr_number}");
+        // gh fills `{owner}` / `{repo}` from the cwd when we use `-F owner={owner}` style,
+        // but graphql variables need explicit values. `gh api graphql` accepts
+        // `-F owner=:owner -F name=:repo` shortcuts that expand against the
+        // current repo — use them to avoid a second round-trip.
+        let args: Vec<&str> = vec![
+            "api",
+            "graphql",
+            "-F",
+            "owner=:owner",
+            "-F",
+            "name=:repo",
+            &pr_arg,
+            "--raw-field",
+            &query_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), PR_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, Some(pr_number)));
+        }
+        crate::gh::review_threads::parse_review_threads(out.stdout.trim())
     }
 
     async fn reply_review_comment(

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -532,14 +532,7 @@ impl GhClient for GhCli {
     ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
         let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}");
         let body_arg = format!("body={body}");
-        let args = vec![
-            "api",
-            "-X",
-            "PATCH",
-            &endpoint,
-            "--raw-field",
-            &body_arg,
-        ];
+        let args = vec!["api", "-X", "PATCH", &endpoint, "--raw-field", &body_arg];
         let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
         if !out.ok() {
             return Err(classify_rest_error(&out.stderr));
@@ -603,9 +596,7 @@ fn classify_rest_error(stderr: &str) -> AppError {
     AppError::process(redact(stderr.trim()))
 }
 
-fn parse_review_comment(
-    raw: &str,
-) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+fn parse_review_comment(raw: &str) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
     #[derive(serde::Deserialize)]
     struct UserField {
         login: String,
@@ -651,11 +642,7 @@ fn parse_review_comment(
     })
 }
 
-async fn run_thread_mutation(
-    repo_path: &str,
-    thread_id: &str,
-    mutation: &str,
-) -> AppResult<()> {
+async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -> AppResult<()> {
     let query_arg = format!("query={mutation}");
     let id_arg = format!("id={thread_id}");
     let args = vec![
@@ -733,8 +720,7 @@ async fn refetch_thread(
             }
         }
     });
-    let fetched =
-        crate::gh::review_threads::parse_review_threads(&wrapped.to_string())?;
+    let fetched = crate::gh::review_threads::parse_review_threads(&wrapped.to_string())?;
     let mut thread = fetched
         .threads
         .into_iter()

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -474,11 +474,13 @@ impl GhClient for GhCli {
         pr_number: u64,
     ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
         let query_arg = format!("query={}", crate::gh::review_threads::REVIEW_THREADS_QUERY);
-        let pr_arg = format!("-F=pr={pr_number}");
+        let pr_arg = format!("pr={pr_number}");
         // gh fills `{owner}` / `{repo}` from the cwd when we use `-F owner={owner}` style,
         // but graphql variables need explicit values. `gh api graphql` accepts
         // `-F owner=:owner -F name=:repo` shortcuts that expand against the
-        // current repo — use them to avoid a second round-trip.
+        // current repo — use them to avoid a second round-trip. Flags and
+        // values stay as separate argv entries (`-F` then `pr=N`) — the
+        // `-F=pr=N` single-token form isn't reliably accepted by gh.
         let args: Vec<&str> = vec![
             "api",
             "graphql",
@@ -486,6 +488,7 @@ impl GhClient for GhCli {
             "owner=:owner",
             "-F",
             "name=:repo",
+            "-F",
             &pr_arg,
             "--raw-field",
             &query_arg,
@@ -504,11 +507,6 @@ impl GhClient for GhCli {
         in_reply_to_comment_id: i64,
         body: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
-        tracing::info!(
-            in_reply_to = in_reply_to_comment_id,
-            body_len = body.len(),
-            "reply_review_comment"
-        );
         let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments");
         let in_reply_arg = format!("in_reply_to={in_reply_to_comment_id}");
         let body_arg = format!("body={body}");
@@ -523,12 +521,6 @@ impl GhClient for GhCli {
             &body_arg,
         ];
         let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
-        tracing::info!(
-            status = out.status,
-            stdout_preview = %out.stdout.chars().take(200).collect::<String>(),
-            stderr = %redact(&out.stderr),
-            "reply_review_comment result"
-        );
         if !out.ok() {
             return Err(classify_rest_error(&out.stderr));
         }
@@ -654,7 +646,6 @@ fn parse_review_comment(raw: &str) -> AppResult<markdown_reviewer_core::domain::
 }
 
 async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -> AppResult<()> {
-    tracing::info!(thread_id, "run_thread_mutation start");
     let query_arg = format!("query={mutation}");
     let id_arg = format!("id={thread_id}");
     let args = vec![
@@ -666,12 +657,6 @@ async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -
         &id_arg,
     ];
     let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
-    tracing::info!(
-        status = out.status,
-        stdout = %out.stdout.trim(),
-        stderr = %redact(&out.stderr),
-        "run_thread_mutation result"
-    );
     if !out.ok() {
         return Err(classify_rest_error(&out.stderr));
     }

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -624,6 +624,12 @@ fn parse_review_comment(
     }
     let c: RawComment = serde_json::from_str(raw)
         .map_err(|e| AppError::process(format!("gh api comments: invalid JSON: {e}")))?;
+    // The REST POST/PATCH/reply responses don't carry `viewerCanUpdate`, so we
+    // infer it from `author_association`. This over-reports for non-author
+    // team members, but in practice this parser only runs against responses
+    // to OUR mutations (reply/edit), where the viewer IS the author and the
+    // permission is always true. The next refresh round-trip pulls the
+    // authoritative `viewerCan*` flags via GraphQL `list_review_threads`.
     let viewer_can_update = matches!(
         c.author_association.as_deref(),
         Some("OWNER" | "MEMBER" | "COLLABORATOR" | "CONTRIBUTOR")
@@ -711,6 +717,10 @@ async fn refetch_thread(
     }
     let env: NodeEnvelope = serde_json::from_str(out.stdout.trim())
         .map_err(|e| AppError::process(format!("gh graphql node: {e}")))?;
+    // Wrap the single node in the multi-thread envelope so we can reuse
+    // `parse_review_threads` instead of duplicating its serde scaffolding.
+    // If that parser grows assumptions specific to the list query, this
+    // call-site is the one to revisit.
     let wrapped = serde_json::json!({
         "data": {
             "repository": {

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -467,6 +467,53 @@ impl GhClient for GhCli {
         })?;
         Ok(id)
     }
+
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
+
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
+
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
+
+    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
+
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
+
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("Phase 6 — implemented in later task")
+    }
 }
 
 /// Stable-lifetime owned strings used to assemble each batch-comment entry's

--- a/crates/infra/src/gh/gh_cli.rs
+++ b/crates/infra/src/gh/gh_cli.rs
@@ -499,42 +499,239 @@ impl GhClient for GhCli {
 
     async fn reply_review_comment(
         &self,
-        _repo_path: &str,
-        _pr_number: u64,
-        _in_reply_to_comment_id: i64,
-        _body: &str,
+        repo_path: &str,
+        pr_number: u64,
+        in_reply_to_comment_id: i64,
+        body: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
-        unimplemented!("Phase 6 — implemented in later task")
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments");
+        let in_reply_arg = format!("in_reply_to={in_reply_to_comment_id}");
+        let body_arg = format!("body={body}");
+        let args = vec![
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-F",
+            &in_reply_arg,
+            "--raw-field",
+            &body_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        parse_review_comment(out.stdout.trim())
     }
 
     async fn edit_review_comment(
         &self,
-        _repo_path: &str,
-        _comment_id: i64,
-        _body: &str,
+        repo_path: &str,
+        comment_id: i64,
+        body: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
-        unimplemented!("Phase 6 — implemented in later task")
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}");
+        let body_arg = format!("body={body}");
+        let args = vec![
+            "api",
+            "-X",
+            "PATCH",
+            &endpoint,
+            "--raw-field",
+            &body_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        parse_review_comment(out.stdout.trim())
     }
 
-    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
-        unimplemented!("Phase 6 — implemented in later task")
+    async fn delete_review_comment(&self, repo_path: &str, comment_id: i64) -> AppResult<()> {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}");
+        let args = vec!["api", "-X", "DELETE", &endpoint];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        Ok(())
     }
 
     async fn resolve_review_thread(
         &self,
-        _repo_path: &str,
-        _thread_id: &str,
+        repo_path: &str,
+        thread_id: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
-        unimplemented!("Phase 6 — implemented in later task")
+        run_thread_mutation(
+            repo_path,
+            thread_id,
+            "mutation($id: ID!) { resolveReviewThread(input: { threadId: $id }) { thread { id } } }",
+        )
+        .await?;
+        refetch_thread(repo_path, thread_id).await
     }
 
     async fn unresolve_review_thread(
         &self,
-        _repo_path: &str,
-        _thread_id: &str,
+        repo_path: &str,
+        thread_id: &str,
     ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
-        unimplemented!("Phase 6 — implemented in later task")
+        run_thread_mutation(
+            repo_path,
+            thread_id,
+            "mutation($id: ID!) { unresolveReviewThread(input: { threadId: $id }) { thread { id } } }",
+        )
+        .await?;
+        refetch_thread(repo_path, thread_id).await
     }
+}
+
+fn classify_rest_error(stderr: &str) -> AppError {
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("status code: 403")
+        || lower.contains("must have write access")
+        || lower.contains("must be the author")
+    {
+        return AppError::validation("read-only on GitHub");
+    }
+    if lower.contains("status code: 404") || lower.contains("not found") {
+        return AppError::validation("upstream thread no longer exists");
+    }
+    if lower.contains("authentication required") || lower.contains("gh auth login") {
+        return AppError::GhNotAuthenticated;
+    }
+    AppError::process(redact(stderr.trim()))
+}
+
+fn parse_review_comment(
+    raw: &str,
+) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+    #[derive(serde::Deserialize)]
+    struct UserField {
+        login: String,
+        avatar_url: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct RawComment {
+        id: i64,
+        user: Option<UserField>,
+        body: String,
+        created_at: String,
+        updated_at: String,
+        html_url: String,
+        #[serde(default)]
+        author_association: Option<String>,
+    }
+    let c: RawComment = serde_json::from_str(raw)
+        .map_err(|e| AppError::process(format!("gh api comments: invalid JSON: {e}")))?;
+    let viewer_can_update = matches!(
+        c.author_association.as_deref(),
+        Some("OWNER" | "MEMBER" | "COLLABORATOR" | "CONTRIBUTOR")
+    );
+    let (author, avatar) = match c.user {
+        Some(u) => (u.login, u.avatar_url),
+        None => ("ghost".into(), None),
+    };
+    Ok(markdown_reviewer_core::domain::RemoteComment {
+        comment_id: c.id,
+        author,
+        author_avatar_url: avatar,
+        body: c.body,
+        created_at: c.created_at,
+        updated_at: c.updated_at,
+        viewer_can_update,
+        viewer_can_delete: viewer_can_update,
+        html_url: c.html_url,
+    })
+}
+
+async fn run_thread_mutation(
+    repo_path: &str,
+    thread_id: &str,
+    mutation: &str,
+) -> AppResult<()> {
+    let query_arg = format!("query={mutation}");
+    let id_arg = format!("id={thread_id}");
+    let args = vec![
+        "api",
+        "graphql",
+        "--raw-field",
+        &query_arg,
+        "--raw-field",
+        &id_arg,
+    ];
+    let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+    if !out.ok() {
+        return Err(classify_rest_error(&out.stderr));
+    }
+    if out.stdout.contains("\"errors\":") {
+        return Err(AppError::process(format!(
+            "graphql mutation failed: {}",
+            redact(out.stdout.trim())
+        )));
+    }
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct NodeEnvelope {
+    data: NodeData,
+}
+#[derive(serde::Deserialize)]
+struct NodeData {
+    node: serde_json::Value,
+}
+
+async fn refetch_thread(
+    repo_path: &str,
+    thread_id: &str,
+) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+    use markdown_reviewer_core::domain::MappingStatus;
+    let single_query = r"query($id: ID!) { node(id: $id) { ... on PullRequestReviewThread {
+            id path originalLine originalStartLine line startLine
+            isOutdated isResolved viewerCanResolve viewerCanUnresolve
+            comments(first: 100) { nodes {
+                databaseId author { login avatarUrl } body createdAt updatedAt
+                viewerCanUpdate viewerCanDelete url originalCommit { oid }
+            } }
+        } } }";
+    let q_arg = format!("query={single_query}");
+    let id_arg = format!("id={thread_id}");
+    let args = vec![
+        "api",
+        "graphql",
+        "--raw-field",
+        &q_arg,
+        "--raw-field",
+        &id_arg,
+    ];
+    let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+    if !out.ok() {
+        return Err(classify_rest_error(&out.stderr));
+    }
+    let env: NodeEnvelope = serde_json::from_str(out.stdout.trim())
+        .map_err(|e| AppError::process(format!("gh graphql node: {e}")))?;
+    let wrapped = serde_json::json!({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [env.data.node]
+                    }
+                }
+            }
+        }
+    });
+    let fetched =
+        crate::gh::review_threads::parse_review_threads(&wrapped.to_string())?;
+    let mut thread = fetched
+        .threads
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::process("graphql node returned no thread"))?;
+    thread.mapping_status = MappingStatus::Mapped;
+    Ok(thread)
 }
 
 /// Stable-lifetime owned strings used to assemble each batch-comment entry's

--- a/crates/infra/src/gh/mod.rs
+++ b/crates/infra/src/gh/mod.rs
@@ -1,4 +1,6 @@
+pub mod file_resolver;
 pub mod gh_cli;
 pub mod review_threads;
 
+pub use file_resolver::GitWithGhFallback;
 pub use gh_cli::GhCli;

--- a/crates/infra/src/gh/mod.rs
+++ b/crates/infra/src/gh/mod.rs
@@ -1,3 +1,4 @@
-mod gh_cli;
+pub mod gh_cli;
+pub mod review_threads;
 
 pub use gh_cli::GhCli;

--- a/crates/infra/src/gh/review_threads.rs
+++ b/crates/infra/src/gh/review_threads.rs
@@ -2,9 +2,7 @@
 //! `gh api graphql -F query=…`. Stays self-contained so a fixture-based
 //! test can run without going through the gh CLI.
 
-use markdown_reviewer_core::domain::{
-    MappingStatus, RemoteComment, RemoteThread, ThreadState,
-};
+use markdown_reviewer_core::domain::{MappingStatus, RemoteComment, RemoteThread, ThreadState};
 use markdown_reviewer_core::ports::FetchedReviewThreads;
 use markdown_reviewer_core::{AppError, AppResult};
 use serde::Deserialize;

--- a/crates/infra/src/gh/review_threads.rs
+++ b/crates/infra/src/gh/review_threads.rs
@@ -1,0 +1,218 @@
+//! Parses the GraphQL `reviewThreads` payload returned by
+//! `gh api graphql -F query=…`. Stays self-contained so a fixture-based
+//! test can run without going through the gh CLI.
+
+use markdown_reviewer_core::domain::{
+    MappingStatus, RemoteComment, RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::FetchedReviewThreads;
+use markdown_reviewer_core::{AppError, AppResult};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Envelope {
+    data: Data,
+}
+
+#[derive(Debug, Deserialize)]
+struct Data {
+    repository: Repo,
+}
+
+#[derive(Debug, Deserialize)]
+struct Repo {
+    #[serde(rename = "pullRequest")]
+    pull_request: Pr,
+}
+
+#[derive(Debug, Deserialize)]
+struct Pr {
+    #[serde(rename = "reviewThreads")]
+    review_threads: Threads,
+}
+
+#[derive(Debug, Deserialize)]
+struct Threads {
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+    nodes: Vec<ThreadNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadNode {
+    id: String,
+    path: String,
+    #[serde(rename = "originalLine")]
+    original_line: u32,
+    #[serde(rename = "originalStartLine")]
+    original_start_line: Option<u32>,
+    line: Option<u32>,
+    #[serde(rename = "startLine")]
+    start_line: Option<u32>,
+    #[serde(rename = "isOutdated")]
+    is_outdated: bool,
+    #[serde(rename = "isResolved")]
+    is_resolved: bool,
+    #[serde(rename = "viewerCanResolve")]
+    viewer_can_resolve: bool,
+    #[serde(rename = "viewerCanUnresolve")]
+    viewer_can_unresolve: bool,
+    comments: Comments,
+}
+
+#[derive(Debug, Deserialize)]
+struct Comments {
+    nodes: Vec<CommentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommentNode {
+    #[serde(rename = "databaseId")]
+    database_id: i64,
+    author: Option<Author>,
+    body: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    #[serde(rename = "viewerCanUpdate")]
+    viewer_can_update: bool,
+    #[serde(rename = "viewerCanDelete")]
+    viewer_can_delete: bool,
+    url: String,
+    #[serde(rename = "originalCommit")]
+    original_commit: Option<Commit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Author {
+    login: String,
+    #[serde(rename = "avatarUrl")]
+    avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Commit {
+    oid: String,
+}
+
+pub fn parse_review_threads(raw: &str) -> AppResult<FetchedReviewThreads> {
+    let env: Envelope = serde_json::from_str(raw)
+        .map_err(|e| AppError::process(format!("gh api graphql reviewThreads: {e}")))?;
+    let truncated = env
+        .data
+        .repository
+        .pull_request
+        .review_threads
+        .page_info
+        .has_next_page;
+    let threads = env
+        .data
+        .repository
+        .pull_request
+        .review_threads
+        .nodes
+        .into_iter()
+        .map(into_thread)
+        .collect();
+    Ok(FetchedReviewThreads { threads, truncated })
+}
+
+fn into_thread(n: ThreadNode) -> RemoteThread {
+    // Original commit is taken from the *first* comment's `originalCommit.oid`
+    // — GraphQL doesn't expose it directly on the thread. Empty when missing
+    // (degenerate payload); the mapping layer will fall through to LineMoved.
+    let original_commit_id = n
+        .comments
+        .nodes
+        .first()
+        .and_then(|c| c.original_commit.as_ref())
+        .map(|c| c.oid.clone())
+        .unwrap_or_default();
+
+    let comments = n.comments.nodes.into_iter().map(into_comment).collect();
+    RemoteThread {
+        thread_id: n.id,
+        path: n.path,
+        original_commit_id,
+        line: n.line,
+        start_line: n.start_line,
+        original_line: n.original_line,
+        original_start_line: n.original_start_line,
+        state: if n.is_resolved {
+            ThreadState::Resolved
+        } else {
+            ThreadState::Open
+        },
+        is_outdated: n.is_outdated,
+        viewer_can_resolve: n.viewer_can_resolve,
+        viewer_can_unresolve: n.viewer_can_unresolve,
+        comments,
+        anchor: None,
+        mapping_status: MappingStatus::Mapped, // overwritten by map_anchor
+    }
+}
+
+fn into_comment(c: CommentNode) -> RemoteComment {
+    let (author, avatar) = match c.author {
+        Some(a) => (a.login, a.avatar_url),
+        None => ("ghost".into(), None),
+    };
+    RemoteComment {
+        comment_id: c.database_id,
+        author,
+        author_avatar_url: avatar,
+        body: c.body,
+        created_at: c.created_at,
+        updated_at: c.updated_at,
+        viewer_can_update: c.viewer_can_update,
+        viewer_can_delete: c.viewer_can_delete,
+        html_url: c.url,
+    }
+}
+
+/// Static GraphQL query used by both `list_review_threads` and the
+/// post-mutation refetch helpers. Variables: `$owner: String!`,
+/// `$name: String!`, `$pr: Int!`.
+pub const REVIEW_THREADS_QUERY: &str = r#"
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          path
+          originalLine
+          originalStartLine
+          line
+          startLine
+          isOutdated
+          isResolved
+          viewerCanResolve
+          viewerCanUnresolve
+          comments(first: 100) {
+            nodes {
+              databaseId
+              author { login avatarUrl }
+              body
+              createdAt
+              updatedAt
+              viewerCanUpdate
+              viewerCanDelete
+              url
+              originalCommit { oid }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;

--- a/crates/infra/src/gh/review_threads.rs
+++ b/crates/infra/src/gh/review_threads.rs
@@ -44,6 +44,7 @@ struct PageInfo {
     has_next_page: bool,
 }
 
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Deserialize)]
 struct ThreadNode {
     id: String,
@@ -180,7 +181,7 @@ fn into_comment(c: CommentNode) -> RemoteComment {
 /// Static GraphQL query used by both `list_review_threads` and the
 /// post-mutation refetch helpers. Variables: `$owner: String!`,
 /// `$name: String!`, `$pr: Int!`.
-pub const REVIEW_THREADS_QUERY: &str = r#"
+pub const REVIEW_THREADS_QUERY: &str = r"
 query($owner: String!, $name: String!, $pr: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $pr) {
@@ -215,4 +216,4 @@ query($owner: String!, $name: String!, $pr: Int!) {
     }
   }
 }
-"#;
+";

--- a/crates/infra/src/lib.rs
+++ b/crates/infra/src/lib.rs
@@ -8,5 +8,6 @@ pub mod sqlite;
 
 pub use clock::SystemClock;
 pub use gh::GhCli;
+pub use gh::GitWithGhFallback;
 pub use git::GitCli;
 pub use paths::Paths;

--- a/crates/infra/src/sqlite/connection.rs
+++ b/crates/infra/src/sqlite/connection.rs
@@ -19,6 +19,10 @@ const MIGRATIONS: &[(&str, &str)] = &[
         "0003_local_comments",
         include_str!("migrations/0003_local_comments.sql"),
     ),
+    (
+        "0004_remote_threads_cache",
+        include_str!("migrations/0004_remote_threads_cache.sql"),
+    ),
 ];
 
 pub fn open_and_migrate(path: &Path) -> AppResult<Db> {

--- a/crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql
+++ b/crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS remote_threads_cache (
+    repo_path TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    refreshed_at_ms INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    PRIMARY KEY (repo_path, pr_number)
+);

--- a/crates/infra/src/sqlite/mod.rs
+++ b/crates/infra/src/sqlite/mod.rs
@@ -1,7 +1,9 @@
 pub mod comments_store;
 pub mod connection;
 pub mod recents_store;
+pub mod remote_threads_store;
 
 pub use comments_store::SqliteCommentsStore;
 pub use connection::{open_and_migrate, Db};
 pub use recents_store::SqliteRecentsStore;
+pub use remote_threads_store::SqliteRemoteThreadsStore;

--- a/crates/infra/src/sqlite/remote_threads_store.rs
+++ b/crates/infra/src/sqlite/remote_threads_store.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use markdown_reviewer_core::ports::{CachedRefresh, RemoteThreadsStore};
+use markdown_reviewer_core::{AppError, AppResult};
+use rusqlite::params;
+
+use super::Db;
+
+pub struct SqliteRemoteThreadsStore {
+    db: Db,
+}
+
+impl SqliteRemoteThreadsStore {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Payload {
+    threads: Vec<markdown_reviewer_core::domain::RemoteThread>,
+    unmapped: Vec<markdown_reviewer_core::domain::RemoteThread>,
+}
+
+#[async_trait]
+impl RemoteThreadsStore for SqliteRemoteThreadsStore {
+    async fn get(&self, repo_path: &str, pr_number: u64) -> AppResult<Option<CachedRefresh>> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        let repo = repo_path.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let row = conn
+                .query_row(
+                    "SELECT head_sha, refreshed_at_ms, payload_json \
+                     FROM remote_threads_cache \
+                     WHERE repo_path = ?1 AND pr_number = ?2",
+                    params![repo, pr_signed],
+                    |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, i64>(1)?,
+                            r.get::<_, String>(2)?,
+                        ))
+                    },
+                )
+                .ok();
+            let Some((head_sha, refreshed_at_ms, payload_json)) = row else {
+                return Ok::<_, AppError>(None);
+            };
+            let payload: Payload = serde_json::from_str(&payload_json)
+                .map_err(|e| AppError::db(format!("cache payload corrupt: {e}")))?;
+            Ok(Some(CachedRefresh {
+                head_sha,
+                refreshed_at_ms,
+                threads: payload.threads,
+                unmapped: payload.unmapped,
+            }))
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn put(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        cached: &CachedRefresh,
+    ) -> AppResult<()> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        let repo = repo_path.to_string();
+        let head = head_sha.to_string();
+        let refreshed = cached.refreshed_at_ms;
+        let payload = Payload {
+            threads: cached.threads.clone(),
+            unmapped: cached.unmapped.clone(),
+        };
+        let json = serde_json::to_string(&payload).expect("Payload always serializes");
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            conn.execute(
+                "INSERT INTO remote_threads_cache(repo_path, pr_number, head_sha, refreshed_at_ms, payload_json) \
+                 VALUES (?1, ?2, ?3, ?4, ?5) \
+                 ON CONFLICT(repo_path, pr_number) DO UPDATE SET \
+                    head_sha = excluded.head_sha, \
+                    refreshed_at_ms = excluded.refreshed_at_ms, \
+                    payload_json = excluded.payload_json",
+                params![repo, pr_signed, head, refreshed, json],
+            )
+            .map_err(AppError::db)?;
+            Ok(())
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+}

--- a/crates/infra/src/sqlite/remote_threads_store.rs
+++ b/crates/infra/src/sqlite/remote_threads_store.rs
@@ -29,21 +29,27 @@ impl RemoteThreadsStore for SqliteRemoteThreadsStore {
         let repo = repo_path.to_string();
         tokio::task::spawn_blocking(move || {
             let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
-            let row = conn
-                .query_row(
-                    "SELECT head_sha, refreshed_at_ms, payload_json \
+            // Match `QueryReturnedNoRows` explicitly — any other rusqlite
+            // error (schema mismatch, locked DB, corruption) propagates as
+            // `AppError::Db` so the UI can show something useful instead
+            // of silently treating it as an empty cache.
+            let row = match conn.query_row(
+                "SELECT head_sha, refreshed_at_ms, payload_json \
                      FROM remote_threads_cache \
                      WHERE repo_path = ?1 AND pr_number = ?2",
-                    params![repo, pr_signed],
-                    |r| {
-                        Ok((
-                            r.get::<_, String>(0)?,
-                            r.get::<_, i64>(1)?,
-                            r.get::<_, String>(2)?,
-                        ))
-                    },
-                )
-                .ok();
+                params![repo, pr_signed],
+                |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, i64>(1)?,
+                        r.get::<_, String>(2)?,
+                    ))
+                },
+            ) {
+                Ok(row) => Some(row),
+                Err(rusqlite::Error::QueryReturnedNoRows) => None,
+                Err(e) => return Err(AppError::db(e)),
+            };
             let Some((head_sha, refreshed_at_ms, payload_json)) = row else {
                 return Ok::<_, AppError>(None);
             };
@@ -76,7 +82,8 @@ impl RemoteThreadsStore for SqliteRemoteThreadsStore {
             threads: cached.threads.clone(),
             unmapped: cached.unmapped.clone(),
         };
-        let json = serde_json::to_string(&payload).expect("Payload always serializes");
+        let json = serde_json::to_string(&payload)
+            .map_err(|e| AppError::db(format!("cache payload serialize: {e}")))?;
         tokio::task::spawn_blocking(move || {
             let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
             conn.execute(

--- a/crates/infra/tests/fixtures/gh/review-threads-basic.json
+++ b/crates/infra/tests/fixtures/gh/review-threads-basic.json
@@ -1,0 +1,67 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": [
+            {
+              "id": "PRRT_kwDOA1",
+              "path": "docs/intro.md",
+              "originalLine": 4,
+              "originalStartLine": null,
+              "line": 4,
+              "startLine": null,
+              "isOutdated": false,
+              "isResolved": false,
+              "viewerCanResolve": true,
+              "viewerCanUnresolve": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 1001,
+                    "author": { "login": "alice", "avatarUrl": "https://avatars/alice" },
+                    "body": "Typo here",
+                    "createdAt": "2026-05-01T10:00:00Z",
+                    "updatedAt": "2026-05-01T10:00:00Z",
+                    "viewerCanUpdate": true,
+                    "viewerCanDelete": true,
+                    "url": "https://github.com/org/repo/pull/7#discussion_r1001",
+                    "originalCommit": { "oid": "abc123" }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRRT_kwDOA2",
+              "path": "docs/intro.md",
+              "originalLine": 10,
+              "originalStartLine": 8,
+              "line": 10,
+              "startLine": 8,
+              "isOutdated": false,
+              "isResolved": true,
+              "viewerCanResolve": false,
+              "viewerCanUnresolve": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 1002,
+                    "author": { "login": "bob", "avatarUrl": "https://avatars/bob" },
+                    "body": "Range comment",
+                    "createdAt": "2026-05-01T11:00:00Z",
+                    "updatedAt": "2026-05-01T11:30:00Z",
+                    "viewerCanUpdate": false,
+                    "viewerCanDelete": false,
+                    "url": "https://github.com/org/repo/pull/7#discussion_r1002",
+                    "originalCommit": { "oid": "abc123" }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/crates/infra/tests/gh_review_threads.rs
+++ b/crates/infra/tests/gh_review_threads.rs
@@ -1,0 +1,34 @@
+//! Parser tests for the GraphQL `reviewThreads` payload. The fixture is
+//! a hand-crafted but realistic response; the `gh_cli` round-trip is
+//! covered by an opt-in #[ignore] smoke test below.
+
+use markdown_reviewer_core::domain::ThreadState;
+use markdown_reviewer_infra::gh::review_threads::parse_review_threads;
+
+#[test]
+fn parses_basic_fixture() {
+    let raw = include_str!("fixtures/gh/review-threads-basic.json");
+    let fetched = parse_review_threads(raw).expect("fixture parses");
+    assert_eq!(fetched.threads.len(), 2);
+    assert!(!fetched.truncated);
+
+    let t1 = &fetched.threads[0];
+    assert_eq!(t1.thread_id, "PRRT_kwDOA1");
+    assert_eq!(t1.path, "docs/intro.md");
+    assert_eq!(t1.line, Some(4));
+    assert_eq!(t1.start_line, None);
+    assert_eq!(t1.original_line, 4);
+    assert_eq!(t1.state, ThreadState::Open);
+    assert!(t1.viewer_can_resolve);
+    assert_eq!(t1.comments.len(), 1);
+    assert_eq!(t1.comments[0].comment_id, 1001);
+    assert_eq!(t1.comments[0].author, "alice");
+    assert!(t1.comments[0].viewer_can_update);
+
+    let t2 = &fetched.threads[1];
+    assert_eq!(t2.thread_id, "PRRT_kwDOA2");
+    assert_eq!(t2.state, ThreadState::Resolved);
+    assert_eq!(t2.start_line, Some(8));
+    assert_eq!(t2.line, Some(10));
+    assert!(!t2.comments[0].viewer_can_update);
+}

--- a/crates/infra/tests/phase1_e2e.rs
+++ b/crates/infra/tests/phase1_e2e.rs
@@ -81,6 +81,51 @@ impl GhClient for StubGh {
     ) -> markdown_reviewer_core::AppResult<i64> {
         Err(AppError::process("not implemented in test fake"))
     }
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+    ) -> markdown_reviewer_core::AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
 }
 
 fn svc(db_dir: &std::path::Path, authed: bool) -> RepoSelection {

--- a/crates/infra/tests/phase1_e2e.rs
+++ b/crates/infra/tests/phase1_e2e.rs
@@ -85,7 +85,8 @@ impl GhClient for StubGh {
         &self,
         _repo_path: &str,
         _pr_number: u64,
-    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+    ) -> markdown_reviewer_core::AppResult<markdown_reviewer_core::ports::FetchedReviewThreads>
+    {
         unimplemented!("not used in this test")
     }
     async fn reply_review_comment(

--- a/crates/infra/tests/sqlite_remote_threads.rs
+++ b/crates/infra/tests/sqlite_remote_threads.rs
@@ -1,0 +1,44 @@
+use markdown_reviewer_core::domain::{MappingStatus, RemoteThread, ThreadState};
+use markdown_reviewer_core::ports::{CachedRefresh, RemoteThreadsStore};
+use markdown_reviewer_infra::sqlite::{open_and_migrate, SqliteRemoteThreadsStore};
+use tempfile::tempdir;
+
+fn sample_thread() -> RemoteThread {
+    RemoteThread {
+        thread_id: "T1".into(),
+        path: "doc.md".into(),
+        original_commit_id: "abc".into(),
+        line: Some(4),
+        start_line: None,
+        original_line: 4,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn roundtrips_a_cache_row() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+    let db = open_and_migrate(&db_path).unwrap();
+    let store = SqliteRemoteThreadsStore::new(db);
+
+    let cached = CachedRefresh {
+        head_sha: "abc".into(),
+        refreshed_at_ms: 42,
+        threads: vec![sample_thread()],
+        unmapped: vec![],
+    };
+    store.put("/repo", 7, "abc", &cached).await.unwrap();
+
+    let fetched = store.get("/repo", 7).await.unwrap().unwrap();
+    assert_eq!(fetched.head_sha, "abc");
+    assert_eq!(fetched.refreshed_at_ms, 42);
+    assert_eq!(fetched.threads.len(), 1);
+}

--- a/crates/ipc/src/commands/mod.rs
+++ b/crates/ipc/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod files;
 pub mod pull_requests;
 pub mod recents;
 pub mod repo;
+pub mod sync;
 pub mod tools;

--- a/crates/ipc/src/commands/sync.rs
+++ b/crates/ipc/src/commands/sync.rs
@@ -32,7 +32,14 @@ pub async fn reply_remote_thread(
     in_reply_to_comment_id: i64,
     body: String,
 ) -> Result<RemoteComment, AppError> {
-    mutations::reply(&state.sync, &repo_path, pr_number, in_reply_to_comment_id, &body).await
+    mutations::reply(
+        &state.sync,
+        &repo_path,
+        pr_number,
+        in_reply_to_comment_id,
+        &body,
+    )
+    .await
 }
 
 #[tauri::command(rename_all = "camelCase")]

--- a/crates/ipc/src/commands/sync.rs
+++ b/crates/ipc/src/commands/sync.rs
@@ -1,0 +1,73 @@
+use markdown_reviewer_core::application::sync::{cache, mutations, refresh};
+use markdown_reviewer_core::domain::{RefreshResult, RemoteComment, RemoteThread};
+use markdown_reviewer_core::AppError;
+use tauri::State;
+
+use crate::state::AppState;
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn refresh_remote_comments(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+    head_sha: String,
+) -> Result<RefreshResult, AppError> {
+    refresh::run(&state.sync, &repo_path, pr_number, &head_sha).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_cached_remote_threads(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+) -> Result<Option<RefreshResult>, AppError> {
+    cache::get_cached(&state.sync, &repo_path, pr_number).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn reply_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+    in_reply_to_comment_id: i64,
+    body: String,
+) -> Result<RemoteComment, AppError> {
+    mutations::reply(&state.sync, &repo_path, pr_number, in_reply_to_comment_id, &body).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn edit_remote_comment(
+    state: State<'_, AppState>,
+    repo_path: String,
+    comment_id: i64,
+    body: String,
+) -> Result<RemoteComment, AppError> {
+    mutations::edit(&state.sync, &repo_path, comment_id, &body).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn delete_remote_comment(
+    state: State<'_, AppState>,
+    repo_path: String,
+    comment_id: i64,
+) -> Result<(), AppError> {
+    mutations::delete(&state.sync, &repo_path, comment_id).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn resolve_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    thread_id: String,
+) -> Result<RemoteThread, AppError> {
+    mutations::resolve(&state.sync, &repo_path, &thread_id).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn reopen_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    thread_id: String,
+) -> Result<RemoteThread, AppError> {
+    mutations::reopen(&state.sync, &repo_path, &thread_id).await
+}

--- a/crates/ipc/src/lib.rs
+++ b/crates/ipc/src/lib.rs
@@ -27,5 +27,12 @@ pub fn register<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
         commands::comments::update_local_comment,
         commands::comments::delete_local_comment,
         commands::comments::submit_review,
+        commands::sync::refresh_remote_comments,
+        commands::sync::get_cached_remote_threads,
+        commands::sync::reply_remote_thread,
+        commands::sync::edit_remote_comment,
+        commands::sync::delete_remote_comment,
+        commands::sync::resolve_remote_thread,
+        commands::sync::reopen_remote_thread,
     ])
 }

--- a/crates/ipc/src/state.rs
+++ b/crates/ipc/src/state.rs
@@ -2,6 +2,7 @@ use markdown_reviewer_core::application::comments::Comments;
 use markdown_reviewer_core::application::files::Files;
 use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
+use markdown_reviewer_core::application::sync::Sync;
 
 /// Tauri managed state. Clone-on-access: every member is `Arc`-wrapped inside
 /// the use-case bundles, so cloning is cheap.
@@ -11,4 +12,5 @@ pub struct AppState {
     pub pull_requests: PullRequests,
     pub files: Files,
     pub comments: Comments,
+    pub sync: Sync,
 }

--- a/docs/superpowers/plans/2026-05-09-long-range-comments.md
+++ b/docs/superpowers/plans/2026-05-09-long-range-comments.md
@@ -1,0 +1,1002 @@
+# Long-range comments — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make multi-line review-comment anchors (10–15+ lines) feel calm and traceable in the Markdown preview, and add a source-snippet preview to every row in the threads pane. Closes [GitHub issue #24](https://github.com/jaovito/markdown-reviewer/issues/24) (Phase 4 — Advanced Comments).
+
+**Architecture:** Frontend-only. `InlineThreads.syncSlots` gains a third slot type (`headers`) that mounts a sticky `RangeHeaderChip` portal above the start line of every multi-line range; per-line CSS keys off a new `data-comment-range="head|body|tail|single"` attribute to draw a continuous left rail instead of the wash. Threads pane gets a new `ThreadSnippet` component fed by a lazy `useFileSource` React Query hook that reuses the existing `read_markdown_file` IPC command — `repoPath` and `headSha` are plumbed from `PullRequestScreen` through `ThreadsPane` → `ThreadList` → `ThreadCard`.
+
+**Tech Stack:** React 18 + TypeScript, Tauri v2 IPC, React Query v5, Tailwind v4, i18next, Bun for runtime + tests, Biome for lint/format.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-long-range-comments-design.md`
+
+**Conventions reminder:**
+- Every user-facing string goes through `i18next`. Add the key to `src/shared/i18n/locales/en.json` and read it with `useTranslation()`. Repo is English-only today.
+- All IPC goes through `src/shared/ipc/client.ts` (`ipc.*`). Never `invoke()` inline.
+- Tests live next to the code as `*.test.ts` and run via `bun test` (no React Testing Library — only pure-function tests are in scope here).
+- Run `bun run check:fix && bun run typecheck && bun test` before each commit. Pre-commit hooks already exist; do not pass `--no-verify`.
+
+---
+
+## File map
+
+**Create:**
+- `src/features/comments/lib/sliceSnippet.ts` — pure helper that slices a file's lines for a `(startLine, endLine)` window.
+- `src/features/comments/lib/sliceSnippet.test.ts` — `bun:test` cases for the slicer.
+- `src/features/comments/hooks/useFileSource.ts` — React Query hook wrapping `ipc.files.readMarkdown`.
+- `src/features/comments/components/RangeHeaderChip.tsx` — sticky header chip portaled above the range start.
+- `src/features/main/components/threads/ThreadSnippet.tsx` — snippet block rendered inside `ThreadCard`.
+
+**Modify:**
+- `src/features/comments/components/InlineThreads.tsx` — extend `SlotMap` with `headers`, allocate header slot in `syncSlots`, stamp `data-comment-range` per-line, mount `RangeHeaderChip` via portal, wire Jump → select + scroll.
+- `src/features/main/components/threads/ThreadCard.tsx` — accept `repoPath` / `sha` props, mount `ThreadSnippet` between header and body.
+- `src/features/main/components/threads/ThreadList.tsx` — accept + forward `repoPath` / `sha`.
+- `src/features/main/components/ThreadsPane.tsx` — accept `repoPath` / `sha` props, forward to `ThreadList`.
+- `src/features/file-explorer/screens/PullRequestScreen/index.tsx` — pass `repoPath.data` and `detail.data?.headSha` to `<ThreadsPane>`.
+- `src/shared/styles/index.css` — gate the existing wash on `data-comment-range="single"`, add rail rules for `head|body|tail` (both prose and `pre [data-code-line]` variants), add `[data-thread-slot="header"]` rule.
+- `src/shared/i18n/locales/en.json` — add the new keys under `comments.range.*` and `threads.snippet.*`.
+
+**Test:** `src/features/comments/lib/sliceSnippet.test.ts` only. Component behavior is verified manually via the smoke checklist at the end of the plan.
+
+---
+
+## Task 1: `sliceSnippet` pure helper (TDD)
+
+**Files:**
+- Create: `src/features/comments/lib/sliceSnippet.ts`
+- Test: `src/features/comments/lib/sliceSnippet.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/features/comments/lib/sliceSnippet.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { sliceSnippet } from "./sliceSnippet";
+
+const FIFTEEN_LINES = Array.from({ length: 15 }, (_, i) => `line ${i + 1}`);
+
+describe("sliceSnippet", () => {
+  test("returns the full range when shorter than maxVisible", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 2, 4, 3);
+    expect(out.visible).toEqual(["line 2", "line 3", "line 4"]);
+    expect(out.more).toBe(0);
+  });
+
+  test("truncates ranges longer than maxVisible and reports the overflow", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 1, 15, 3);
+    expect(out.visible).toEqual(["line 1", "line 2", "line 3"]);
+    expect(out.more).toBe(12);
+  });
+
+  test("single-line range yields one visible line", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 7, 7, 3);
+    expect(out.visible).toEqual(["line 7"]);
+    expect(out.more).toBe(0);
+  });
+
+  test("clamps when endLine exceeds the file length", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 14, 20, 3);
+    // The window starts at line 14; only lines 14 and 15 exist; `more`
+    // counts requested lines beyond the file.
+    expect(out.visible).toEqual(["line 14", "line 15"]);
+    expect(out.more).toBe(5);
+  });
+
+  test("returns empty when startLine is past the end of the file", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 99, 100, 3);
+    expect(out.visible).toEqual([]);
+    expect(out.more).toBe(2);
+  });
+
+  test("uses default maxVisible = 3 when omitted", () => {
+    const out = sliceSnippet(FIFTEEN_LINES, 1, 10);
+    expect(out.visible).toHaveLength(3);
+    expect(out.more).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `bun test src/features/comments/lib/sliceSnippet.test.ts`
+Expected: FAIL with `Cannot find module './sliceSnippet'` or similar.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/features/comments/lib/sliceSnippet.ts`:
+
+```ts
+export interface SnippetSlice {
+  /** Lines visible inside the snippet block, in source order. */
+  visible: string[];
+  /** Count of additional lines requested but not shown — drives the `+N more lines` row. */
+  more: number;
+}
+
+/**
+ * Slices a file's lines for the snippet preview shown in the threads pane.
+ *
+ * Inputs use 1-based line numbers (the rest of the comments feature speaks in
+ * source line numbers). The function clamps gracefully when the requested
+ * range extends past the end of the file — `more` reports how many requested
+ * lines were truncated, including any beyond the file's length.
+ */
+export function sliceSnippet(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  maxVisible = 3,
+): SnippetSlice {
+  const total = Math.max(0, endLine - startLine + 1);
+  const startIndex = Math.max(0, startLine - 1);
+  const stop = startIndex + Math.min(total, maxVisible);
+  const visible = lines.slice(startIndex, stop);
+  const more = total - visible.length;
+  return { visible, more };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `bun test src/features/comments/lib/sliceSnippet.test.ts`
+Expected: PASS — 6 passed.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/comments/lib/sliceSnippet.ts src/features/comments/lib/sliceSnippet.test.ts
+git commit -m "feat(phase-4 #24): add sliceSnippet helper for thread snippet preview"
+```
+
+---
+
+## Task 2: `useFileSource` hook
+
+**Files:**
+- Create: `src/features/comments/hooks/useFileSource.ts`
+
+- [ ] **Step 1: Implement the hook**
+
+Create `src/features/comments/hooks/useFileSource.ts`:
+
+```ts
+import { ipc } from "@/shared/ipc/client";
+import type { AppError } from "@/shared/ipc/contract";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+interface UseFileSourceResult {
+  lines: string[] | null;
+  isLoading: boolean;
+  error: AppError | null;
+}
+
+/**
+ * Lazily reads a Markdown file's source bytes for a given (repoPath, sha)
+ * pair and exposes it as an array of lines for snippet rendering. Backed by
+ * the existing `read_markdown_file` IPC command and React Query, so multiple
+ * consumers reading the same file dedupe to a single read.
+ *
+ * The cache key includes `sha`, so refreshing the PR (which produces a new
+ * head sha) auto-invalidates without manual busting.
+ */
+export function useFileSource(
+  repoPath: string | undefined,
+  sha: string | undefined,
+  filePath: string,
+): UseFileSourceResult {
+  const enabled = Boolean(repoPath && sha && filePath);
+  const query = useQuery<string, AppError>({
+    queryKey: ["file-source", repoPath, sha, filePath],
+    enabled,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: 5 * 60_000,
+    queryFn: async () => {
+      const res = await ipc.files.readMarkdown(repoPath as string, sha as string, filePath);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+  });
+
+  // Memoize the split so two ThreadSnippet instances reading the same file
+  // share the exact same string[] reference — keeps downstream React equality
+  // checks cheap.
+  const lines = useMemo(() => (query.data ? query.data.split("\n") : null), [query.data]);
+
+  return {
+    lines,
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+  };
+}
+```
+
+- [ ] **Step 2: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/comments/hooks/useFileSource.ts
+git commit -m "feat(phase-4 #24): add useFileSource hook for snippet source"
+```
+
+---
+
+## Task 3: i18n keys
+
+**Files:**
+- Modify: `src/shared/i18n/locales/en.json`
+
+- [ ] **Step 1: Locate the existing groups**
+
+Open `src/shared/i18n/locales/en.json` and find the existing `"comments"` and `"threads"` top-level objects (they were added in earlier Phase 4 tasks).
+
+- [ ] **Step 2: Add the new keys**
+
+Inside the existing `"comments"` object, add a `"range"` sub-object next to the current `"thread"`, `"composer"`, `"markers"` siblings:
+
+```json
+"range": {
+  "headerLabel_one": "L{{start}}–L{{end}} · {{count}} comment",
+  "headerLabel_other": "L{{start}}–L{{end}} · {{count}} comments",
+  "jump": "Jump",
+  "jumpAria": "Jump to comment thread"
+}
+```
+
+Inside the existing `"threads"` object, add a `"snippet"` sub-object next to the current `"row"` sibling:
+
+```json
+"snippet": {
+  "moreLines_one": "… +{{count}} more line",
+  "moreLines_other": "… +{{count}} more lines"
+}
+```
+
+Use real commas to separate the new sub-objects from neighboring keys; Biome will error on a trailing comma.
+
+- [ ] **Step 3: Verify the type generator picks up the new keys**
+
+Run: `bun run typecheck`
+Expected: no diagnostics. The generated `src/shared/i18n/types.d.ts` is regenerated from `en.json` on `tsc`, and any consumer typo would surface here in later tasks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/i18n/locales/en.json
+git commit -m "feat(phase-4 #24): i18n keys for range header chip and snippet preview"
+```
+
+---
+
+## Task 4: `RangeHeaderChip` component
+
+**Files:**
+- Create: `src/features/comments/components/RangeHeaderChip.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/features/comments/components/RangeHeaderChip.tsx`:
+
+```tsx
+import type { CommentState } from "@/shared/ipc/contract";
+import { cn } from "@/shared/lib/cn";
+import { CornerDownRightIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface RangeHeaderChipProps {
+  startLine: number;
+  endLine: number;
+  /** Total number of comments anchored to this range. */
+  count: number;
+  /** Drives the muted/desaturated styling for resolved or hidden threads. */
+  state: CommentState;
+  /** Smooth-scrolls the matching card into view and selects the head. */
+  onJump: () => void;
+}
+
+/**
+ * Compact, sticky header rendered above the first line of a multi-line range
+ * anchor. Tells the reader "there is a comment thread spanning L{start}–L{end}"
+ * even when the thread card itself is scrolled off the bottom of the viewport.
+ *
+ * The chip itself is rendered into a slot inserted by `InlineThreads` directly
+ * in the article DOM, so `position: sticky; top: 0` (set in CSS via
+ * `[data-thread-slot="header"]`) keeps it pinned to the top of the preview's
+ * scroll container while the user reads through the range.
+ */
+export function RangeHeaderChip({ startLine, endLine, count, state, onJump }: RangeHeaderChipProps) {
+  const { t } = useTranslation();
+  const muted = state === "resolved" || state === "hidden";
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-md border px-2 py-1 text-[11px]",
+        "border-[hsl(var(--comment-marker-border))] bg-[hsl(var(--comment-marker-bg))]",
+        "text-[hsl(var(--comment-marker-fg))] shadow-sm",
+        muted ? "opacity-70" : null,
+      )}
+      data-comment-range-header="true"
+    >
+      <span className="font-mono">
+        {t("comments.range.headerLabel", { count, start: startLine, end: endLine })}
+      </span>
+      <span className="ml-auto" />
+      <button
+        type="button"
+        onClick={onJump}
+        aria-label={t("comments.range.jumpAria")}
+        className={cn(
+          "inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium",
+          "hover:bg-[hsl(var(--comment-marker-hover))]",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+        )}
+      >
+        <CornerDownRightIcon className="h-3 w-3" aria-hidden="true" />
+        <span>{t("comments.range.jump")}</span>
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/comments/components/RangeHeaderChip.tsx
+git commit -m "feat(phase-4 #24): RangeHeaderChip for sticky long-range header"
+```
+
+---
+
+## Task 5: extend `InlineThreads` slot machinery
+
+**Files:**
+- Modify: `src/features/comments/components/InlineThreads.tsx`
+
+This is the largest task in the plan — keep it on its own commit.
+
+- [ ] **Step 1: Add the `headers` slot to `SlotMap`**
+
+Locate the `SlotMap` interface (around line 40) and add a `headers` field:
+
+```ts
+interface SlotMap {
+  /** key → portal target div for the expanded card */
+  threads: Map<SlotKey, HTMLDivElement>;
+  /** key → portal target span for the minimized "open" badge */
+  badges: Map<SlotKey, HTMLSpanElement>;
+  /** key → portal target div for the sticky range header (multi-line ranges only) */
+  headers: Map<SlotKey, HTMLDivElement>;
+  composerSlot: HTMLDivElement | null;
+}
+```
+
+Update the initial `useRef<SlotMap>` initializer (around line 171) to include `headers: new Map()`. Update the unmount cleanup `useEffect` (around line 248) to reset `headers` too.
+
+- [ ] **Step 2: Stamp `data-comment-range` per-line in `markRange`**
+
+Modify the `markRange` helper (around line 638) so it stamps a `data-comment-range` attribute alongside `data-has-comment`. New signature:
+
+```ts
+function markRange(
+  lineNodes: Map<number, HTMLElement>,
+  start: number,
+  end: number,
+  collapsed: boolean,
+  resolved: boolean,
+) {
+  const single = start === end;
+  for (let line = start; line <= end; line++) {
+    const el = lineNodes.get(line);
+    if (!el) continue;
+    el.dataset.hasComment = "true";
+    el.dataset.commentRange = single
+      ? "single"
+      : line === start
+        ? "head"
+        : line === end
+          ? "tail"
+          : "body";
+    if (collapsed) el.dataset.commentMinimized = "true";
+    if (resolved) el.dataset.commentResolved = "true";
+  }
+}
+```
+
+Also extend the cleanup pass at the start of `syncSlots` (the block of `for (const n of container.querySelectorAll<HTMLElement>("[data-has-comment]")) ...`) so it deletes `data-comment-range` along with the existing flags. Add a parallel pass:
+
+```ts
+for (const n of container.querySelectorAll<HTMLElement>("[data-comment-range]")) {
+  delete n.dataset.commentRange;
+}
+```
+
+Mirror the same delete in `removeAllSlots` (around line 654).
+
+- [ ] **Step 3: Allocate the header slot in `syncSlots`**
+
+Inside the main slot-allocation loop in `syncSlots` (around line 570 — `for (const group of groups)`), at the end of the loop body and **only** when the group is multi-line and not collapsed, insert a header slot **before** the start-line node. New code added inside the existing loop, after the existing badge/card branch:
+
+```ts
+const wantsHeader = !isCollapsed && group.startLine !== group.endLine;
+if (wantsHeader) {
+  if (!current.headers.has(key)) {
+    const startNode = lineNodes.get(group.startLine);
+    if (startNode?.parentNode) {
+      const header = document.createElement("div");
+      header.dataset.threadSlot = "header";
+      header.dataset.threadSlotLine = String(group.startLine);
+      startNode.parentNode.insertBefore(header, startNode);
+      current.headers.set(key, header);
+      changed = true;
+    }
+  }
+} else if (current.headers.has(key)) {
+  current.headers.get(key)?.remove();
+  current.headers.delete(key);
+  changed = true;
+}
+```
+
+And just like for the existing `threads` and `badges` maps, add a leading cleanup pass that removes header slots for groups that no longer exist or whose nodes have detached:
+
+```ts
+const wantsHeaderKeys = new Set<SlotKey>();
+for (const g of groups) {
+  if (collapsed.has(slotKeyFor(g.startLine, g.endLine))) continue;
+  if (g.startLine === g.endLine) continue;
+  wantsHeaderKeys.add(slotKeyFor(g.startLine, g.endLine));
+}
+for (const [key, node] of current.headers) {
+  if (!wantsHeaderKeys.has(key) || !node.isConnected) {
+    node.remove();
+    current.headers.delete(key);
+    changed = true;
+  }
+}
+```
+
+Place this cleanup pass right after the existing badge cleanup (the `for (const [key, node] of current.badges)` block).
+
+- [ ] **Step 4: Mount `RangeHeaderChip` via portal**
+
+At the top of `InlineThreads.tsx`, add the import:
+
+```ts
+import { RangeHeaderChip } from "./RangeHeaderChip";
+```
+
+In the `groups.map(...)` render block (around line 287), at the very start of the callback (before any branches that `return null` early), compute and emit a header portal — but only for multi-line non-collapsed groups. Wrap each group's output in a fragment:
+
+```tsx
+{groups.flatMap((group) => {
+  const slotKey = slotKeyFor(group.startLine, group.endLine);
+  const minKey = minimizedKey(prNumber, filePath, group.startLine, group.endLine);
+  const minimized = minimizedSet.has(minKey);
+  const allHidden = allHiddenSet.has(slotKey);
+  const isResolvedCollapsed = resolvedCollapsed.has(slotKey);
+  const headerSlot = slots.headers.get(slotKey);
+  const wantsHeader =
+    group.startLine !== group.endLine && !minimized && !allHidden && !isResolvedCollapsed;
+
+  const headerNode =
+    wantsHeader && headerSlot
+      ? createPortal(
+          <RangeHeaderChip
+            key={`hdr-${slotKey}`}
+            startLine={group.startLine}
+            endLine={group.endLine}
+            count={group.comments.length}
+            state={group.comments[0]?.state ?? "submitted"}
+            onJump={() => {
+              const head = group.comments[0];
+              if (head) select(head.id);
+              const cardSlot = slotsRef.current.threads.get(slotKey);
+              if (cardSlot) {
+                const reduce =
+                  typeof window !== "undefined" &&
+                  typeof window.matchMedia === "function" &&
+                  window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+                cardSlot.scrollIntoView({
+                  block: "center",
+                  behavior: reduce ? "auto" : "smooth",
+                });
+              }
+            }}
+          />,
+          headerSlot,
+          `thread-header-${slotKey}`,
+        )
+      : null;
+
+  // … existing per-group branches that return the inline card / badge …
+  const body = /* keep the existing single return value here */ null;
+
+  return [headerNode, body];
+})}
+```
+
+The existing per-group code (composer, badges, hidden marker, resolved marker, full card) stays unchanged — it just becomes the value assigned to `body` instead of being returned directly. The outer `return [headerNode, body]` plus `flatMap` ensures both portals end up in the tree without an extra DOM wrapper.
+
+When you do this conversion, double-check that every existing branch that previously did `return createPortal(...)` now assigns to `body` and falls through to the final `return [headerNode, body]`. Do not remove any of the existing branches.
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics. If TypeScript complains about `flatMap` returning `(JSX.Element | null)[]`, that's expected — React accepts arrays of nodes.
+
+- [ ] **Step 6: Run the existing comments tests to make sure nothing regressed**
+
+Run: `bun test src/features/comments`
+Expected: all existing tests pass (the new `sliceSnippet` test passes too).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/comments/components/InlineThreads.tsx
+git commit -m "feat(phase-4 #24): mount sticky range header chip in InlineThreads"
+```
+
+---
+
+## Task 6: CSS — left rail + sticky header
+
+**Files:**
+- Modify: `src/shared/styles/index.css`
+
+- [ ] **Step 1: Gate the existing wash on `data-comment-range="single"`**
+
+In `src/shared/styles/index.css`, find the `.prose-styles [data-source-line][data-has-comment="true"]` rule (around line 164) and change the selector to:
+
+```css
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="single"] {
+  background: hsl(var(--comment-selection-bg));
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  border-radius: 6px;
+  padding-left: 0.6em;
+  margin-left: -0.6em;
+}
+```
+
+Apply the same `[data-comment-range="single"]` qualifier to the two minimized/resolved variants of that rule that follow.
+
+In the `.prose-styles pre [data-code-line][data-has-comment="true"]` family (around line 192), apply the same `[data-comment-range="single"]` qualifier to the base rule and its two minimized/resolved variants.
+
+- [ ] **Step 2: Add the rail rules for `head|body|tail`**
+
+Append below the existing wash rules (still in `index.css`):
+
+```css
+/* Multi-line range anchors get a continuous 3px left rail spanning every
+   covered line — much lighter visually than the per-line wash, scales from
+   2 lines to 50+ without dominating the document. The head line gets the
+   top corner rounded; the tail line gets the bottom corner rounded. */
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="head"],
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="body"],
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  padding-left: 0.6em;
+  margin-left: -0.6em;
+}
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="head"] {
+  border-top-left-radius: 6px;
+}
+.prose-styles [data-source-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-bottom-left-radius: 6px;
+}
+/* Minimized / resolved long ranges desaturate the rail to match the existing
+   collapse treatment, keeping the same selector shape as the wash variants. */
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="head"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="body"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="tail"][data-comment-minimized="true"] {
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
+}
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="head"][data-comment-resolved="true"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="body"][data-comment-resolved="true"][data-comment-minimized="true"],
+.prose-styles
+  [data-source-line][data-has-comment="true"][data-comment-range="tail"][data-comment-resolved="true"][data-comment-minimized="true"] {
+  border-left-color: hsl(var(--border));
+}
+
+/* Mirror the rail on per-line code spans inside <pre>. */
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="head"],
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="body"],
+.prose-styles pre [data-code-line][data-has-comment="true"][data-comment-range="tail"] {
+  border-left: 3px solid hsl(var(--comment-marker-fg));
+  border-radius: 0;
+  padding-left: 0.5em;
+  margin-left: -0.5em;
+}
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="head"][data-comment-minimized="true"],
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="body"][data-comment-minimized="true"],
+.prose-styles
+  pre
+  [data-code-line][data-has-comment="true"][data-comment-range="tail"][data-comment-minimized="true"] {
+  border-left-color: hsl(var(--comment-marker-fg) / 0.4);
+}
+```
+
+- [ ] **Step 3: Add the sticky header slot rule**
+
+Below the existing `.prose-styles [data-thread-slot]` rule (around line 255), append:
+
+```css
+/* Sticky range header chip mounted above the first line of a multi-line
+   range. Sticks to the top of the preview's scroll container so the reader
+   keeps a "there is a comment here" affordance even when scrolled into the
+   middle of a long range. */
+.prose-styles [data-thread-slot="header"] {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  margin: 0 0 4px;
+  background: hsl(var(--background));
+}
+```
+
+- [ ] **Step 4: Visual smoke check**
+
+Run: `bun run dev`
+Open a Markdown PR, drag-select 12 lines, click Comment, save the draft. Expect:
+- A continuous left rail (no full background wash) along all 12 covered lines.
+- Rounded top-left on line 1 of the range, rounded bottom-left on line 12, straight in between.
+- A sticky chip pinned to the top of the preview reading `L{x}–L{y} · 1 comment` plus a Jump link.
+- A single-line comment elsewhere in the same file still uses the wash + 3px bar (unchanged).
+
+If something looks wrong, re-check Step 1 (the qualifier on the wash rule) — a missed `[data-comment-range="single"]` is the most likely culprit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/styles/index.css
+git commit -m "feat(phase-4 #24): left rail + sticky header CSS for long-range anchors"
+```
+
+---
+
+## Task 7: `ThreadSnippet` component
+
+**Files:**
+- Create: `src/features/main/components/threads/ThreadSnippet.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/features/main/components/threads/ThreadSnippet.tsx`:
+
+```tsx
+import { useFileSource } from "@/features/comments/hooks/useFileSource";
+import { sliceSnippet } from "@/features/comments/lib/sliceSnippet";
+import { Skeleton } from "@/shared/ui/skeleton";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+const MAX_VISIBLE = 3;
+
+interface ThreadSnippetProps {
+  /** Repo absolute path — required for the IPC read; undefined disables the read. */
+  repoPath: string | undefined;
+  /** Head sha of the PR; included in the cache key so refresh invalidates it. */
+  sha: string | undefined;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+}
+
+/**
+ * Renders up to 3 lines of the underlying Markdown source for a thread's
+ * anchor, plus a `… +N more lines` row when the range extends beyond the
+ * visible window. Used in the threads pane so reviewers can identify a
+ * thread without opening the file.
+ *
+ * Failure is silent — when the file read errors out, the snippet is omitted
+ * and the rest of the card (anchor label + comment body + author) still
+ * works. The error already surfaces elsewhere via the file-explorer view.
+ */
+export function ThreadSnippet({ repoPath, sha, filePath, startLine, endLine }: ThreadSnippetProps) {
+  const { t } = useTranslation();
+  const { lines, isLoading, error } = useFileSource(repoPath, sha, filePath);
+
+  const slice = useMemo(
+    () => (lines ? sliceSnippet(lines, startLine, endLine, MAX_VISIBLE) : null),
+    [lines, startLine, endLine],
+  );
+
+  if (isLoading || (!lines && !error)) {
+    return (
+      <div className="my-1.5 flex flex-col gap-1">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-5/6" />
+        <Skeleton className="h-3 w-4/6" />
+      </div>
+    );
+  }
+
+  if (!slice || slice.visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="my-1.5 rounded border-[hsl(var(--comment-marker-fg))] border-l-[1.5px] bg-[hsl(var(--muted))]/30 py-1 pl-2 font-mono text-[11px] leading-snug"
+      data-thread-snippet="true"
+    >
+      <pre className="overflow-hidden text-ellipsis whitespace-pre text-[hsl(var(--foreground))]/85">
+        {slice.visible.join("\n")}
+      </pre>
+      {slice.more > 0 ? (
+        <p className="mt-1 text-[10px] text-[hsl(var(--muted-foreground))]">
+          {t("threads.snippet.moreLines", { count: slice.more })}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/main/components/threads/ThreadSnippet.tsx
+git commit -m "feat(phase-4 #24): ThreadSnippet renders source preview in threads pane"
+```
+
+---
+
+## Task 8: thread-pane plumbing — accept `repoPath` + `sha`
+
+**Files:**
+- Modify: `src/features/main/components/threads/ThreadCard.tsx`
+- Modify: `src/features/main/components/threads/ThreadList.tsx`
+- Modify: `src/features/main/components/ThreadsPane.tsx`
+- Modify: `src/features/file-explorer/screens/PullRequestScreen/index.tsx`
+
+- [ ] **Step 1: Accept the new props in `ThreadCard`**
+
+Open `src/features/main/components/threads/ThreadCard.tsx`. Add the import:
+
+```tsx
+import { ThreadSnippet } from "./ThreadSnippet";
+```
+
+Add two props to `ThreadCardProps`:
+
+```ts
+interface ThreadCardProps {
+  group: ThreadGroup;
+  selected: boolean;
+  hideFilePath: boolean;
+  hideAnchorLabel?: boolean;
+  tabIndex?: number;
+  asTreeItem?: boolean;
+  /** Forwarded to ThreadSnippet's `useFileSource` — undefined disables the snippet. */
+  repoPath?: string;
+  /** Head sha for the snippet's cache key. */
+  sha?: string;
+  onFocus?: () => void;
+  onSelect: (comment: ReviewComment) => void;
+  onReopen?: (comment: ReviewComment) => void;
+}
+```
+
+Destructure the two new props alongside the existing ones in the function signature.
+
+Mount `<ThreadSnippet>` between the anchor-label/header row and the body row. Compute `startLine` / `endLine` from the head's anchor with the existing pattern used at the bottom of `ThreadList.tsx` (`startLineOf` / `endLineOf`). Inline a tiny helper at the top of the file:
+
+```ts
+function rangeOf(anchor: ReviewComment["anchor"]): { startLine: number; endLine: number } {
+  if (anchor.kind === "singleLine") return { startLine: anchor.line, endLine: anchor.line };
+  return { startLine: anchor.startLine, endLine: anchor.endLine };
+}
+```
+
+Then immediately after the existing `hideAnchorLabel` block (the `<div>` containing the anchor label / state badge — around line 109), insert:
+
+```tsx
+{(() => {
+  const { startLine, endLine } = rangeOf(head.anchor);
+  return (
+    <ThreadSnippet
+      repoPath={repoPath}
+      sha={sha}
+      filePath={group.filePath}
+      startLine={startLine}
+      endLine={endLine}
+    />
+  );
+})()}
+```
+
+The IIFE keeps the helper call out of the JSX without forcing another sub-component file.
+
+- [ ] **Step 2: Forward the new props through `ThreadList`**
+
+Open `src/features/main/components/threads/ThreadList.tsx`. Add to `ThreadListProps`:
+
+```ts
+/** Repo absolute path — forwarded to ThreadCard for the snippet read. */
+repoPath?: string;
+/** PR head sha — forwarded to ThreadCard for the snippet cache key. */
+sha?: string;
+```
+
+Destructure them in the function signature alongside the other props. Pass them to every `<ThreadCard>` instance — there's currently one inside the file (the call wrapped in `<ThreadAnchorGroup>` around line 448):
+
+```tsx
+<ThreadCard
+  ref={setItemRef(cId)}
+  group={anchor}
+  selected={isSelected}
+  hideFilePath={hideFilePath}
+  hideAnchorLabel
+  asTreeItem
+  tabIndex={effectiveActiveId === cId ? 0 : -1}
+  onFocus={() => setActiveId(cId)}
+  repoPath={repoPath}
+  sha={sha}
+  onSelect={(comment) => { /* unchanged */ }}
+  onReopen={onReopen}
+/>
+```
+
+- [ ] **Step 3: Forward the new props through `ThreadsPane`**
+
+Open `src/features/main/components/ThreadsPane.tsx`. Add to `ThreadsPaneProps`:
+
+```ts
+/** Repo absolute path — forwarded to ThreadList for the snippet read. */
+repoPath?: string;
+/** PR head sha — forwarded to ThreadList for the snippet cache key. */
+sha?: string;
+```
+
+Destructure them in the function signature. Pass them through to the existing `<ThreadList>` call (around line 150):
+
+```tsx
+<ThreadList
+  comments={visible}
+  isLoading={query.isLoading}
+  hideFilePath={effectiveScope === "currentFile"}
+  hiddenCount={hiddenCount}
+  prNumber={prNumber}
+  currentFilePath={filePath}
+  repoPath={repoPath}
+  sha={sha}
+/>
+```
+
+- [ ] **Step 4: Pass the values from `PullRequestScreen`**
+
+Open `src/features/file-explorer/screens/PullRequestScreen/index.tsx`. The values are already in scope: `repoPath.data` and `detail.data?.headSha`. Update the existing `<ThreadsPane>` call (around line 116):
+
+```tsx
+<ThreadsPane
+  prNumber={prNumber}
+  filePath={selectedPath}
+  repoPath={repoPath.data ?? undefined}
+  sha={detail.data?.headSha}
+/>
+```
+
+- [ ] **Step 5: Lint + typecheck**
+
+Run: `bun run check:fix && bun run typecheck`
+Expected: no diagnostics.
+
+- [ ] **Step 6: Run all tests**
+
+Run: `bun test`
+Expected: all tests pass — including the existing `groupAnchors.test.ts` and the new `sliceSnippet.test.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/main/components/threads/ThreadCard.tsx \
+        src/features/main/components/threads/ThreadList.tsx \
+        src/features/main/components/ThreadsPane.tsx \
+        src/features/file-explorer/screens/PullRequestScreen/index.tsx
+git commit -m "feat(phase-4 #24): plumb repoPath + sha to ThreadSnippet"
+```
+
+---
+
+## Task 9: manual smoke + close the issue
+
+**Files:** none (smoke testing only).
+
+- [ ] **Step 1: Run the dev app**
+
+Run: `bun run dev`
+Wait for the Tauri webview to open. Authenticate via `gh` if prompted.
+
+- [ ] **Step 2: Long-range inline smoke**
+
+Open a Markdown file in any PR. Verify each of these in turn:
+
+1. Drag-select a paragraph spanning ~3 lines, click Comment, save. Expect: thin left rail across all 3 lines (rounded top + bottom corners), sticky header chip above line 1, card immediately below the last line.
+2. Drag-select a 15-line region across paragraphs and a code block. Save. Expect: continuous rail along every covered line, header chip pinned at top reading `L{start}–L{end} · 1 comment` + Jump.
+3. Scroll past the chip into the middle of the range. Expect: chip remains visible at the top of the preview while the rail keeps highlighting the surrounding lines.
+4. Click the Jump button on the chip. Expect: smooth scroll lands on the card, the head comment is visibly selected.
+5. Resolve the long-range thread. Expect: the rail desaturates (its border-left color drops to the muted variant) and the gutter marker takes over. Hidden behaves the same way.
+6. Reopen the thread. Expect: rail returns to full color.
+7. Create a single-line comment elsewhere. Expect: existing wash + 3px bar (unchanged from before this PR).
+
+If the chip ever overlaps or disappears: confirm `position: sticky; top: 0` is firing inside `.prose-styles [data-thread-slot="header"]` (DevTools → Computed). If the rail disappears mid-range: `data-comment-range="body"` may have been stripped — check Step 2 of Task 5.
+
+- [ ] **Step 3: Threads-pane snippet smoke**
+
+Open the threads pane (right side). Verify:
+
+1. Each row shows up to 3 lines of monospace source from the corresponding file.
+2. Threads in unloaded files show a brief Skeleton flash, then snap to content.
+3. Range threads longer than 3 lines show `… +N more lines` beneath the snippet.
+4. Switching to a different file in the sidebar does not refetch already-cached file source (DevTools → React Query devtools, if installed; otherwise visual: no extra Skeleton flash on revisit).
+5. A resolved long-range thread still shows its snippet (only the inline highlight desaturates; the pane stays informative).
+
+- [ ] **Step 4: Update the GitHub issue**
+
+Run:
+
+```bash
+gh issue comment 24 --body "Implemented in PR (link to follow). Smoke tested: long-range left rail + sticky header + threads-pane snippet preview all behave as designed; existing single-line wash unchanged."
+```
+
+(Or comment via the GitHub UI if `gh` is not authenticated locally.)
+
+- [ ] **Step 5: Open the PR and link the issue**
+
+When the branch is ready to ship:
+
+```bash
+gh pr create --title "feat(phase-4 #24): long range comments (10–15+ lines)" --body "$(cat <<'EOF'
+## Summary
+- Inline long-range anchors now use a thin left rail + sticky header chip instead of the per-line wash; single-line anchors are unchanged.
+- Threads pane shows a 3-line source-snippet preview per thread, lazily loaded via React Query reusing `read_markdown_file`.
+
+Closes #24.
+
+## Test plan
+- [ ] `bun test` passes.
+- [ ] `bun run typecheck` passes.
+- [ ] `bun run check` passes.
+- [ ] Manual smoke per the plan's Task 9.
+EOF
+)"
+```
+
+---
+
+## Self-review notes (resolved during planning)
+
+- **Spec coverage:** every section (§1 long-range layout, §2 snippet preview, §3 IPC, §4 state/i18n, §5 tests, §6 file estimate) is implemented across Tasks 1–8. Task 9 covers the manual smoke from §5.
+- **Test scope:** the spec called for component tests via Bun + happy-dom, but the repo has no React Testing Library / happy-dom setup today and no other Phase 4 task added one. The plan keeps only the pure-function `sliceSnippet` test from §5; component behavior is verified via the smoke checklist. If we later adopt RTL, add `RangeHeaderChip.test.tsx` / `ThreadSnippet.test.tsx` per the spec.
+- **Type consistency:** `useFileSource` exposes `{ lines, isLoading, error }`. `ThreadSnippet` consumes the same shape. `ThreadCard` / `ThreadList` / `ThreadsPane` all use `repoPath?: string` and `sha?: string` — same names, same optionality, throughout the chain.
+- **No placeholders:** every step contains the actual code or command an engineer needs.

--- a/docs/superpowers/plans/2026-05-24-phase-6-github-sync.md
+++ b/docs/superpowers/plans/2026-05-24-phase-6-github-sync.md
@@ -1,0 +1,4076 @@
+# Phase 6 — GitHub Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the full GitHub-sync surface (issues #31, #32, #33, #34) on branch `feat/phase-6-github-sync`: refresh remote threads, map them to local anchors, cache them per-PR, mutate (reply / edit / delete / resolve / reopen) where GitHub allows, and surface unmapped threads in the UI.
+
+**Architecture:** Hexagonal-lite per `ARCHITECTURE.md` — pure `core` (domain types, ports, use cases), `infra` adapters for `gh` GraphQL/REST and SQLite cache, thin `ipc` commands. Frontend gets a new `src/features/sync/` feature with React-Query hooks consumed by the existing `ThreadsPane`. Spec lives at `docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md` — read it before starting.
+
+**Tech Stack:** Rust (tokio, async-trait, rusqlite, serde, tracing), Tauri v2, React 19 + TypeScript, React Query, Tailwind v4, i18next, Bun for tests/scripts.
+
+---
+
+## File map
+
+**Rust — new files**
+- `crates/core/src/domain/remote_thread.rs` — `RemoteThread`, `RemoteComment`, `ThreadState`, `MappingStatus`, `RefreshResult`.
+- `crates/core/src/ports/remote_threads_store.rs` — `RemoteThreadsStore` trait + `CachedRefresh` DTO.
+- `crates/core/src/ports/file_resolver.rs` — `FileResolver` trait used by the mapping algorithm.
+- `crates/core/src/application/sync/mod.rs` — `Sync` use-case bundle (ports).
+- `crates/core/src/application/sync/mapping.rs` — pure `map_anchor`.
+- `crates/core/src/application/sync/refresh.rs` — orchestrates list → map → cache write.
+- `crates/core/src/application/sync/cache.rs` — `get_cached`.
+- `crates/core/src/application/sync/mutations.rs` — reply/edit/delete/resolve/reopen use cases.
+- `crates/infra/src/gh/review_threads.rs` — GraphQL query + REST mutation helpers.
+- `crates/infra/src/gh/file_resolver.rs` — production `FileResolver` (git + gh fallback).
+- `crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql` — cache table.
+- `crates/infra/src/sqlite/remote_threads_store.rs` — `SqliteRemoteThreadsStore`.
+- `crates/ipc/src/commands/sync.rs` — 7 IPC commands.
+- `crates/core/tests/sync_mapping.rs`, `crates/core/tests/sync_refresh.rs`, `crates/core/tests/sync_mutations.rs`.
+- `crates/infra/tests/gh_review_threads.rs` — fixture-based parser tests (`#[ignore]`).
+- `crates/infra/tests/fixtures/gh/reviewThreads-*.json` — recorded GraphQL response fixtures.
+
+**Rust — modified files**
+- `crates/core/src/domain/mod.rs` — re-export new types.
+- `crates/core/src/ports/mod.rs` — re-export new ports.
+- `crates/core/src/ports/gh.rs` — add 6 new `GhClient` methods.
+- `crates/core/src/application/mod.rs` — register `sync`.
+- `crates/infra/src/sqlite/mod.rs` — re-export new store.
+- `crates/infra/src/sqlite/connection.rs` — append migration to `MIGRATIONS`.
+- `crates/infra/src/gh/mod.rs` — re-export helpers.
+- `crates/infra/src/gh/gh_cli.rs` — implement the 6 new `GhClient` methods.
+- `crates/ipc/src/commands/mod.rs` — register `sync`.
+- `crates/ipc/src/state.rs` — add `pub sync: Sync` field.
+- `crates/ipc/src/lib.rs` — register the 7 new handlers.
+- `src-tauri/src/bootstrap.rs` — wire `SqliteRemoteThreadsStore`, `FileResolver`, and `Sync` bundle into `AppState`.
+
+**Frontend — new files**
+- `src/features/sync/hooks/useRemoteThreads.ts` — query + refresh.
+- `src/features/sync/hooks/useReplyRemoteThread.ts`, `useEditRemoteComment.ts`, `useDeleteRemoteComment.ts`, `useResolveRemoteThread.ts`, `useReopenRemoteThread.ts`.
+- `src/features/sync/components/RemoteThreadCard.tsx` — remote-thread renderer.
+- `src/features/sync/components/RemoteReplyComposer.tsx` — single-thread reply textarea.
+- `src/features/sync/components/RemoteCommentBody.tsx` — author/avatar/body/actions row.
+- `src/features/sync/components/UnmappedThreadsSection.tsx` — collapsible footer in ThreadsPane.
+- `src/features/sync/lib/mergeLocalAndRemote.ts` + `.test.ts` — merge + dedupe by `githubId`.
+- `src/features/sync/lib/unmappedReason.ts` — i18n key resolver for each `MappingStatus`.
+
+**Frontend — modified files**
+- `src/features/sync/index.ts` — replace placeholder with feature surface.
+- `src/shared/ipc/contract.ts` — add `RemoteThread`, `RemoteComment`, etc., and the 7 commands.
+- `src/shared/ipc/client.ts` — add typed helpers under `ipc.sync.*`.
+- `src/shared/ipc/errors.ts` — map `validation` messages from sync errors (e.g. read-only).
+- `src/shared/i18n/locales/en.json` — `sync.*` namespace.
+- `src/features/main/components/RefreshButton.tsx` — add `remote-threads` to default invalidation keys.
+- `src/features/main/components/ThreadsPane.tsx` — consume `useRemoteThreads`, render merged list + unmapped section.
+- `src-tauri/capabilities/default.json` — capability lists are auto-derived in Tauri v2 from registered commands; no update needed unless we add a new permission. Verify in Task 10.
+
+---
+
+## Branch / setup
+
+This plan assumes branch `feat/phase-6-github-sync` (already created with the spec commit `docs(phase-6): spec for GitHub sync`). Every task ends in a commit on this branch. The final PR groups everything.
+
+---
+
+# Phase 0 — Foundation
+
+## Task 1: Domain types for remote threads
+
+**Files:**
+- Create: `crates/core/src/domain/remote_thread.rs`
+- Modify: `crates/core/src/domain/mod.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/core/src/domain/remote_thread.rs` test module:
+
+```rust
+//! Domain types for remote-originating PR review threads (Phase 6).
+//! GitHub returns line numbers as a mix of `int?` (current position) and
+//! `int!` (original position). We mirror that here so the mapping layer
+//! can decide what to do without re-fetching.
+
+use serde::{Deserialize, Serialize};
+
+use super::CommentAnchor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThreadState {
+    Open,
+    Resolved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum MappingStatus {
+    Mapped,
+    Outdated { reason: String },
+    FileMissing,
+    LineMoved,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteComment {
+    pub comment_id: i64,
+    pub author: String,
+    pub author_avatar_url: Option<String>,
+    pub body: String,
+    /// RFC3339 strings; the UI does its own formatting.
+    pub created_at: String,
+    pub updated_at: String,
+    pub viewer_can_update: bool,
+    pub viewer_can_delete: bool,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteThread {
+    /// GraphQL node id of the review thread. Required by resolve/unresolve.
+    pub thread_id: String,
+    pub path: String,
+    pub original_commit_id: String,
+    pub line: Option<u32>,
+    pub start_line: Option<u32>,
+    pub original_line: u32,
+    pub original_start_line: Option<u32>,
+    pub state: ThreadState,
+    pub is_outdated: bool,
+    pub viewer_can_resolve: bool,
+    pub viewer_can_unresolve: bool,
+    pub comments: Vec<RemoteComment>,
+    pub anchor: Option<CommentAnchor>,
+    pub mapping_status: MappingStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshResult {
+    /// Threads with `mapping_status == Mapped` and `anchor.is_some()`.
+    pub threads: Vec<RemoteThread>,
+    /// Threads we couldn't safely anchor; preserved for the #34 panel.
+    pub unmapped: Vec<RemoteThread>,
+    pub refreshed_at_ms: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapping_status_serializes_with_kind_tag() {
+        let json = serde_json::to_string(&MappingStatus::Outdated {
+            reason: "github_outdated".into(),
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"outdated\""));
+        assert!(json.contains("\"reason\":\"github_outdated\""));
+    }
+
+    #[test]
+    fn thread_state_round_trips() {
+        let raw = serde_json::to_string(&ThreadState::Resolved).unwrap();
+        assert_eq!(raw, "\"resolved\"");
+        let back: ThreadState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(back, ThreadState::Resolved);
+    }
+}
+```
+
+- [ ] **Step 2: Re-export from domain module**
+
+Edit `crates/core/src/domain/mod.rs` — add the module and re-exports:
+
+```rust
+pub mod changed_file;
+pub mod comment;
+pub mod file_diff;
+pub mod pull_request;
+pub mod remote_thread;
+pub mod repository;
+pub mod tool_status;
+
+pub use changed_file::{ChangeStatus, ChangedFile};
+pub use comment::{CommentAnchor, CommentState, CommentUpdate, ReviewComment};
+pub use file_diff::{DiffHunk, FileDiff, HunkKind};
+pub use pull_request::{PullRequestDetail, PullRequestState, PullRequestSummary};
+pub use remote_thread::{
+    MappingStatus, RefreshResult, RemoteComment, RemoteThread, ThreadState,
+};
+pub use repository::{RemoteUrl, Repository};
+pub use tool_status::{ToolCheck, ToolStatus};
+```
+
+- [ ] **Step 3: Run the test and verify it passes**
+
+Run: `cargo test -p markdown-reviewer-core --lib remote_thread`
+Expected: 2 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/core/src/domain/remote_thread.rs crates/core/src/domain/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6): remote thread domain types
+
+Adds RemoteThread/RemoteComment/MappingStatus/RefreshResult.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Port traits — `RemoteThreadsStore` and `FileResolver`
+
+**Files:**
+- Create: `crates/core/src/ports/remote_threads_store.rs`
+- Create: `crates/core/src/ports/file_resolver.rs`
+- Modify: `crates/core/src/ports/mod.rs`
+
+- [ ] **Step 1: Write `RemoteThreadsStore` trait**
+
+Create `crates/core/src/ports/remote_threads_store.rs`:
+
+```rust
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::{RefreshResult, RemoteThread};
+use crate::AppResult;
+
+/// Snapshot returned by `RemoteThreadsStore::get`. Carries the head sha we
+/// were anchored to so the UI can warn when the cache predates the current
+/// head.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedRefresh {
+    pub head_sha: String,
+    pub refreshed_at_ms: i64,
+    pub threads: Vec<RemoteThread>,
+    pub unmapped: Vec<RemoteThread>,
+}
+
+impl CachedRefresh {
+    pub fn into_refresh_result(self) -> RefreshResult {
+        RefreshResult {
+            threads: self.threads,
+            unmapped: self.unmapped,
+            refreshed_at_ms: self.refreshed_at_ms,
+        }
+    }
+}
+
+#[async_trait]
+pub trait RemoteThreadsStore: Send + Sync {
+    /// Reads the cached payload for `(repo_path, pr_number)`. Returns
+    /// `Ok(None)` when no row exists yet.
+    async fn get(&self, repo_path: &str, pr_number: u64) -> AppResult<Option<CachedRefresh>>;
+
+    /// Writes the cache row, replacing any previous entry for the same
+    /// `(repo_path, pr_number)`. Called from `application::sync::refresh`
+    /// after a successful round-trip.
+    async fn put(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        cached: &CachedRefresh,
+    ) -> AppResult<()>;
+}
+```
+
+- [ ] **Step 2: Write `FileResolver` trait**
+
+Create `crates/core/src/ports/file_resolver.rs`:
+
+```rust
+use async_trait::async_trait;
+
+use crate::AppResult;
+
+/// Reads a file's contents at a specific commit. Implementations may fall
+/// back to `gh` when the ref isn't in the local clone.
+#[async_trait]
+pub trait FileResolver: Send + Sync {
+    async fn read(&self, repo_path: &str, sha: &str, file_path: &str) -> AppResult<String>;
+}
+```
+
+- [ ] **Step 3: Wire into `ports::mod.rs`**
+
+Edit `crates/core/src/ports/mod.rs`:
+
+```rust
+pub mod clock;
+pub mod comments_store;
+pub mod file_resolver;
+pub mod gh;
+pub mod git;
+pub mod recents_store;
+pub mod remote_threads_store;
+
+pub use clock::Clock;
+pub use comments_store::{CommentsStore, NewComment, SubmitOutcome};
+pub use file_resolver::FileResolver;
+pub use gh::{
+    GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult, SubmittedReviewComment,
+};
+pub use git::GitClient;
+pub use recents_store::{RecentRepository, RecentsStore};
+pub use remote_threads_store::{CachedRefresh, RemoteThreadsStore};
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check -p markdown-reviewer-core`
+Expected: clean build (no impls yet, so no consumer breakage).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/ports/remote_threads_store.rs \
+         crates/core/src/ports/file_resolver.rs \
+         crates/core/src/ports/mod.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6): RemoteThreadsStore + FileResolver ports
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Extend `GhClient` port with 7 new methods
+
+**Files:**
+- Modify: `crates/core/src/ports/gh.rs`
+
+- [ ] **Step 1: Add method signatures**
+
+Append to `crates/core/src/ports/gh.rs` (inside the existing `#[async_trait] impl GhClient` block — at the end of the trait body):
+
+```rust
+    /// Fetches every review thread on a PR via the GraphQL endpoint
+    /// `repository.pullRequest.reviewThreads(first: 100)`. Includes the
+    /// thread node id (for resolve/unresolve), `isResolved`, `isOutdated`,
+    /// and every comment's `viewerCan*` flags. Truncation past 100 threads
+    /// is logged inside the adapter and surfaced via `truncated == true`.
+    async fn list_review_threads(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+    ) -> AppResult<FetchedReviewThreads>;
+
+    /// Posts a reply to an existing review thread via REST
+    /// `POST /repos/{owner}/{repo}/pulls/{n}/comments` with `in_reply_to`.
+    /// Returns the freshly-created `RemoteComment`.
+    async fn reply_review_comment(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        in_reply_to_comment_id: i64,
+        body: &str,
+    ) -> AppResult<crate::domain::RemoteComment>;
+
+    /// `PATCH /repos/{owner}/{repo}/pulls/comments/{id}`.
+    async fn edit_review_comment(
+        &self,
+        repo_path: &str,
+        comment_id: i64,
+        body: &str,
+    ) -> AppResult<crate::domain::RemoteComment>;
+
+    /// `DELETE /repos/{owner}/{repo}/pulls/comments/{id}` — 204 on success.
+    async fn delete_review_comment(&self, repo_path: &str, comment_id: i64) -> AppResult<()>;
+
+    /// GraphQL `resolveReviewThread(threadId: <node id>)`. Returns the
+    /// updated thread (refetched via `list_review_threads_by_id`).
+    async fn resolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<crate::domain::RemoteThread>;
+
+    /// GraphQL `unresolveReviewThread(threadId: <node id>)`.
+    async fn unresolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<crate::domain::RemoteThread>;
+```
+
+And add the new return DTO above the trait (after the existing `ReviewSubmissionResult` block):
+
+```rust
+/// Raw GraphQL payload as returned by the adapter. The mapping use case is
+/// the only consumer; `truncated` lets the UI surface a banner when we
+/// stopped at the first page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchedReviewThreads {
+    pub threads: Vec<crate::domain::RemoteThread>,
+    pub truncated: bool,
+}
+```
+
+- [ ] **Step 2: Re-export from `ports::mod.rs`**
+
+Edit `crates/core/src/ports/mod.rs` — update the `gh` re-export line:
+
+```rust
+pub use gh::{
+    FetchedReviewThreads, GhAuthReport, GhClient, ReviewCommentInput, ReviewSubmissionResult,
+    SubmittedReviewComment,
+};
+```
+
+- [ ] **Step 3: Run the workspace check — every test fake will fail to compile**
+
+Run: `cargo check --workspace --all-targets`
+Expected: failures in `crates/core/tests/comments_submit.rs` (and any other test that impls `GhClient`). This is intentional — we're about to add stubs.
+
+- [ ] **Step 4: Add `unimplemented!()` stubs to existing test fakes**
+
+Add to every `impl GhClient for ...` block in `crates/core/tests/` (currently just `comments_submit.rs`) the seven stubs:
+
+```rust
+    async fn list_review_threads(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        unimplemented!("not used in this test")
+    }
+    async fn reply_review_comment(
+        &self,
+        _repo_path: &str,
+        _pr_number: u64,
+        _in_reply_to_comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn edit_review_comment(
+        &self,
+        _repo_path: &str,
+        _comment_id: i64,
+        _body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        unimplemented!("not used in this test")
+    }
+    async fn delete_review_comment(&self, _repo_path: &str, _comment_id: i64) -> AppResult<()> {
+        unimplemented!("not used in this test")
+    }
+    async fn resolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+    async fn unresolve_review_thread(
+        &self,
+        _repo_path: &str,
+        _thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        unimplemented!("not used in this test")
+    }
+```
+
+- [ ] **Step 5: Add the same stubs to the production `GhCli` impl**
+
+In `crates/infra/src/gh/gh_cli.rs`, at the end of `impl GhClient for GhCli`, paste the same seven method bodies with `unimplemented!("Phase 6 — implemented in later task")`. They'll be replaced in Tasks 8 and 9.
+
+- [ ] **Step 6: Verify workspace compiles again**
+
+Run: `cargo check --workspace --all-targets`
+Expected: clean.
+
+- [ ] **Step 7: Run existing tests to confirm no regression**
+
+Run: `cargo test --workspace --lib`
+Expected: pre-existing tests pass; new code is stubs only.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/core/src/ports/gh.rs crates/core/src/ports/mod.rs \
+         crates/core/tests/comments_submit.rs crates/infra/src/gh/gh_cli.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6): extend GhClient port with review-thread methods
+
+Adds list_review_threads + reply/edit/delete/resolve/unresolve.
+Production impl + test fakes get unimplemented!() bodies until the
+adapters land.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Sync use-case scaffold + cache migration
+
+**Files:**
+- Create: `crates/core/src/application/sync/mod.rs`
+- Modify: `crates/core/src/application/mod.rs`
+- Create: `crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql`
+- Modify: `crates/infra/src/sqlite/connection.rs`
+
+- [ ] **Step 1: Create the migration**
+
+Create `crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS remote_threads_cache (
+    repo_path TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    refreshed_at_ms INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    PRIMARY KEY (repo_path, pr_number)
+);
+```
+
+- [ ] **Step 2: Register the migration**
+
+Edit `crates/infra/src/sqlite/connection.rs` — extend `MIGRATIONS`:
+
+```rust
+const MIGRATIONS: &[(&str, &str)] = &[
+    ("0001_recents", include_str!("migrations/0001_recents.sql")),
+    (
+        "0002_ui_state",
+        include_str!("migrations/0002_ui_state.sql"),
+    ),
+    (
+        "0003_local_comments",
+        include_str!("migrations/0003_local_comments.sql"),
+    ),
+    (
+        "0004_remote_threads_cache",
+        include_str!("migrations/0004_remote_threads_cache.sql"),
+    ),
+];
+```
+
+- [ ] **Step 3: Create the Sync use-case bundle**
+
+Create `crates/core/src/application/sync/mod.rs`:
+
+```rust
+pub mod cache;
+pub mod mapping;
+pub mod mutations;
+pub mod refresh;
+
+use std::sync::Arc;
+
+use crate::ports::{Clock, FileResolver, GhClient, RemoteThreadsStore};
+
+/// Ports bundle for every sync use case. Cloned from `AppState`; every field
+/// is `Arc<dyn …>` so cloning is cheap.
+#[derive(Clone)]
+pub struct Sync {
+    pub gh: Arc<dyn GhClient>,
+    pub store: Arc<dyn RemoteThreadsStore>,
+    pub files: Arc<dyn FileResolver>,
+    pub clock: Arc<dyn Clock>,
+}
+```
+
+- [ ] **Step 4: Create empty submodule files**
+
+Create with placeholder content:
+
+```rust
+// crates/core/src/application/sync/mapping.rs
+//! Pure anchor-mapping algorithm. Implemented in Task 5.
+```
+
+```rust
+// crates/core/src/application/sync/refresh.rs
+//! Refresh-and-cache orchestration. Implemented in Task 6.
+```
+
+```rust
+// crates/core/src/application/sync/cache.rs
+//! Cache hydration read path. Implemented in Task 7.
+```
+
+```rust
+// crates/core/src/application/sync/mutations.rs
+//! Reply/edit/delete/resolve/reopen use cases. Implemented in Task 9.
+```
+
+- [ ] **Step 5: Register the application family**
+
+Edit `crates/core/src/application/mod.rs`:
+
+```rust
+pub mod comments;
+pub mod files;
+pub mod pull_requests;
+pub mod repo_selection;
+pub mod sync;
+```
+
+- [ ] **Step 6: Verify compile**
+
+Run: `cargo check --workspace`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/core/src/application/sync \
+         crates/core/src/application/mod.rs \
+         crates/infra/src/sqlite/migrations/0004_remote_threads_cache.sql \
+         crates/infra/src/sqlite/connection.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #33): scaffold Sync use-case bundle and cache migration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 1 — Anchor mapping + refresh (#31 + #34)
+
+## Task 5: Pure anchor-mapping algorithm
+
+**Files:**
+- Modify: `crates/core/src/application/sync/mapping.rs`
+- Create: `crates/core/tests/sync_mapping.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/core/tests/sync_mapping.rs`:
+
+```rust
+//! Use-case tests for `application::sync::mapping::map_anchor`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::mapping::map_anchor;
+use markdown_reviewer_core::domain::{
+    CommentAnchor, MappingStatus, RemoteComment, RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::FileResolver;
+use markdown_reviewer_core::{AppError, AppResult};
+
+/// Resolves files by exact (sha, path) lookup.
+#[derive(Default)]
+struct FakeFiles {
+    files: Mutex<HashMap<(String, String), String>>,
+}
+
+impl FakeFiles {
+    fn insert(&self, sha: &str, path: &str, content: &str) {
+        self.files
+            .lock()
+            .unwrap()
+            .insert((sha.into(), path.into()), content.into());
+    }
+}
+
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _repo_path: &str, sha: &str, path: &str) -> AppResult<String> {
+        self.files
+            .lock()
+            .unwrap()
+            .get(&(sha.into(), path.into()))
+            .cloned()
+            .ok_or_else(|| AppError::FileNotFound {
+                sha: sha.into(),
+                path: path.into(),
+            })
+    }
+}
+
+fn thread_with(
+    original_sha: &str,
+    path: &str,
+    original_line: u32,
+    original_start_line: Option<u32>,
+    line: Option<u32>,
+    is_outdated: bool,
+) -> RemoteThread {
+    RemoteThread {
+        thread_id: "T_kw1".into(),
+        path: path.into(),
+        original_commit_id: original_sha.into(),
+        line,
+        start_line: None,
+        original_line,
+        original_start_line,
+        state: ThreadState::Open,
+        is_outdated,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![RemoteComment {
+            comment_id: 1,
+            author: "alice".into(),
+            author_avatar_url: None,
+            body: "hi".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            viewer_can_update: false,
+            viewer_can_delete: false,
+            html_url: "https://example".into(),
+        }],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn maps_when_head_matches_original_commit() {
+    let files = FakeFiles::default();
+    let t = thread_with("abc", "README.md", 4, None, Some(4), false);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(anchor, Some(CommentAnchor::SingleLine { line: 4 }));
+}
+
+#[tokio::test]
+async fn maps_multi_line_range_when_head_matches() {
+    let files = FakeFiles::default();
+    let mut t = thread_with("abc", "doc.md", 7, Some(4), Some(7), false);
+    t.start_line = Some(4);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(
+        anchor,
+        Some(CommentAnchor::LineRange { start_line: 4, end_line: 7 })
+    );
+}
+
+#[tokio::test]
+async fn outdated_threads_stay_unmapped() {
+    let files = FakeFiles::default();
+    let t = thread_with("abc", "README.md", 4, None, None, true);
+    let (anchor, status) = map_anchor(&t, "abc", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert!(matches!(status, MappingStatus::Outdated { .. }));
+}
+
+#[tokio::test]
+async fn snippet_relocated_in_new_head_remaps() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\ngamma\n"); // line 2 = "beta"
+    files.insert("new", "doc.md", "x\ny\nz\nbeta\n"); // line 4 = "beta"
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert_eq!(status, MappingStatus::Mapped);
+    assert_eq!(anchor, Some(CommentAnchor::SingleLine { line: 4 }));
+}
+
+#[tokio::test]
+async fn snippet_missing_in_new_head_is_line_moved() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    files.insert("new", "doc.md", "alpha\nDELTA\n");
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::LineMoved);
+}
+
+#[tokio::test]
+async fn snippet_appears_twice_is_ambiguous() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    files.insert("new", "doc.md", "beta\nbeta\n");
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::Ambiguous);
+}
+
+#[tokio::test]
+async fn missing_file_at_new_head_is_file_missing() {
+    let files = FakeFiles::default();
+    files.insert("old", "doc.md", "alpha\nbeta\n");
+    // new sha has no "doc.md" entry → resolver returns FileNotFound.
+    let t = thread_with("old", "doc.md", 2, None, Some(2), false);
+    let (anchor, status) = map_anchor(&t, "new", "/tmp", &files).await;
+    assert!(anchor.is_none());
+    assert_eq!(status, MappingStatus::FileMissing);
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_mapping`
+Expected: compile error (`map_anchor` not yet exported).
+
+- [ ] **Step 3: Implement `map_anchor`**
+
+Replace `crates/core/src/application/sync/mapping.rs` with:
+
+```rust
+//! Pure anchor-mapping algorithm — decides whether a remote thread can be
+//! anchored to the current head, and why if not.
+
+use crate::domain::{CommentAnchor, MappingStatus, RemoteThread};
+use crate::ports::FileResolver;
+use crate::AppError;
+
+/// Maps a remote thread onto an anchor against `head_sha`. Returns the
+/// anchor + status pair so callers can re-set both on the thread.
+pub async fn map_anchor(
+    thread: &RemoteThread,
+    head_sha: &str,
+    repo_path: &str,
+    files: &dyn FileResolver,
+) -> (Option<CommentAnchor>, MappingStatus) {
+    // 1. GitHub-flagged outdated short-circuit.
+    if thread.is_outdated || thread.line.is_none() {
+        return (
+            None,
+            MappingStatus::Outdated {
+                reason: "github_outdated".into(),
+            },
+        );
+    }
+    let end_line = thread
+        .line
+        .expect("checked is_some() in the guard above");
+    let start_line = thread.start_line.unwrap_or(end_line);
+
+    // 2. Same-commit fast path.
+    if thread.original_commit_id == head_sha {
+        return (Some(build_anchor(start_line, end_line)), MappingStatus::Mapped);
+    }
+
+    // 3. Cross-commit — find the original snippet in the new head.
+    let original = match files
+        .read(repo_path, &thread.original_commit_id, &thread.path)
+        .await
+    {
+        Ok(text) => text,
+        // The original blob is unreachable — treat as unmapped, not as a
+        // hard error. The thread is still surfaced under "Unmapped".
+        Err(AppError::FileNotFound { .. }) | Err(_) => {
+            return (None, MappingStatus::FileMissing);
+        }
+    };
+    let new = match files.read(repo_path, head_sha, &thread.path).await {
+        Ok(text) => text,
+        Err(_) => return (None, MappingStatus::FileMissing),
+    };
+
+    let snippet = match extract_lines(&original, start_line, end_line) {
+        Some(s) => s,
+        None => return (None, MappingStatus::LineMoved),
+    };
+
+    let matches = find_snippet_positions(&new, &snippet);
+    match matches.len() {
+        1 => {
+            let new_start = matches[0];
+            let span = end_line - start_line;
+            (
+                Some(build_anchor(new_start, new_start + span)),
+                MappingStatus::Mapped,
+            )
+        }
+        0 => (None, MappingStatus::LineMoved),
+        _ => (None, MappingStatus::Ambiguous),
+    }
+}
+
+fn build_anchor(start: u32, end: u32) -> CommentAnchor {
+    if start == end {
+        CommentAnchor::SingleLine { line: start }
+    } else {
+        CommentAnchor::LineRange {
+            start_line: start,
+            end_line: end,
+        }
+    }
+}
+
+/// Returns the contiguous lines `[start..=end]` (1-indexed) of `text` joined
+/// by `\n`, or `None` when the range falls outside the file.
+fn extract_lines(text: &str, start: u32, end: u32) -> Option<String> {
+    let lines: Vec<&str> = text.lines().collect();
+    let s = (start as usize).checked_sub(1)?;
+    let e = (end as usize).checked_sub(1)?;
+    if e >= lines.len() {
+        return None;
+    }
+    Some(lines[s..=e].join("\n"))
+}
+
+/// Returns every 1-indexed starting line in `haystack` where `snippet` is
+/// found as a contiguous block of full lines.
+fn find_snippet_positions(haystack: &str, snippet: &str) -> Vec<u32> {
+    let hay: Vec<&str> = haystack.lines().collect();
+    let needle: Vec<&str> = snippet.split('\n').collect();
+    if needle.is_empty() || hay.len() < needle.len() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let last_start = hay.len() - needle.len();
+    for start in 0..=last_start {
+        if hay[start..start + needle.len()] == needle[..] {
+            out.push((start as u32) + 1);
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_mapping`
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/application/sync/mapping.rs \
+         crates/core/tests/sync_mapping.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #31): pure anchor-mapping algorithm
+
+Maps remote threads onto the current head via exact-commit match
+or snippet relocation; falls back to MappingStatus::{Outdated,
+LineMoved, Ambiguous, FileMissing} when it cannot.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `refresh::run` orchestration (#31 + #34)
+
+**Files:**
+- Modify: `crates/core/src/application/sync/refresh.rs`
+- Create: `crates/core/tests/sync_refresh.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `crates/core/tests/sync_refresh.rs`:
+
+```rust
+//! End-to-end tests for `application::sync::refresh::run`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::{refresh, Sync};
+use markdown_reviewer_core::domain::{
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
+    RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::{
+    CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
+    RemoteThreadsStore, ReviewCommentInput,
+};
+use markdown_reviewer_core::{AppError, AppResult};
+
+#[derive(Default)]
+struct FakeFiles(Mutex<HashMap<(String, String), String>>);
+
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _repo: &str, sha: &str, path: &str) -> AppResult<String> {
+        self.0
+            .lock()
+            .unwrap()
+            .get(&(sha.into(), path.into()))
+            .cloned()
+            .ok_or_else(|| AppError::FileNotFound {
+                sha: sha.into(),
+                path: path.into(),
+            })
+    }
+}
+
+struct FakeGh {
+    payload: Mutex<FetchedReviewThreads>,
+}
+
+#[async_trait]
+impl GhClient for FakeGh {
+    async fn version(&self) -> AppResult<String> { unimplemented!() }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
+    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
+    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
+
+    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> {
+        Ok(self.payload.lock().unwrap().clone())
+    }
+
+    async fn reply_review_comment(&self, _: &str, _: u64, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
+    async fn edit_review_comment(&self, _: &str, _: i64, _: &str) -> AppResult<RemoteComment> { unimplemented!() }
+    async fn delete_review_comment(&self, _: &str, _: i64) -> AppResult<()> { unimplemented!() }
+    async fn resolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
+    async fn unresolve_review_thread(&self, _: &str, _: &str) -> AppResult<RemoteThread> { unimplemented!() }
+}
+
+#[derive(Default)]
+struct FakeStore(Mutex<HashMap<(String, u64), CachedRefresh>>);
+
+#[async_trait]
+impl RemoteThreadsStore for FakeStore {
+    async fn get(&self, repo: &str, pr: u64) -> AppResult<Option<CachedRefresh>> {
+        Ok(self.0.lock().unwrap().get(&(repo.into(), pr)).cloned())
+    }
+    async fn put(&self, repo: &str, pr: u64, _head: &str, cached: &CachedRefresh) -> AppResult<()> {
+        self.0
+            .lock()
+            .unwrap()
+            .insert((repo.into(), pr), cached.clone());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct FixedClock;
+impl Clock for FixedClock {
+    fn now_unix_ms(&self) -> i64 { 1_700_000_000_000 }
+}
+
+fn thread(thread_id: &str, path: &str, line: u32, original_sha: &str) -> RemoteThread {
+    RemoteThread {
+        thread_id: thread_id.into(),
+        path: path.into(),
+        original_commit_id: original_sha.into(),
+        line: Some(line),
+        start_line: None,
+        original_line: line,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn partitions_mapped_and_unmapped_and_writes_cache() {
+    let gh = Arc::new(FakeGh {
+        payload: Mutex::new(FetchedReviewThreads {
+            threads: vec![
+                thread("T1", "doc.md", 1, "abc"), // will map (same head)
+                {
+                    let mut t = thread("T2", "missing.md", 1, "abc");
+                    t.is_outdated = true;
+                    t.line = None;
+                    t
+                },
+            ],
+            truncated: false,
+        }),
+    });
+    let files = Arc::new(FakeFiles::default());
+    let store = Arc::new(FakeStore::default());
+    let svc = Sync {
+        gh: gh.clone(),
+        store: store.clone(),
+        files,
+        clock: Arc::new(FixedClock),
+    };
+
+    let result = refresh::run(&svc, "/repo", 7, "abc").await.unwrap();
+    assert_eq!(result.threads.len(), 1);
+    assert_eq!(result.unmapped.len(), 1);
+    assert_eq!(result.refreshed_at_ms, 1_700_000_000_000);
+
+    let cached = store.get("/repo", 7).await.unwrap().expect("cache row");
+    assert_eq!(cached.head_sha, "abc");
+    assert_eq!(cached.threads.len(), 1);
+    assert_eq!(cached.unmapped.len(), 1);
+}
+```
+
+- [ ] **Step 2: Run — expect compile failure**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_refresh`
+Expected: missing `refresh::run`.
+
+- [ ] **Step 3: Implement `refresh::run`**
+
+Replace `crates/core/src/application/sync/refresh.rs` with:
+
+```rust
+//! Refresh + map + cache pipeline. Always hits the network — caller is
+//! responsible for invalidating React Query / SQLite cache as needed.
+
+use crate::domain::{MappingStatus, RefreshResult, RemoteThread};
+use crate::ports::CachedRefresh;
+use crate::AppResult;
+
+use super::{mapping::map_anchor, Sync};
+
+pub async fn run(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+    head_sha: &str,
+) -> AppResult<RefreshResult> {
+    let fetched = svc.gh.list_review_threads(repo_path, pr_number).await?;
+    let mut mapped: Vec<RemoteThread> = Vec::new();
+    let mut unmapped: Vec<RemoteThread> = Vec::new();
+
+    for mut thread in fetched.threads {
+        let (anchor, status) =
+            map_anchor(&thread, head_sha, repo_path, svc.files.as_ref()).await;
+        thread.anchor = anchor;
+        thread.mapping_status = status.clone();
+        if matches!(status, MappingStatus::Mapped) && thread.anchor.is_some() {
+            mapped.push(thread);
+        } else {
+            unmapped.push(thread);
+        }
+    }
+
+    // Deterministic ordering: file path, then start line, then thread id.
+    mapped.sort_by(|a, b| {
+        let a_line = a.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
+        let b_line = b.anchor.as_ref().map(|x| x.start_line()).unwrap_or(0);
+        a.path
+            .cmp(&b.path)
+            .then(a_line.cmp(&b_line))
+            .then(a.thread_id.cmp(&b.thread_id))
+    });
+    unmapped.sort_by(|a, b| a.path.cmp(&b.path).then(a.thread_id.cmp(&b.thread_id)));
+
+    let refreshed_at_ms = svc.clock.now_unix_ms();
+    let cached = CachedRefresh {
+        head_sha: head_sha.to_string(),
+        refreshed_at_ms,
+        threads: mapped.clone(),
+        unmapped: unmapped.clone(),
+    };
+    svc.store
+        .put(repo_path, pr_number, head_sha, &cached)
+        .await?;
+
+    if fetched.truncated {
+        tracing::warn!(
+            pr_number,
+            "list_review_threads truncated at 100 threads — pagination not yet implemented"
+        );
+    }
+
+    Ok(RefreshResult {
+        threads: mapped,
+        unmapped,
+        refreshed_at_ms,
+    })
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_refresh`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/core/src/application/sync/refresh.rs \
+         crates/core/tests/sync_refresh.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #31 #34): refresh pipeline with mapped/unmapped partition
+
+Orchestrates list_review_threads → map_anchor → cache write.
+Mapped threads go to RefreshResult.threads; everything else lands
+in RefreshResult.unmapped so the UI can render the unmapped section.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Cache read use case + SQLite store
+
+**Files:**
+- Modify: `crates/core/src/application/sync/cache.rs`
+- Create: `crates/infra/src/sqlite/remote_threads_store.rs`
+- Modify: `crates/infra/src/sqlite/mod.rs`
+
+- [ ] **Step 1: Implement the cache read use case**
+
+Replace `crates/core/src/application/sync/cache.rs`:
+
+```rust
+//! Read-only hydration helper for the per-PR remote-thread cache.
+
+use crate::domain::RefreshResult;
+use crate::AppResult;
+
+use super::Sync;
+
+pub async fn get_cached(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+) -> AppResult<Option<RefreshResult>> {
+    let row = svc.store.get(repo_path, pr_number).await?;
+    Ok(row.map(|c| c.into_refresh_result()))
+}
+```
+
+- [ ] **Step 2: Implement `SqliteRemoteThreadsStore`**
+
+Create `crates/infra/src/sqlite/remote_threads_store.rs`:
+
+```rust
+use async_trait::async_trait;
+use markdown_reviewer_core::ports::{CachedRefresh, RemoteThreadsStore};
+use markdown_reviewer_core::{AppError, AppResult};
+use rusqlite::params;
+
+use super::Db;
+
+pub struct SqliteRemoteThreadsStore {
+    db: Db,
+}
+
+impl SqliteRemoteThreadsStore {
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Payload {
+    threads: Vec<markdown_reviewer_core::domain::RemoteThread>,
+    unmapped: Vec<markdown_reviewer_core::domain::RemoteThread>,
+}
+
+#[async_trait]
+impl RemoteThreadsStore for SqliteRemoteThreadsStore {
+    async fn get(&self, repo_path: &str, pr_number: u64) -> AppResult<Option<CachedRefresh>> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        let repo = repo_path.to_string();
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            let row = conn
+                .query_row(
+                    "SELECT head_sha, refreshed_at_ms, payload_json \
+                     FROM remote_threads_cache \
+                     WHERE repo_path = ?1 AND pr_number = ?2",
+                    params![repo, pr_signed],
+                    |r| {
+                        Ok((
+                            r.get::<_, String>(0)?,
+                            r.get::<_, i64>(1)?,
+                            r.get::<_, String>(2)?,
+                        ))
+                    },
+                )
+                .ok();
+            let Some((head_sha, refreshed_at_ms, payload_json)) = row else {
+                return Ok::<_, AppError>(None);
+            };
+            let payload: Payload = serde_json::from_str(&payload_json)
+                .map_err(|e| AppError::db(format!("cache payload corrupt: {e}")))?;
+            Ok(Some(CachedRefresh {
+                head_sha,
+                refreshed_at_ms,
+                threads: payload.threads,
+                unmapped: payload.unmapped,
+            }))
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+
+    async fn put(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        head_sha: &str,
+        cached: &CachedRefresh,
+    ) -> AppResult<()> {
+        let db = self.db.clone();
+        let pr_signed = i64::try_from(pr_number).unwrap_or(i64::MAX);
+        let repo = repo_path.to_string();
+        let head = head_sha.to_string();
+        let refreshed = cached.refreshed_at_ms;
+        let payload = Payload {
+            threads: cached.threads.clone(),
+            unmapped: cached.unmapped.clone(),
+        };
+        let json = serde_json::to_string(&payload).expect("Payload always serializes");
+        tokio::task::spawn_blocking(move || {
+            let conn = db.lock().map_err(|e| AppError::db(e.to_string()))?;
+            conn.execute(
+                "INSERT INTO remote_threads_cache(repo_path, pr_number, head_sha, refreshed_at_ms, payload_json) \
+                 VALUES (?1, ?2, ?3, ?4, ?5) \
+                 ON CONFLICT(repo_path, pr_number) DO UPDATE SET \
+                    head_sha = excluded.head_sha, \
+                    refreshed_at_ms = excluded.refreshed_at_ms, \
+                    payload_json = excluded.payload_json",
+                params![repo, pr_signed, head, refreshed, json],
+            )
+            .map_err(AppError::db)?;
+            Ok(())
+        })
+        .await
+        .map_err(AppError::unexpected)?
+    }
+}
+```
+
+- [ ] **Step 3: Re-export from sqlite module**
+
+Edit `crates/infra/src/sqlite/mod.rs`:
+
+```rust
+pub mod comments_store;
+pub mod connection;
+pub mod recents_store;
+pub mod remote_threads_store;
+
+pub use comments_store::SqliteCommentsStore;
+pub use connection::{open_and_migrate, Db};
+pub use recents_store::SqliteRecentsStore;
+pub use remote_threads_store::SqliteRemoteThreadsStore;
+```
+
+- [ ] **Step 4: Add an integration smoke test**
+
+Create `crates/infra/tests/sqlite_remote_threads.rs`:
+
+```rust
+use markdown_reviewer_core::domain::{MappingStatus, RemoteThread, ThreadState};
+use markdown_reviewer_core::ports::{CachedRefresh, RemoteThreadsStore};
+use markdown_reviewer_infra::sqlite::{open_and_migrate, SqliteRemoteThreadsStore};
+use tempfile::tempdir;
+
+fn sample_thread() -> RemoteThread {
+    RemoteThread {
+        thread_id: "T1".into(),
+        path: "doc.md".into(),
+        original_commit_id: "abc".into(),
+        line: Some(4),
+        start_line: None,
+        original_line: 4,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[tokio::test]
+async fn roundtrips_a_cache_row() {
+    let dir = tempdir().unwrap();
+    let db_path = dir.path().join("test.sqlite");
+    let db = open_and_migrate(&db_path).unwrap();
+    let store = SqliteRemoteThreadsStore::new(db);
+
+    let cached = CachedRefresh {
+        head_sha: "abc".into(),
+        refreshed_at_ms: 42,
+        threads: vec![sample_thread()],
+        unmapped: vec![],
+    };
+    store.put("/repo", 7, "abc", &cached).await.unwrap();
+
+    let fetched = store.get("/repo", 7).await.unwrap().unwrap();
+    assert_eq!(fetched.head_sha, "abc");
+    assert_eq!(fetched.refreshed_at_ms, 42);
+    assert_eq!(fetched.threads.len(), 1);
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_refresh` (still green)
+Run: `cargo test -p markdown-reviewer-infra --test sqlite_remote_threads`
+Expected: both green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/core/src/application/sync/cache.rs \
+         crates/infra/src/sqlite/remote_threads_store.rs \
+         crates/infra/src/sqlite/mod.rs \
+         crates/infra/tests/sqlite_remote_threads.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #33): SqliteRemoteThreadsStore + get_cached use case
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 2 — Production `gh` adapter
+
+## Task 8: Implement `list_review_threads` (GraphQL)
+
+**Files:**
+- Modify: `crates/infra/src/gh/gh_cli.rs`
+- Create: `crates/infra/src/gh/review_threads.rs`
+- Modify: `crates/infra/src/gh/mod.rs`
+- Create: `crates/infra/tests/fixtures/gh/review-threads-basic.json`
+- Create: `crates/infra/tests/gh_review_threads.rs`
+
+- [ ] **Step 1: Add a fixture**
+
+Create `crates/infra/tests/fixtures/gh/review-threads-basic.json`. Hand-craft a minimal but realistic GraphQL response with 2 threads (one open, one resolved, with multi-line range and viewerCan* flags):
+
+```json
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": [
+            {
+              "id": "PRRT_kwDOA1",
+              "path": "docs/intro.md",
+              "originalLine": 4,
+              "originalStartLine": null,
+              "line": 4,
+              "startLine": null,
+              "isOutdated": false,
+              "isResolved": false,
+              "viewerCanResolve": true,
+              "viewerCanUnresolve": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 1001,
+                    "author": { "login": "alice", "avatarUrl": "https://avatars/alice" },
+                    "body": "Typo here",
+                    "createdAt": "2026-05-01T10:00:00Z",
+                    "updatedAt": "2026-05-01T10:00:00Z",
+                    "viewerCanUpdate": true,
+                    "viewerCanDelete": true,
+                    "url": "https://github.com/org/repo/pull/7#discussion_r1001",
+                    "originalCommit": { "oid": "abc123" }
+                  }
+                ]
+              }
+            },
+            {
+              "id": "PRRT_kwDOA2",
+              "path": "docs/intro.md",
+              "originalLine": 10,
+              "originalStartLine": 8,
+              "line": 10,
+              "startLine": 8,
+              "isOutdated": false,
+              "isResolved": true,
+              "viewerCanResolve": false,
+              "viewerCanUnresolve": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "databaseId": 1002,
+                    "author": { "login": "bob", "avatarUrl": "https://avatars/bob" },
+                    "body": "Range comment",
+                    "createdAt": "2026-05-01T11:00:00Z",
+                    "updatedAt": "2026-05-01T11:30:00Z",
+                    "viewerCanUpdate": false,
+                    "viewerCanDelete": false,
+                    "url": "https://github.com/org/repo/pull/7#discussion_r1002",
+                    "originalCommit": { "oid": "abc123" }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write the failing parser test**
+
+Create `crates/infra/tests/gh_review_threads.rs`:
+
+```rust
+//! Parser tests for the GraphQL `reviewThreads` payload. The fixture is
+//! a hand-crafted but realistic response; the `gh_cli` round-trip is
+//! covered by an opt-in #[ignore] smoke test below.
+
+use markdown_reviewer_core::domain::ThreadState;
+use markdown_reviewer_infra::gh::review_threads::parse_review_threads;
+
+#[test]
+fn parses_basic_fixture() {
+    let raw = include_str!("fixtures/gh/review-threads-basic.json");
+    let fetched = parse_review_threads(raw).expect("fixture parses");
+    assert_eq!(fetched.threads.len(), 2);
+    assert!(!fetched.truncated);
+
+    let t1 = &fetched.threads[0];
+    assert_eq!(t1.thread_id, "PRRT_kwDOA1");
+    assert_eq!(t1.path, "docs/intro.md");
+    assert_eq!(t1.line, Some(4));
+    assert_eq!(t1.start_line, None);
+    assert_eq!(t1.original_line, 4);
+    assert_eq!(t1.state, ThreadState::Open);
+    assert!(t1.viewer_can_resolve);
+    assert_eq!(t1.comments.len(), 1);
+    assert_eq!(t1.comments[0].comment_id, 1001);
+    assert_eq!(t1.comments[0].author, "alice");
+    assert!(t1.comments[0].viewer_can_update);
+
+    let t2 = &fetched.threads[1];
+    assert_eq!(t2.thread_id, "PRRT_kwDOA2");
+    assert_eq!(t2.state, ThreadState::Resolved);
+    assert_eq!(t2.start_line, Some(8));
+    assert_eq!(t2.line, Some(10));
+    assert!(!t2.comments[0].viewer_can_update);
+}
+```
+
+- [ ] **Step 3: Run — expect compile failure (missing `parse_review_threads`)**
+
+Run: `cargo test -p markdown-reviewer-infra --test gh_review_threads`
+Expected: error.
+
+- [ ] **Step 4: Implement the parser**
+
+Create `crates/infra/src/gh/review_threads.rs`:
+
+```rust
+//! Parses the GraphQL `reviewThreads` payload returned by
+//! `gh api graphql -F query=…`. Stays self-contained so a fixture-based
+//! test can run without going through the gh CLI.
+
+use markdown_reviewer_core::domain::{
+    MappingStatus, RemoteComment, RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::FetchedReviewThreads;
+use markdown_reviewer_core::{AppError, AppResult};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct Envelope {
+    data: Data,
+}
+
+#[derive(Debug, Deserialize)]
+struct Data {
+    repository: Repo,
+}
+
+#[derive(Debug, Deserialize)]
+struct Repo {
+    #[serde(rename = "pullRequest")]
+    pull_request: Pr,
+}
+
+#[derive(Debug, Deserialize)]
+struct Pr {
+    #[serde(rename = "reviewThreads")]
+    review_threads: Threads,
+}
+
+#[derive(Debug, Deserialize)]
+struct Threads {
+    #[serde(rename = "pageInfo")]
+    page_info: PageInfo,
+    nodes: Vec<ThreadNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadNode {
+    id: String,
+    path: String,
+    #[serde(rename = "originalLine")]
+    original_line: u32,
+    #[serde(rename = "originalStartLine")]
+    original_start_line: Option<u32>,
+    line: Option<u32>,
+    #[serde(rename = "startLine")]
+    start_line: Option<u32>,
+    #[serde(rename = "isOutdated")]
+    is_outdated: bool,
+    #[serde(rename = "isResolved")]
+    is_resolved: bool,
+    #[serde(rename = "viewerCanResolve")]
+    viewer_can_resolve: bool,
+    #[serde(rename = "viewerCanUnresolve")]
+    viewer_can_unresolve: bool,
+    comments: Comments,
+}
+
+#[derive(Debug, Deserialize)]
+struct Comments {
+    nodes: Vec<CommentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommentNode {
+    #[serde(rename = "databaseId")]
+    database_id: i64,
+    author: Option<Author>,
+    body: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    #[serde(rename = "viewerCanUpdate")]
+    viewer_can_update: bool,
+    #[serde(rename = "viewerCanDelete")]
+    viewer_can_delete: bool,
+    url: String,
+    #[serde(rename = "originalCommit")]
+    original_commit: Option<Commit>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Author {
+    login: String,
+    #[serde(rename = "avatarUrl")]
+    avatar_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Commit {
+    oid: String,
+}
+
+pub fn parse_review_threads(raw: &str) -> AppResult<FetchedReviewThreads> {
+    let env: Envelope = serde_json::from_str(raw)
+        .map_err(|e| AppError::process(format!("gh api graphql reviewThreads: {e}")))?;
+    let threads = env
+        .data
+        .repository
+        .pull_request
+        .review_threads
+        .nodes
+        .into_iter()
+        .map(into_thread)
+        .collect();
+    Ok(FetchedReviewThreads {
+        threads,
+        truncated: env.data.repository.pull_request.review_threads.page_info.has_next_page,
+    })
+}
+
+fn into_thread(n: ThreadNode) -> RemoteThread {
+    // Original commit is taken from the *first* comment's `originalCommit.oid`
+    // — GraphQL doesn't expose it directly on the thread. Empty when missing
+    // (degenerate payload); the mapping layer will fall through to LineMoved.
+    let original_commit_id = n
+        .comments
+        .nodes
+        .first()
+        .and_then(|c| c.original_commit.as_ref())
+        .map(|c| c.oid.clone())
+        .unwrap_or_default();
+
+    let comments = n.comments.nodes.into_iter().map(into_comment).collect();
+    RemoteThread {
+        thread_id: n.id,
+        path: n.path,
+        original_commit_id,
+        line: n.line,
+        start_line: n.start_line,
+        original_line: n.original_line,
+        original_start_line: n.original_start_line,
+        state: if n.is_resolved {
+            ThreadState::Resolved
+        } else {
+            ThreadState::Open
+        },
+        is_outdated: n.is_outdated,
+        viewer_can_resolve: n.viewer_can_resolve,
+        viewer_can_unresolve: n.viewer_can_unresolve,
+        comments,
+        anchor: None,
+        mapping_status: MappingStatus::Mapped, // overwritten by map_anchor
+    }
+}
+
+fn into_comment(c: CommentNode) -> RemoteComment {
+    let (author, avatar) = match c.author {
+        Some(a) => (a.login, a.avatar_url),
+        None => ("ghost".into(), None),
+    };
+    RemoteComment {
+        comment_id: c.database_id,
+        author,
+        author_avatar_url: avatar,
+        body: c.body,
+        created_at: c.created_at,
+        updated_at: c.updated_at,
+        viewer_can_update: c.viewer_can_update,
+        viewer_can_delete: c.viewer_can_delete,
+        html_url: c.url,
+    }
+}
+
+/// Static GraphQL query used by both `list_review_threads` and the
+/// post-mutation refetch helpers. Variables: `$owner: String!`,
+/// `$name: String!`, `$pr: Int!`.
+pub const REVIEW_THREADS_QUERY: &str = r#"
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          path
+          originalLine
+          originalStartLine
+          line
+          startLine
+          isOutdated
+          isResolved
+          viewerCanResolve
+          viewerCanUnresolve
+          comments(first: 100) {
+            nodes {
+              databaseId
+              author { login avatarUrl }
+              body
+              createdAt
+              updatedAt
+              viewerCanUpdate
+              viewerCanDelete
+              url
+              originalCommit { oid }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+```
+
+- [ ] **Step 5: Re-export from `gh/mod.rs`**
+
+Edit `crates/infra/src/gh/mod.rs`:
+
+```rust
+pub mod gh_cli;
+pub mod review_threads;
+
+pub use gh_cli::GhCli;
+```
+
+- [ ] **Step 6: Wire `GhCli::list_review_threads` to hit `gh api graphql`**
+
+Find the `unimplemented!()` body for `list_review_threads` inside `crates/infra/src/gh/gh_cli.rs` and replace with:
+
+```rust
+    async fn list_review_threads(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+    ) -> AppResult<markdown_reviewer_core::ports::FetchedReviewThreads> {
+        // We need the (owner, name) tuple. `gh repo view` is the cheapest way
+        // to get it from the cwd — same pattern used elsewhere.
+        let owner_arg = "owner=".to_string();
+        let name_arg = "name=".to_string();
+        let _ = (owner_arg, name_arg); // placeholder so the snippet below shows intent
+
+        let query_arg = format!("query={}", crate::gh::review_threads::REVIEW_THREADS_QUERY);
+        let pr_arg = format!("-F=pr={pr_number}");
+        // gh fills `{owner}` / `{repo}` from the cwd when we use `-F owner={owner}` style,
+        // but graphql variables need explicit values. `gh api graphql` accepts
+        // `-F owner=:owner -F name=:repo` shortcuts that expand against the
+        // current repo — use them to avoid a second round-trip.
+        let args: Vec<&str> = vec![
+            "api",
+            "graphql",
+            "-F",
+            "owner=:owner",
+            "-F",
+            "name=:repo",
+            &pr_arg,
+            "--raw-field",
+            &query_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), PR_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(map_gh_error(&out.stderr, Some(pr_number)));
+        }
+        crate::gh::review_threads::parse_review_threads(out.stdout.trim())
+    }
+```
+
+- [ ] **Step 7: Run the parser test (fixture-only — no `gh` needed)**
+
+Run: `cargo test -p markdown-reviewer-infra --test gh_review_threads`
+Expected: pass.
+
+- [ ] **Step 8: Run workspace tests to confirm nothing else broke**
+
+Run: `cargo test --workspace --lib`
+Expected: pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/infra/src/gh/review_threads.rs \
+         crates/infra/src/gh/mod.rs \
+         crates/infra/src/gh/gh_cli.rs \
+         crates/infra/tests/fixtures/gh/review-threads-basic.json \
+         crates/infra/tests/gh_review_threads.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #31): GhCli::list_review_threads via GraphQL
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Implement remote mutations + use cases (#32)
+
+**Files:**
+- Modify: `crates/infra/src/gh/gh_cli.rs`
+- Create: `crates/core/src/application/sync/mutations.rs`
+- Create: `crates/core/tests/sync_mutations.rs`
+
+- [ ] **Step 1: Write the failing use-case tests**
+
+Create `crates/core/tests/sync_mutations.rs`:
+
+```rust
+//! Use-case tests for sync::mutations. Confirms each call delegates to the
+//! GhClient with the right arguments and propagates viewer-denied errors as
+//! `Validation` so the UI can map them to a read-only tooltip.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use markdown_reviewer_core::application::sync::{mutations, Sync};
+use markdown_reviewer_core::domain::{
+    ChangedFile, MappingStatus, PullRequestDetail, PullRequestSummary, RemoteComment,
+    RemoteThread, ThreadState,
+};
+use markdown_reviewer_core::ports::{
+    CachedRefresh, Clock, FetchedReviewThreads, FileResolver, GhAuthReport, GhClient,
+    RemoteThreadsStore, ReviewCommentInput,
+};
+use markdown_reviewer_core::{AppError, AppResult};
+
+#[derive(Default)]
+struct FakeFiles;
+#[async_trait]
+impl FileResolver for FakeFiles {
+    async fn read(&self, _: &str, _: &str, _: &str) -> AppResult<String> {
+        unimplemented!()
+    }
+}
+
+#[derive(Default)]
+struct FakeStore;
+#[async_trait]
+impl RemoteThreadsStore for FakeStore {
+    async fn get(&self, _: &str, _: u64) -> AppResult<Option<CachedRefresh>> { Ok(None) }
+    async fn put(&self, _: &str, _: u64, _: &str, _: &CachedRefresh) -> AppResult<()> { Ok(()) }
+}
+
+struct FixedClock;
+impl Clock for FixedClock {
+    fn now_unix_ms(&self) -> i64 { 0 }
+}
+
+#[derive(Default)]
+struct GhSpy {
+    pub reply_calls: Mutex<Vec<(i64, String)>>,
+    pub edit_calls: Mutex<Vec<(i64, String)>>,
+    pub delete_calls: Mutex<Vec<i64>>,
+    pub resolve_calls: Mutex<Vec<String>>,
+    pub unresolve_calls: Mutex<Vec<String>>,
+    pub fail_with: Mutex<Option<AppError>>,
+}
+
+fn sample_comment(id: i64) -> RemoteComment {
+    RemoteComment {
+        comment_id: id,
+        author: "alice".into(),
+        author_avatar_url: None,
+        body: "body".into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        updated_at: "2026-01-01T00:00:00Z".into(),
+        viewer_can_update: true,
+        viewer_can_delete: true,
+        html_url: "https://".into(),
+    }
+}
+
+fn sample_thread(id: &str) -> RemoteThread {
+    RemoteThread {
+        thread_id: id.into(),
+        path: "doc.md".into(),
+        original_commit_id: "abc".into(),
+        line: Some(4),
+        start_line: None,
+        original_line: 4,
+        original_start_line: None,
+        state: ThreadState::Open,
+        is_outdated: false,
+        viewer_can_resolve: true,
+        viewer_can_unresolve: false,
+        comments: vec![sample_comment(1)],
+        anchor: None,
+        mapping_status: MappingStatus::Mapped,
+    }
+}
+
+#[async_trait]
+impl GhClient for GhSpy {
+    async fn version(&self) -> AppResult<String> { unimplemented!() }
+    async fn auth_status(&self) -> AppResult<GhAuthReport> { unimplemented!() }
+    async fn list_pull_requests(&self, _: &str) -> AppResult<Vec<PullRequestSummary>> { unimplemented!() }
+    async fn load_pull_request(&self, _: &str, _: u64) -> AppResult<PullRequestDetail> { unimplemented!() }
+    async fn list_changed_files(&self, _: &str, _: u64) -> AppResult<Vec<ChangedFile>> { unimplemented!() }
+    async fn get_file_content(&self, _: &str, _: &str, _: &str) -> AppResult<String> { unimplemented!() }
+    async fn submit_review_batch(&self, _: &str, _: u64, _: &str, _: &[ReviewCommentInput]) -> AppResult<Vec<i64>> { unimplemented!() }
+    async fn submit_review_comment(&self, _: &str, _: u64, _: &str, _: &ReviewCommentInput) -> AppResult<i64> { unimplemented!() }
+    async fn list_review_threads(&self, _: &str, _: u64) -> AppResult<FetchedReviewThreads> { unimplemented!() }
+
+    async fn reply_review_comment(&self, _: &str, _: u64, in_reply: i64, body: &str) -> AppResult<RemoteComment> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.reply_calls.lock().unwrap().push((in_reply, body.into()));
+        Ok(sample_comment(99))
+    }
+    async fn edit_review_comment(&self, _: &str, id: i64, body: &str) -> AppResult<RemoteComment> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.edit_calls.lock().unwrap().push((id, body.into()));
+        Ok(sample_comment(id))
+    }
+    async fn delete_review_comment(&self, _: &str, id: i64) -> AppResult<()> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.delete_calls.lock().unwrap().push(id);
+        Ok(())
+    }
+    async fn resolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.resolve_calls.lock().unwrap().push(id.into());
+        Ok(sample_thread(id))
+    }
+    async fn unresolve_review_thread(&self, _: &str, id: &str) -> AppResult<RemoteThread> {
+        if let Some(err) = self.fail_with.lock().unwrap().clone() { return Err(err); }
+        self.unresolve_calls.lock().unwrap().push(id.into());
+        Ok(sample_thread(id))
+    }
+}
+
+fn svc_with(gh: Arc<GhSpy>) -> Sync {
+    Sync {
+        gh,
+        store: Arc::new(FakeStore),
+        files: Arc::new(FakeFiles),
+        clock: Arc::new(FixedClock),
+    }
+}
+
+#[tokio::test]
+async fn reply_delegates_to_gh() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    let out = mutations::reply(&svc, "/repo", 7, 42, "ok").await.unwrap();
+    assert_eq!(out.comment_id, 99);
+    assert_eq!(gh.reply_calls.lock().unwrap().as_slice(), &[(42, "ok".to_string())]);
+}
+
+#[tokio::test]
+async fn edit_passes_body() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::edit(&svc, "/repo", 11, "new body").await.unwrap();
+    assert_eq!(
+        gh.edit_calls.lock().unwrap().as_slice(),
+        &[(11, "new body".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn delete_passes_id() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::delete(&svc, "/repo", 11).await.unwrap();
+    assert_eq!(gh.delete_calls.lock().unwrap().as_slice(), &[11]);
+}
+
+#[tokio::test]
+async fn resolve_and_reopen_delegate() {
+    let gh = Arc::new(GhSpy::default());
+    let svc = svc_with(gh.clone());
+    mutations::resolve(&svc, "/repo", "PRRT_1").await.unwrap();
+    mutations::reopen(&svc, "/repo", "PRRT_1").await.unwrap();
+    assert_eq!(gh.resolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
+    assert_eq!(gh.unresolve_calls.lock().unwrap().as_slice(), &["PRRT_1".to_string()]);
+}
+
+#[tokio::test]
+async fn viewer_denied_surfaces_as_validation() {
+    let gh = Arc::new(GhSpy::default());
+    *gh.fail_with.lock().unwrap() = Some(AppError::Validation {
+        message: "read-only on GitHub".into(),
+    });
+    let svc = svc_with(gh.clone());
+    let err = mutations::edit(&svc, "/repo", 11, "x").await.unwrap_err();
+    assert!(matches!(err, AppError::Validation { .. }));
+}
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_mutations`
+Expected: compile error (mutations module empty).
+
+- [ ] **Step 3: Implement the use cases**
+
+Replace `crates/core/src/application/sync/mutations.rs`:
+
+```rust
+//! Reply / edit / delete / resolve / reopen use cases. Each one is a thin
+//! delegation to the `GhClient` port; the only logic here is choosing
+//! between the resolve and unresolve mutations.
+
+use crate::domain::{RemoteComment, RemoteThread};
+use crate::AppResult;
+
+use super::Sync;
+
+pub async fn reply(
+    svc: &Sync,
+    repo_path: &str,
+    pr_number: u64,
+    in_reply_to_comment_id: i64,
+    body: &str,
+) -> AppResult<RemoteComment> {
+    svc.gh
+        .reply_review_comment(repo_path, pr_number, in_reply_to_comment_id, body)
+        .await
+}
+
+pub async fn edit(
+    svc: &Sync,
+    repo_path: &str,
+    comment_id: i64,
+    body: &str,
+) -> AppResult<RemoteComment> {
+    svc.gh
+        .edit_review_comment(repo_path, comment_id, body)
+        .await
+}
+
+pub async fn delete(svc: &Sync, repo_path: &str, comment_id: i64) -> AppResult<()> {
+    svc.gh.delete_review_comment(repo_path, comment_id).await
+}
+
+pub async fn resolve(svc: &Sync, repo_path: &str, thread_id: &str) -> AppResult<RemoteThread> {
+    svc.gh.resolve_review_thread(repo_path, thread_id).await
+}
+
+pub async fn reopen(svc: &Sync, repo_path: &str, thread_id: &str) -> AppResult<RemoteThread> {
+    svc.gh.unresolve_review_thread(repo_path, thread_id).await
+}
+```
+
+- [ ] **Step 4: Run the use-case tests**
+
+Run: `cargo test -p markdown-reviewer-core --test sync_mutations`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Implement the production `GhCli` mutation methods**
+
+Replace the `unimplemented!()` bodies in `crates/infra/src/gh/gh_cli.rs` for:
+
+```rust
+    async fn reply_review_comment(
+        &self,
+        repo_path: &str,
+        pr_number: u64,
+        in_reply_to_comment_id: i64,
+        body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments");
+        let in_reply_arg = format!("in_reply_to={in_reply_to_comment_id}");
+        let body_arg = format!("body={body}");
+        let args = vec![
+            "api",
+            "-X",
+            "POST",
+            &endpoint,
+            "-F",
+            &in_reply_arg,
+            "--raw-field",
+            &body_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        parse_review_comment(out.stdout.trim())
+    }
+
+    async fn edit_review_comment(
+        &self,
+        repo_path: &str,
+        comment_id: i64,
+        body: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}");
+        let body_arg = format!("body={body}");
+        let args = vec![
+            "api",
+            "-X",
+            "PATCH",
+            &endpoint,
+            "--raw-field",
+            &body_arg,
+        ];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        parse_review_comment(out.stdout.trim())
+    }
+
+    async fn delete_review_comment(&self, repo_path: &str, comment_id: i64) -> AppResult<()> {
+        let endpoint = format!("repos/{{owner}}/{{repo}}/pulls/comments/{comment_id}");
+        let args = vec!["api", "-X", "DELETE", &endpoint];
+        let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+        if !out.ok() {
+            return Err(classify_rest_error(&out.stderr));
+        }
+        Ok(())
+    }
+
+    async fn resolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        run_thread_mutation(
+            repo_path,
+            thread_id,
+            "mutation($id: ID!) { resolveReviewThread(input: { threadId: $id }) { thread { id } } }",
+        )
+        .await?;
+        refetch_thread(repo_path, thread_id).await
+    }
+
+    async fn unresolve_review_thread(
+        &self,
+        repo_path: &str,
+        thread_id: &str,
+    ) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+        run_thread_mutation(
+            repo_path,
+            thread_id,
+            "mutation($id: ID!) { unresolveReviewThread(input: { threadId: $id }) { thread { id } } }",
+        )
+        .await?;
+        refetch_thread(repo_path, thread_id).await
+    }
+```
+
+Add the four helpers at the bottom of `gh_cli.rs` (before the existing `BatchCommentSlot` struct):
+
+```rust
+fn classify_rest_error(stderr: &str) -> AppError {
+    let lower = stderr.to_ascii_lowercase();
+    if lower.contains("status code: 403") || lower.contains("must have write access")
+        || lower.contains("must be the author")
+    {
+        return AppError::validation("read-only on GitHub");
+    }
+    if lower.contains("status code: 404") || lower.contains("not found") {
+        return AppError::validation("upstream thread no longer exists");
+    }
+    if lower.contains("authentication required") || lower.contains("gh auth login") {
+        return AppError::GhNotAuthenticated;
+    }
+    AppError::process(redact(stderr.trim()))
+}
+
+fn parse_review_comment(raw: &str) -> AppResult<markdown_reviewer_core::domain::RemoteComment> {
+    #[derive(serde::Deserialize)]
+    struct UserField { login: String, avatar_url: Option<String> }
+    #[derive(serde::Deserialize)]
+    struct RawComment {
+        id: i64,
+        user: Option<UserField>,
+        body: String,
+        created_at: String,
+        updated_at: String,
+        html_url: String,
+        #[serde(default)] author_association: Option<String>,
+    }
+    let c: RawComment = serde_json::from_str(raw)
+        .map_err(|e| AppError::process(format!("gh api comments: invalid JSON: {e}")))?;
+    let viewer_can_update = matches!(
+        c.author_association.as_deref(),
+        Some("OWNER" | "MEMBER" | "COLLABORATOR" | "CONTRIBUTOR")
+    );
+    let (author, avatar) = match c.user {
+        Some(u) => (u.login, u.avatar_url),
+        None => ("ghost".into(), None),
+    };
+    Ok(markdown_reviewer_core::domain::RemoteComment {
+        comment_id: c.id,
+        author,
+        author_avatar_url: avatar,
+        body: c.body,
+        created_at: c.created_at,
+        updated_at: c.updated_at,
+        viewer_can_update,
+        viewer_can_delete: viewer_can_update,
+        html_url: c.html_url,
+    })
+}
+
+async fn run_thread_mutation(repo_path: &str, thread_id: &str, mutation: &str) -> AppResult<()> {
+    let query_arg = format!("query={mutation}");
+    let id_arg = format!("id={thread_id}");
+    let args = vec![
+        "api",
+        "graphql",
+        "--raw-field",
+        &query_arg,
+        "--raw-field",
+        &id_arg,
+    ];
+    let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+    if !out.ok() {
+        return Err(classify_rest_error(&out.stderr));
+    }
+    if out.stdout.contains("\"errors\":") {
+        return Err(AppError::process(format!(
+            "graphql mutation failed: {}",
+            redact(out.stdout.trim())
+        )));
+    }
+    Ok(())
+}
+
+async fn refetch_thread(
+    repo_path: &str,
+    thread_id: &str,
+) -> AppResult<markdown_reviewer_core::domain::RemoteThread> {
+    // We re-fetch every thread (cheap: usually < 100) and find ours by id.
+    // The mutation endpoint itself doesn't return enough data for the UI.
+    use markdown_reviewer_core::domain::MappingStatus;
+    let query_arg = format!("query={}", crate::gh::review_threads::REVIEW_THREADS_QUERY);
+    // We need owner/name/pr to refetch. The thread id alone is enough for a
+    // single-node query: `node(id: ...) { ... on PullRequestReviewThread { ... } }`.
+    // That avoids parsing owner/name out of the caller path.
+    let single_query = format!(
+        r#"query($id: ID!) {{ node(id: $id) {{ ... on PullRequestReviewThread {{
+            id path originalLine originalStartLine line startLine
+            isOutdated isResolved viewerCanResolve viewerCanUnresolve
+            comments(first: 100) {{ nodes {{
+                databaseId author {{ login avatarUrl }} body createdAt updatedAt
+                viewerCanUpdate viewerCanDelete url originalCommit {{ oid }}
+            }} }}
+        }} }} }}"#
+    );
+    let _ = query_arg;
+    let q_arg = format!("query={single_query}");
+    let id_arg = format!("id={thread_id}");
+    let args = vec![
+        "api",
+        "graphql",
+        "--raw-field",
+        &q_arg,
+        "--raw-field",
+        &id_arg,
+    ];
+    let out = run("gh", &args, Some(repo_path), REVIEW_COMMENT_TIMEOUT_MS).await?;
+    if !out.ok() {
+        return Err(classify_rest_error(&out.stderr));
+    }
+    #[derive(serde::Deserialize)]
+    struct Envelope { data: Data }
+    #[derive(serde::Deserialize)]
+    struct Data { node: serde_json::Value }
+    let env: Envelope = serde_json::from_str(out.stdout.trim())
+        .map_err(|e| AppError::process(format!("gh graphql node: {e}")))?;
+    // Wrap the single node into the shape `parse_review_threads` expects so we
+    // can reuse the parser.
+    let wrapped = serde_json::json!({
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [env.node]
+                    }
+                }
+            }
+        }
+    });
+    let fetched = crate::gh::review_threads::parse_review_threads(&wrapped.to_string())?;
+    let mut thread = fetched
+        .threads
+        .into_iter()
+        .next()
+        .ok_or_else(|| AppError::process("graphql node returned no thread"))?;
+    thread.mapping_status = MappingStatus::Mapped;
+    Ok(thread)
+}
+```
+
+- [ ] **Step 6: Run workspace tests**
+
+Run: `cargo test --workspace --lib`
+Expected: pass.
+
+- [ ] **Step 7: Run clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: clean. Fix any warnings inline (likely small lifetime / borrow issues).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/infra/src/gh/gh_cli.rs \
+         crates/core/src/application/sync/mutations.rs \
+         crates/core/tests/sync_mutations.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #32): remote mutations (reply/edit/delete/resolve/reopen)
+
+GhCli implements the REST + GraphQL endpoints; viewer-denied
+responses get mapped to AppError::Validation so the UI can show
+a read-only tooltip.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 3 — IPC surface + bootstrap
+
+## Task 10: IPC commands + bootstrap wiring
+
+**Files:**
+- Create: `crates/ipc/src/commands/sync.rs`
+- Modify: `crates/ipc/src/commands/mod.rs`
+- Modify: `crates/ipc/src/state.rs`
+- Modify: `crates/ipc/src/lib.rs`
+- Create: `crates/infra/src/gh/file_resolver.rs`
+- Modify: `crates/infra/src/gh/mod.rs`
+- Modify: `crates/infra/src/lib.rs`
+- Modify: `src-tauri/src/bootstrap.rs`
+
+- [ ] **Step 1: Production `FileResolver`**
+
+Create `crates/infra/src/gh/file_resolver.rs`:
+
+```rust
+//! Production `FileResolver`. Tries the local clone first; falls back to
+//! `gh api contents` when the ref isn't in the working tree.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use markdown_reviewer_core::ports::{FileResolver, GhClient, GitClient};
+use markdown_reviewer_core::{AppError, AppResult};
+
+pub struct GitWithGhFallback {
+    pub git: Arc<dyn GitClient>,
+    pub gh: Arc<dyn GhClient>,
+}
+
+#[async_trait]
+impl FileResolver for GitWithGhFallback {
+    async fn read(&self, repo_path: &str, sha: &str, path: &str) -> AppResult<String> {
+        match self.git.show(repo_path, sha, path).await {
+            Ok(text) => Ok(text),
+            Err(AppError::FileNotFound { .. }) | Err(AppError::Process { .. }) => {
+                self.gh.get_file_content(repo_path, sha, path).await
+            }
+            Err(other) => Err(other),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Confirm `GitClient::show` exists**
+
+Run: `grep -n "fn show" crates/core/src/ports/git.rs crates/infra/src/git/git_cli.rs`
+Expected: a `show(repo_path, sha, path)` method. If it returns a different signature, adapt the resolver above to match. If it doesn't exist, replace the `git.show` call with the existing `read_blob` / equivalent method already used by `application::files::read_markdown`.
+
+- [ ] **Step 3: Re-export from `infra/src/gh/mod.rs` and from the crate root**
+
+```rust
+// crates/infra/src/gh/mod.rs
+pub mod file_resolver;
+pub mod gh_cli;
+pub mod review_threads;
+
+pub use file_resolver::GitWithGhFallback;
+pub use gh_cli::GhCli;
+```
+
+In `crates/infra/src/lib.rs` (already re-exports `GhCli`), add:
+
+```rust
+pub use gh::GitWithGhFallback;
+```
+
+- [ ] **Step 4: Add the IPC command module**
+
+Create `crates/ipc/src/commands/sync.rs`:
+
+```rust
+use markdown_reviewer_core::application::sync::{cache, mutations, refresh};
+use markdown_reviewer_core::domain::{RefreshResult, RemoteComment, RemoteThread};
+use markdown_reviewer_core::AppError;
+use tauri::State;
+
+use crate::state::AppState;
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn refresh_remote_comments(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+    head_sha: String,
+) -> Result<RefreshResult, AppError> {
+    refresh::run(&state.sync, &repo_path, pr_number, &head_sha).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn get_cached_remote_threads(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+) -> Result<Option<RefreshResult>, AppError> {
+    cache::get_cached(&state.sync, &repo_path, pr_number).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn reply_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    pr_number: u64,
+    in_reply_to_comment_id: i64,
+    body: String,
+) -> Result<RemoteComment, AppError> {
+    mutations::reply(&state.sync, &repo_path, pr_number, in_reply_to_comment_id, &body).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn edit_remote_comment(
+    state: State<'_, AppState>,
+    repo_path: String,
+    comment_id: i64,
+    body: String,
+) -> Result<RemoteComment, AppError> {
+    mutations::edit(&state.sync, &repo_path, comment_id, &body).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn delete_remote_comment(
+    state: State<'_, AppState>,
+    repo_path: String,
+    comment_id: i64,
+) -> Result<(), AppError> {
+    mutations::delete(&state.sync, &repo_path, comment_id).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn resolve_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    thread_id: String,
+) -> Result<RemoteThread, AppError> {
+    mutations::resolve(&state.sync, &repo_path, &thread_id).await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn reopen_remote_thread(
+    state: State<'_, AppState>,
+    repo_path: String,
+    thread_id: String,
+) -> Result<RemoteThread, AppError> {
+    mutations::reopen(&state.sync, &repo_path, &thread_id).await
+}
+```
+
+- [ ] **Step 5: Register the module**
+
+Edit `crates/ipc/src/commands/mod.rs`:
+
+```rust
+pub mod comments;
+pub mod files;
+pub mod pull_requests;
+pub mod recents;
+pub mod repo;
+pub mod sync;
+pub mod tools;
+```
+
+- [ ] **Step 6: Extend `AppState`**
+
+Edit `crates/ipc/src/state.rs`:
+
+```rust
+use markdown_reviewer_core::application::comments::Comments;
+use markdown_reviewer_core::application::files::Files;
+use markdown_reviewer_core::application::pull_requests::PullRequests;
+use markdown_reviewer_core::application::repo_selection::RepoSelection;
+use markdown_reviewer_core::application::sync::Sync;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub repo_selection: RepoSelection,
+    pub pull_requests: PullRequests,
+    pub files: Files,
+    pub comments: Comments,
+    pub sync: Sync,
+}
+```
+
+- [ ] **Step 7: Register handlers**
+
+Edit `crates/ipc/src/lib.rs` — extend `generate_handler![…]` with the seven new commands at the end:
+
+```rust
+        commands::sync::refresh_remote_comments,
+        commands::sync::get_cached_remote_threads,
+        commands::sync::reply_remote_thread,
+        commands::sync::edit_remote_comment,
+        commands::sync::delete_remote_comment,
+        commands::sync::resolve_remote_thread,
+        commands::sync::reopen_remote_thread,
+```
+
+- [ ] **Step 8: Wire bootstrap**
+
+Edit `src-tauri/src/bootstrap.rs` — extend the `AppState` construction:
+
+```rust
+            use markdown_reviewer_infra::{sqlite::SqliteRemoteThreadsStore, GitWithGhFallback};
+            use markdown_reviewer_core::application::sync::Sync;
+
+            let remote_store = Arc::new(SqliteRemoteThreadsStore::new(db.clone()));
+            let file_resolver = Arc::new(GitWithGhFallback {
+                git: git.clone(),
+                gh: gh.clone(),
+            });
+            // … inside `let state = AppState { … }` add:
+            sync: Sync {
+                gh: gh.clone(),
+                store: remote_store,
+                files: file_resolver,
+                clock: clock.clone(),
+            },
+```
+
+(The existing `db` binding is moved into `SqliteRecentsStore::new(db)` later, so move the `db.clone()` calls accordingly to keep ownership consistent.)
+
+- [ ] **Step 9: Build the whole workspace + Tauri**
+
+Run: `cargo check --workspace --all-targets`
+Expected: clean.
+
+Run: `cargo build -p markdown-reviewer-tauri --bin markdown-reviewer-tauri`
+Expected: success.
+
+- [ ] **Step 10: Confirm no new capability needed**
+
+Tauri v2 derives the IPC allowlist from the `generate_handler!` macro — no edit to `capabilities/default.json` should be required. Verify by grepping for any explicit per-command `allow-…` entry and ensuring none reference the new names.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add crates/ipc/src/commands/sync.rs \
+         crates/ipc/src/commands/mod.rs \
+         crates/ipc/src/state.rs \
+         crates/ipc/src/lib.rs \
+         crates/infra/src/gh/file_resolver.rs \
+         crates/infra/src/gh/mod.rs \
+         crates/infra/src/lib.rs \
+         src-tauri/src/bootstrap.rs
+git commit -m "$(cat <<'EOF'
+feat(phase-6): IPC commands + bootstrap for sync
+
+Wires the seven new sync commands and the SqliteRemoteThreadsStore +
+GitWithGhFallback file resolver into AppState.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 4 — Frontend foundation
+
+## Task 11: TypeScript IPC contract + client helpers
+
+**Files:**
+- Modify: `src/shared/ipc/contract.ts`
+- Modify: `src/shared/ipc/client.ts`
+
+- [ ] **Step 1: Extend `contract.ts`**
+
+Append after the existing `ReviewSubmissionResult` interface block:
+
+```ts
+export type ThreadState = "open" | "resolved";
+
+export type MappingStatus =
+  | { kind: "mapped" }
+  | { kind: "outdated"; reason: string }
+  | { kind: "fileMissing" }
+  | { kind: "lineMoved" }
+  | { kind: "ambiguous" };
+
+export interface RemoteComment {
+  commentId: number;
+  author: string;
+  authorAvatarUrl: string | null;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  viewerCanUpdate: boolean;
+  viewerCanDelete: boolean;
+  htmlUrl: string;
+}
+
+export interface RemoteThread {
+  threadId: string;
+  path: string;
+  originalCommitId: string;
+  line: number | null;
+  startLine: number | null;
+  originalLine: number;
+  originalStartLine: number | null;
+  state: ThreadState;
+  isOutdated: boolean;
+  viewerCanResolve: boolean;
+  viewerCanUnresolve: boolean;
+  comments: RemoteComment[];
+  anchor: CommentAnchor | null;
+  mappingStatus: MappingStatus;
+}
+
+export interface RefreshResult {
+  threads: RemoteThread[];
+  unmapped: RemoteThread[];
+  refreshedAtMs: number;
+}
+```
+
+Then extend the `Commands` interface:
+
+```ts
+  refresh_remote_comments: {
+    args: { repoPath: string; prNumber: number; headSha: string };
+    result: RefreshResult;
+  };
+  get_cached_remote_threads: {
+    args: { repoPath: string; prNumber: number };
+    result: RefreshResult | null;
+  };
+  reply_remote_thread: {
+    args: { repoPath: string; prNumber: number; inReplyToCommentId: number; body: string };
+    result: RemoteComment;
+  };
+  edit_remote_comment: {
+    args: { repoPath: string; commentId: number; body: string };
+    result: RemoteComment;
+  };
+  delete_remote_comment: {
+    args: { repoPath: string; commentId: number };
+    result: null;
+  };
+  resolve_remote_thread: {
+    args: { repoPath: string; threadId: string };
+    result: RemoteThread;
+  };
+  reopen_remote_thread: {
+    args: { repoPath: string; threadId: string };
+    result: RemoteThread;
+  };
+```
+
+- [ ] **Step 2: Extend `client.ts`**
+
+Open `src/shared/ipc/client.ts`, find the `ipc` object, and add a `sync` namespace mirroring the existing `comments` / `repo` / `pullRequests` namespaces. Use the existing `call(...)` wrapper. Example:
+
+```ts
+import type { RefreshResult, RemoteComment, RemoteThread } from "./contract";
+
+export const ipc = {
+  // … existing namespaces unchanged …
+  sync: {
+    refresh(repoPath: string, prNumber: number, headSha: string) {
+      return call("refresh_remote_comments", { repoPath, prNumber, headSha });
+    },
+    getCached(repoPath: string, prNumber: number) {
+      return call("get_cached_remote_threads", { repoPath, prNumber });
+    },
+    reply(repoPath: string, prNumber: number, inReplyToCommentId: number, body: string) {
+      return call("reply_remote_thread", { repoPath, prNumber, inReplyToCommentId, body });
+    },
+    edit(repoPath: string, commentId: number, body: string) {
+      return call("edit_remote_comment", { repoPath, commentId, body });
+    },
+    delete(repoPath: string, commentId: number) {
+      return call("delete_remote_comment", { repoPath, commentId });
+    },
+    resolve(repoPath: string, threadId: string) {
+      return call("resolve_remote_thread", { repoPath, threadId });
+    },
+    reopen(repoPath: string, threadId: string) {
+      return call("reopen_remote_thread", { repoPath, threadId });
+    },
+  },
+};
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/ipc/contract.ts src/shared/ipc/client.ts
+git commit -m "$(cat <<'EOF'
+feat(phase-6): TS contract + client helpers for sync IPC
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: `mergeLocalAndRemote` + tests
+
+**Files:**
+- Create: `src/features/sync/lib/mergeLocalAndRemote.ts`
+- Create: `src/features/sync/lib/mergeLocalAndRemote.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/sync/lib/mergeLocalAndRemote.test.ts`:
+
+```ts
+import { test, expect } from "bun:test";
+import type { RemoteThread, ReviewComment } from "@/shared/ipc/contract";
+import { mergeLocalAndRemote } from "./mergeLocalAndRemote";
+
+function local(id: number, githubId: number | null = null): ReviewComment {
+  return {
+    id,
+    prNumber: 7,
+    filePath: "doc.md",
+    headSha: "abc",
+    body: "local body",
+    author: "me",
+    state: githubId ? "submitted" : "draft",
+    anchor: { kind: "singleLine", line: 4 },
+    createdAt: 0,
+    updatedAt: 0,
+    githubId,
+    submitError: null,
+  };
+}
+
+function remote(id: string, commentId: number, line: number): RemoteThread {
+  return {
+    threadId: id,
+    path: "doc.md",
+    originalCommitId: "abc",
+    line,
+    startLine: null,
+    originalLine: line,
+    originalStartLine: null,
+    state: "open",
+    isOutdated: false,
+    viewerCanResolve: true,
+    viewerCanUnresolve: false,
+    comments: [
+      {
+        commentId,
+        author: "alice",
+        authorAvatarUrl: null,
+        body: "remote body",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+        viewerCanUpdate: false,
+        viewerCanDelete: false,
+        htmlUrl: "https://",
+      },
+    ],
+    anchor: { kind: "singleLine", line },
+    mappingStatus: { kind: "mapped" },
+  };
+}
+
+test("orders entries by file then start line", () => {
+  const merged = mergeLocalAndRemote([local(1)], [remote("T1", 100, 1)]);
+  expect(merged.map((e) => (e.kind === "remote" ? e.thread.threadId : `L${e.comment.id}`))).toEqual(
+    ["T1", "L1"],
+  );
+});
+
+test("drops local submitted comment when its githubId matches a remote one", () => {
+  const merged = mergeLocalAndRemote([local(1, 100)], [remote("T1", 100, 4)]);
+  expect(merged.length).toBe(1);
+  expect(merged[0].kind).toBe("remote");
+});
+
+test("keeps local drafts even at the same anchor", () => {
+  const merged = mergeLocalAndRemote([local(1, null)], [remote("T1", 100, 4)]);
+  expect(merged.length).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+Run: `bun test src/features/sync/lib/mergeLocalAndRemote.test.ts`
+Expected: module not found.
+
+- [ ] **Step 3: Implement**
+
+Create `src/features/sync/lib/mergeLocalAndRemote.ts`:
+
+```ts
+import type { CommentAnchor, RemoteThread, ReviewComment } from "@/shared/ipc/contract";
+
+export type MergedEntry =
+  | { kind: "remote"; key: string; filePath: string; startLine: number; thread: RemoteThread }
+  | { kind: "local"; key: string; filePath: string; startLine: number; comment: ReviewComment };
+
+function anchorStart(anchor: CommentAnchor): number {
+  return anchor.kind === "singleLine" ? anchor.line : anchor.startLine;
+}
+
+/**
+ * Merges local comments and mapped remote threads into a stable ordered list.
+ * Any local comment whose `githubId` matches a `RemoteComment.commentId` is
+ * dropped — the remote thread carries the richer data (replies, viewerCan*,
+ * resolved state), so showing both would be a confusing duplicate.
+ *
+ * Sort key: filePath, then anchor start line, then a stable tiebreaker
+ * (`threadId` for remote, `id` for local).
+ */
+export function mergeLocalAndRemote(
+  local: ReviewComment[],
+  remote: RemoteThread[],
+): MergedEntry[] {
+  const remoteCommentIds = new Set<number>();
+  for (const thread of remote) {
+    for (const c of thread.comments) remoteCommentIds.add(c.commentId);
+  }
+
+  const entries: MergedEntry[] = [];
+
+  for (const thread of remote) {
+    if (!thread.anchor) continue; // unmapped goes elsewhere
+    entries.push({
+      kind: "remote",
+      key: `remote:${thread.threadId}`,
+      filePath: thread.path,
+      startLine: anchorStart(thread.anchor),
+      thread,
+    });
+  }
+
+  for (const comment of local) {
+    if (comment.githubId !== null && remoteCommentIds.has(comment.githubId)) continue;
+    entries.push({
+      kind: "local",
+      key: `local:${comment.id}`,
+      filePath: comment.filePath,
+      startLine: anchorStart(comment.anchor),
+      comment,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+    if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+    return a.key.localeCompare(b.key);
+  });
+
+  return entries;
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `bun test src/features/sync/lib/mergeLocalAndRemote.test.ts`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/sync/lib/mergeLocalAndRemote.ts \
+         src/features/sync/lib/mergeLocalAndRemote.test.ts
+git commit -m "$(cat <<'EOF'
+feat(phase-6): mergeLocalAndRemote helper
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: i18n keys
+
+**Files:**
+- Modify: `src/shared/i18n/locales/en.json`
+
+- [ ] **Step 1: Add a `sync` namespace**
+
+Append to `en.json` (top-level object key, between `comments` and `errors`):
+
+```json
+  "sync": {
+    "section": {
+      "remoteHeading": "GitHub threads",
+      "unmappedHeading": "Unmapped threads",
+      "unmappedSubtitle": "These remote threads couldn't be anchored to a line in the current head.",
+      "truncatedWarning": "Showing the first 100 review threads. Older threads will sync once pagination is implemented.",
+      "emptyMapped": "No remote review threads on this pull request yet.",
+      "openOnGithub": "Open on GitHub"
+    },
+    "actions": {
+      "reply": "Reply",
+      "edit": "Edit",
+      "delete": "Delete",
+      "resolve": "Mark as resolved",
+      "reopen": "Reopen thread",
+      "cancel": "Cancel",
+      "save": "Save",
+      "send": "Send reply",
+      "deleteConfirm": "Delete this comment? This cannot be undone."
+    },
+    "thread": {
+      "replyPlaceholder": "Write a reply…",
+      "editPlaceholder": "Edit your comment…",
+      "byAuthor": "by {{author}}",
+      "edited": "edited",
+      "resolvedBadge": "Resolved",
+      "openBadge": "Open",
+      "outdatedBadge": "Outdated",
+      "readOnlyTooltip": "You can only edit or delete your own comments."
+    },
+    "unmapped": {
+      "fileMissing": "File no longer in this PR head ({{path}})",
+      "lineMoved": "Original snippet no longer found at {{path}}:{{line}}",
+      "ambiguous": "Snippet matches multiple positions in {{path}}",
+      "outdated": "GitHub marked this thread as outdated"
+    },
+    "errors": {
+      "refreshFailedTitle": "Couldn't refresh remote threads",
+      "refreshFailedDescription": "We kept the cached threads. Try refreshing again.",
+      "mutationFailedTitle": "Action failed",
+      "readOnlyTitle": "Read-only on GitHub",
+      "readOnlyDescription": "GitHub didn't allow this action — you may need write access on the repository."
+    }
+  },
+```
+
+- [ ] **Step 2: Validate JSON shape**
+
+Run: `bun run typecheck`
+Expected: clean (the `types.d.ts` regenerator is part of typecheck).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/i18n/locales/en.json
+git commit -m "$(cat <<'EOF'
+feat(phase-6): i18n keys for sync UI
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: React Query hooks for sync
+
+**Files:**
+- Create: `src/features/sync/hooks/useRemoteThreads.ts`
+- Create: `src/features/sync/hooks/useReplyRemoteThread.ts`
+- Create: `src/features/sync/hooks/useEditRemoteComment.ts`
+- Create: `src/features/sync/hooks/useDeleteRemoteComment.ts`
+- Create: `src/features/sync/hooks/useResolveRemoteThread.ts`
+- Create: `src/features/sync/hooks/useReopenRemoteThread.ts`
+
+- [ ] **Step 1: Implement `useRemoteThreads`**
+
+```ts
+// src/features/sync/hooks/useRemoteThreads.ts
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult } from "@/shared/ipc/contract";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface Options {
+  repoPath?: string;
+  prNumber?: number;
+  headSha?: string;
+}
+
+export function remoteThreadsKey(repoPath: string, prNumber: number) {
+  return ["remote-threads", repoPath, prNumber] as const;
+}
+
+/**
+ * Loads remote review threads for `(repoPath, prNumber)`. On mount we read
+ * the SQLite cache; the user must click Refresh to hit GitHub. Both the
+ * initial cache read and the manual refresh return the same `RefreshResult`
+ * shape so the consumer doesn't care which path produced it.
+ */
+export function useRemoteThreads({ repoPath, prNumber, headSha }: Options) {
+  const qc = useQueryClient();
+  const enabled = Boolean(repoPath && prNumber !== undefined);
+  const query = useQuery<RefreshResult | null>({
+    queryKey: enabled ? remoteThreadsKey(repoPath!, prNumber!) : ["remote-threads", "disabled"],
+    enabled,
+    staleTime: Infinity, // never auto-refetch — refresh is explicit
+    queryFn: async () => {
+      const result = await ipc.sync.getCached(repoPath!, prNumber!);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+  });
+
+  const refresh = async (): Promise<RefreshResult | null> => {
+    if (!repoPath || prNumber === undefined || !headSha) return null;
+    const result = await ipc.sync.refresh(repoPath, prNumber, headSha);
+    if (!result.ok) throw result.error;
+    qc.setQueryData(remoteThreadsKey(repoPath, prNumber), result.value);
+    return result.value;
+  };
+
+  return { ...query, refresh };
+}
+```
+
+- [ ] **Step 2: Implement the five mutation hooks**
+
+Each follows the same template. Example for reply (other four follow the same shape, swapping the `ipc.sync.*` call and the cache patcher):
+
+```ts
+// src/features/sync/hooks/useReplyRemoteThread.ts
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteComment, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  inReplyToCommentId: number;
+  body: string;
+}
+
+export function useReplyRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteComment, Error, Vars>({
+    mutationFn: async ({ repoPath, prNumber, inReplyToCommentId, body }) => {
+      const result = await ipc.sync.reply(repoPath, prNumber, inReplyToCommentId, body);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (added, { repoPath, prNumber, threadId }) => {
+      qc.setQueryData<RefreshResult | null>(
+        remoteThreadsKey(repoPath, prNumber),
+        (prev) => prev && patchThread(prev, threadId, (t) => ({ ...t, comments: [...t.comments, added] })),
+      );
+    },
+  });
+}
+
+function patchThread(
+  prev: RefreshResult,
+  threadId: string,
+  patch: (t: RemoteThread) => RemoteThread,
+): RefreshResult {
+  return {
+    ...prev,
+    threads: prev.threads.map((t) => (t.threadId === threadId ? patch(t) : t)),
+  };
+}
+```
+
+Create:
+
+```ts
+// src/features/sync/hooks/useEditRemoteComment.ts
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteComment } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  commentId: number;
+  body: string;
+}
+
+export function useEditRemoteComment() {
+  const qc = useQueryClient();
+  return useMutation<RemoteComment, Error, Vars>({
+    mutationFn: async ({ repoPath, commentId, body }) => {
+      const result = await ipc.sync.edit(repoPath, commentId, body);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber, threadId, commentId }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) =>
+            t.threadId === threadId
+              ? {
+                  ...t,
+                  comments: t.comments.map((c) => (c.commentId === commentId ? updated : c)),
+                }
+              : t,
+          ),
+        };
+      });
+    },
+  });
+}
+```
+
+```ts
+// src/features/sync/hooks/useDeleteRemoteComment.ts
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  commentId: number;
+}
+
+export function useDeleteRemoteComment() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, Vars>({
+    mutationFn: async ({ repoPath, commentId }) => {
+      const result = await ipc.sync.delete(repoPath, commentId);
+      if (!result.ok) throw result.error;
+    },
+    onSuccess: (_void, { repoPath, prNumber, threadId, commentId }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads
+            .map((t) =>
+              t.threadId === threadId
+                ? { ...t, comments: t.comments.filter((c) => c.commentId !== commentId) }
+                : t,
+            )
+            // Drop the thread when its last comment is gone — matches what
+            // GitHub does on the web.
+            .filter((t) => t.comments.length > 0),
+        };
+      });
+    },
+  });
+}
+```
+
+```ts
+// src/features/sync/hooks/useResolveRemoteThread.ts
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars { repoPath: string; prNumber: number; threadId: string }
+
+export function useResolveRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteThread, Error, Vars>({
+    mutationFn: async ({ repoPath, threadId }) => {
+      const result = await ipc.sync.resolve(repoPath, threadId);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) => (t.threadId === updated.threadId ? updated : t)),
+        };
+      });
+    },
+  });
+}
+```
+
+```ts
+// src/features/sync/hooks/useReopenRemoteThread.ts — identical body except for `ipc.sync.reopen`.
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars { repoPath: string; prNumber: number; threadId: string }
+
+export function useReopenRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteThread, Error, Vars>({
+    mutationFn: async ({ repoPath, threadId }) => {
+      const result = await ipc.sync.reopen(repoPath, threadId);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) => (t.threadId === updated.threadId ? updated : t)),
+        };
+      });
+    },
+  });
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/sync/hooks
+git commit -m "$(cat <<'EOF'
+feat(phase-6): React Query hooks for remote threads
+
+useRemoteThreads loads from cache + refresh; five mutation hooks
+optimistically patch the cached payload.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 5 — Frontend UI
+
+## Task 15: `RemoteCommentBody` + `RemoteReplyComposer` + `RemoteThreadCard`
+
+**Files:**
+- Create: `src/features/sync/components/RemoteCommentBody.tsx`
+- Create: `src/features/sync/components/RemoteReplyComposer.tsx`
+- Create: `src/features/sync/components/RemoteThreadCard.tsx`
+
+- [ ] **Step 1: `RemoteCommentBody`**
+
+```tsx
+// src/features/sync/components/RemoteCommentBody.tsx
+import type { RemoteComment } from "@/shared/ipc/contract";
+import { Button } from "@/shared/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { PencilIcon, TrashIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  comment: RemoteComment;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export function RemoteCommentBody({ comment, onEdit, onDelete }: Props) {
+  const { t } = useTranslation();
+  return (
+    <article className="flex flex-col gap-1.5 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+      <header className="flex items-center justify-between gap-2 text-xs">
+        <span className="flex items-center gap-2 font-medium text-[hsl(var(--foreground))]">
+          {comment.authorAvatarUrl ? (
+            <img
+              src={comment.authorAvatarUrl}
+              alt=""
+              className="size-5 rounded-full"
+              loading="lazy"
+            />
+          ) : null}
+          {t("sync.thread.byAuthor", { author: comment.author })}
+        </span>
+        {comment.viewerCanUpdate || comment.viewerCanDelete ? (
+          <div className="flex items-center gap-1">
+            {comment.viewerCanUpdate ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={onEdit}
+                    aria-label={t("sync.actions.edit")}
+                  >
+                    <PencilIcon className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("sync.actions.edit")}</TooltipContent>
+              </Tooltip>
+            ) : null}
+            {comment.viewerCanDelete ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={onDelete}
+                    aria-label={t("sync.actions.delete")}
+                  >
+                    <TrashIcon className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("sync.actions.delete")}</TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+        ) : null}
+      </header>
+      <p className="whitespace-pre-wrap text-sm text-[hsl(var(--foreground))]">{comment.body}</p>
+    </article>
+  );
+}
+```
+
+- [ ] **Step 2: `RemoteReplyComposer`**
+
+```tsx
+// src/features/sync/components/RemoteReplyComposer.tsx
+import { Button } from "@/shared/ui/button";
+import { Textarea } from "@/shared/ui/textarea";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  pending: boolean;
+  onSubmit: (body: string) => void;
+}
+
+export function RemoteReplyComposer({ pending, onSubmit }: Props) {
+  const { t } = useTranslation();
+  const [body, setBody] = useState("");
+  const submit = () => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setBody("");
+  };
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder={t("sync.thread.replyPlaceholder")}
+        rows={2}
+        disabled={pending}
+      />
+      <div className="flex justify-end">
+        <Button type="submit" size="sm" disabled={pending || body.trim().length === 0}>
+          {t("sync.actions.send")}
+        </Button>
+      </div>
+    </form>
+  );
+}
+```
+
+If `Textarea` doesn't exist yet under `src/shared/ui/`, install via `bunx --bun shadcn@latest add textarea` (the project already uses this pattern — see ARCHITECTURE.md). Run `bun run check:fix` afterwards.
+
+- [ ] **Step 3: `RemoteThreadCard`**
+
+```tsx
+// src/features/sync/components/RemoteThreadCard.tsx
+import type { RemoteThread } from "@/shared/ipc/contract";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDeleteRemoteComment } from "../hooks/useDeleteRemoteComment";
+import { useEditRemoteComment } from "../hooks/useEditRemoteComment";
+import { useReopenRemoteThread } from "../hooks/useReopenRemoteThread";
+import { useReplyRemoteThread } from "../hooks/useReplyRemoteThread";
+import { useResolveRemoteThread } from "../hooks/useResolveRemoteThread";
+import { RemoteCommentBody } from "./RemoteCommentBody";
+import { RemoteReplyComposer } from "./RemoteReplyComposer";
+
+interface Props {
+  thread: RemoteThread;
+  repoPath: string;
+  prNumber: number;
+}
+
+export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
+  const { t } = useTranslation();
+  const reply = useReplyRemoteThread();
+  const edit = useEditRemoteComment();
+  const del = useDeleteRemoteComment();
+  const resolve = useResolveRemoteThread();
+  const reopen = useReopenRemoteThread();
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingBody, setEditingBody] = useState("");
+
+  const first = thread.comments[0];
+  const lastReplyTarget = thread.comments.at(-1)?.commentId ?? first?.commentId;
+
+  return (
+    <section className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3">
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Badge tone={thread.state === "resolved" ? "success" : "default"}>
+            {thread.state === "resolved"
+              ? t("sync.thread.resolvedBadge")
+              : t("sync.thread.openBadge")}
+          </Badge>
+          {thread.isOutdated ? (
+            <Badge tone="warning">{t("sync.thread.outdatedBadge")}</Badge>
+          ) : null}
+        </div>
+        {thread.state === "open" && thread.viewerCanResolve ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() =>
+              resolve.mutate({ repoPath, prNumber, threadId: thread.threadId })
+            }
+            disabled={resolve.isPending}
+          >
+            {t("sync.actions.resolve")}
+          </Button>
+        ) : null}
+        {thread.state === "resolved" && thread.viewerCanUnresolve ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => reopen.mutate({ repoPath, prNumber, threadId: thread.threadId })}
+            disabled={reopen.isPending}
+          >
+            {t("sync.actions.reopen")}
+          </Button>
+        ) : null}
+      </header>
+
+      <ol className="flex flex-col gap-2">
+        {thread.comments.map((c) => (
+          <li key={c.commentId}>
+            {editingId === c.commentId ? (
+              <form
+                className="flex flex-col gap-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const trimmed = editingBody.trim();
+                  if (!trimmed) return;
+                  edit.mutate(
+                    {
+                      repoPath,
+                      prNumber,
+                      threadId: thread.threadId,
+                      commentId: c.commentId,
+                      body: trimmed,
+                    },
+                    { onSuccess: () => setEditingId(null) },
+                  );
+                }}
+              >
+                <textarea
+                  className="min-h-20 rounded border border-[hsl(var(--border))] bg-[hsl(var(--background))] p-2 text-sm"
+                  value={editingBody}
+                  onChange={(e) => setEditingBody(e.target.value)}
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingId(null)}
+                  >
+                    {t("sync.actions.cancel")}
+                  </Button>
+                  <Button type="submit" size="sm" disabled={edit.isPending}>
+                    {t("sync.actions.save")}
+                  </Button>
+                </div>
+              </form>
+            ) : (
+              <RemoteCommentBody
+                comment={c}
+                onEdit={() => {
+                  setEditingId(c.commentId);
+                  setEditingBody(c.body);
+                }}
+                onDelete={() => {
+                  if (window.confirm(t("sync.actions.deleteConfirm"))) {
+                    del.mutate({
+                      repoPath,
+                      prNumber,
+                      threadId: thread.threadId,
+                      commentId: c.commentId,
+                    });
+                  }
+                }}
+              />
+            )}
+          </li>
+        ))}
+      </ol>
+
+      {thread.state === "open" && lastReplyTarget !== undefined ? (
+        <RemoteReplyComposer
+          pending={reply.isPending}
+          onSubmit={(body) =>
+            reply.mutate({
+              repoPath,
+              prNumber,
+              threadId: thread.threadId,
+              inReplyToCommentId: lastReplyTarget,
+              body,
+            })
+          }
+        />
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/sync/components/RemoteCommentBody.tsx \
+         src/features/sync/components/RemoteReplyComposer.tsx \
+         src/features/sync/components/RemoteThreadCard.tsx
+# If you installed a new shadcn primitive, include it:
+git add src/shared/ui/textarea.tsx components.json 2>/dev/null
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #32): RemoteThreadCard with reply/edit/delete/resolve actions
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: `UnmappedThreadsSection` (#34) + `unmappedReason` helper
+
+**Files:**
+- Create: `src/features/sync/lib/unmappedReason.ts`
+- Create: `src/features/sync/components/UnmappedThreadsSection.tsx`
+
+- [ ] **Step 1: Reason resolver**
+
+```ts
+// src/features/sync/lib/unmappedReason.ts
+import type { RemoteThread } from "@/shared/ipc/contract";
+import type { TFunction } from "i18next";
+
+export function describeUnmappedReason(thread: RemoteThread, t: TFunction): string {
+  const status = thread.mappingStatus;
+  switch (status.kind) {
+    case "fileMissing":
+      return t("sync.unmapped.fileMissing", { path: thread.path });
+    case "lineMoved":
+      return t("sync.unmapped.lineMoved", {
+        path: thread.path,
+        line: thread.originalLine,
+      });
+    case "ambiguous":
+      return t("sync.unmapped.ambiguous", { path: thread.path });
+    case "outdated":
+      return t("sync.unmapped.outdated");
+    case "mapped":
+      // Defensive: an unmapped thread should never report Mapped, but
+      // returning a sensible message keeps the UI from crashing on stale
+      // payloads.
+      return t("sync.unmapped.outdated");
+  }
+}
+```
+
+- [ ] **Step 2: Section component**
+
+```tsx
+// src/features/sync/components/UnmappedThreadsSection.tsx
+import type { RemoteThread } from "@/shared/ipc/contract";
+import { Button } from "@/shared/ui/button";
+import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { describeUnmappedReason } from "../lib/unmappedReason";
+
+interface Props {
+  threads: RemoteThread[];
+}
+
+export function UnmappedThreadsSection({ threads }: Props) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  if (threads.length === 0) return null;
+  const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
+  return (
+    <section className="border-t border-[hsl(var(--border))] px-4 py-3">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left text-xs font-semibold text-[hsl(var(--foreground))]"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Chevron className="size-3.5" />
+        {t("sync.section.unmappedHeading")} ({threads.length})
+      </button>
+      {open ? (
+        <div className="mt-2 flex flex-col gap-2">
+          <p className="text-[11px] text-[hsl(var(--muted-foreground))]">
+            {t("sync.section.unmappedSubtitle")}
+          </p>
+          <ul className="flex flex-col gap-2">
+            {threads.map((thread) => {
+              const firstComment = thread.comments[0];
+              return (
+                <li
+                  key={thread.threadId}
+                  className="flex flex-col gap-1 rounded-md border border-dashed border-[hsl(var(--border))] p-2"
+                >
+                  <span className="text-xs font-medium text-[hsl(var(--foreground))]">
+                    {describeUnmappedReason(thread, t)}
+                  </span>
+                  {firstComment ? (
+                    <span className="line-clamp-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+                      {t("sync.thread.byAuthor", { author: firstComment.author })}: {firstComment.body}
+                    </span>
+                  ) : null}
+                  {firstComment ? (
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-fit gap-1 px-2 text-[11px]"
+                    >
+                      <a href={firstComment.htmlUrl} target="_blank" rel="noreferrer">
+                        <ExternalLinkIcon className="size-3" />
+                        {t("sync.section.openOnGithub")}
+                      </a>
+                    </Button>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Typecheck + lint**
+
+Run: `bun run typecheck && bun run check`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/sync/lib/unmappedReason.ts \
+         src/features/sync/components/UnmappedThreadsSection.tsx
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #34): UnmappedThreadsSection + reason resolver
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Export sync feature + extend RefreshButton
+
+**Files:**
+- Modify: `src/features/sync/index.ts`
+- Modify: `src/features/main/components/RefreshButton.tsx`
+
+- [ ] **Step 1: Replace the placeholder export**
+
+```ts
+// src/features/sync/index.ts
+export { RemoteThreadCard } from "./components/RemoteThreadCard";
+export { UnmappedThreadsSection } from "./components/UnmappedThreadsSection";
+export { useRemoteThreads, remoteThreadsKey } from "./hooks/useRemoteThreads";
+export { useReplyRemoteThread } from "./hooks/useReplyRemoteThread";
+export { useEditRemoteComment } from "./hooks/useEditRemoteComment";
+export { useDeleteRemoteComment } from "./hooks/useDeleteRemoteComment";
+export { useResolveRemoteThread } from "./hooks/useResolveRemoteThread";
+export { useReopenRemoteThread } from "./hooks/useReopenRemoteThread";
+export { mergeLocalAndRemote } from "./lib/mergeLocalAndRemote";
+export type { MergedEntry } from "./lib/mergeLocalAndRemote";
+```
+
+- [ ] **Step 2: Extend `RefreshButton` defaults**
+
+Edit `src/features/main/components/RefreshButton.tsx` — extend `DEFAULT_KEYS`:
+
+```ts
+const DEFAULT_KEYS = [
+  "pull-requests",
+  "pull-request",
+  "changed-files",
+  "file-content",
+  "file-diff",
+  "remote-threads",
+];
+```
+
+But invalidating the cache won't actually trigger a network fetch (the hook's `queryFn` only reads the SQLite cache). The "remote refresh from GitHub" semantic lives on a separate path: the consumer that mounts `useRemoteThreads` is responsible for calling `.refresh()` from a refresh action. To wire that up, we need `RefreshButton` to take an optional `onRefresh` callback the consumer can supply. Add:
+
+```ts
+interface RefreshButtonProps {
+  keys?: string[];
+  /**
+   * Optional async hook the consumer fires alongside the React Query
+   * invalidation — used by ThreadsPane to also call `useRemoteThreads.refresh`
+   * so the user sees the GitHub round-trip when they click Refresh.
+   */
+  onRefresh?: () => Promise<unknown>;
+}
+```
+
+And inside `handleClick`:
+
+```ts
+    try {
+      await Promise.all([
+        ...keys.map((k) => qc.invalidateQueries({ queryKey: [k] })),
+        onRefresh?.(),
+      ]);
+    } finally { … }
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `bun run typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/sync/index.ts src/features/main/components/RefreshButton.tsx
+git commit -m "$(cat <<'EOF'
+feat(phase-6): wire RefreshButton to trigger remote-thread refresh
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: ThreadsPane integration
+
+**Files:**
+- Modify: `src/features/main/components/ThreadsPane.tsx`
+
+- [ ] **Step 1: Wire `useRemoteThreads` + merged list + unmapped section**
+
+The existing `ThreadsPane` renders a list of local-only threads. We replace that list with a merged stream — keep the local-only `ThreadList` rendering for `local`-kind entries (so existing keyboard navigation and grouping continues to work) and render the new `RemoteThreadCard` for `remote`-kind entries. The unmapped section is appended after the main list.
+
+Edit `ThreadsPane.tsx`:
+
+1. Add imports near the top:
+
+```tsx
+import {
+  RemoteThreadCard,
+  UnmappedThreadsSection,
+  mergeLocalAndRemote,
+  useRemoteThreads,
+} from "@/features/sync";
+```
+
+2. Inside the component, call the new hook (props already include `repoPath`, `prNumber`, `sha`):
+
+```tsx
+  const remote = useRemoteThreads({ repoPath, prNumber, headSha: sha });
+  const remoteData = remote.data;
+```
+
+3. Replace the existing `scopedComments`/`visible`/`hiddenCount` plumbing's *render* (not the local filter logic — keep that as is for local threads) with a merged stream when in `allFiles` scope, or filtered by the active file when scoped to the current file. Concretely, compute:
+
+```tsx
+  const remoteThreads = useMemo(() => {
+    if (!remoteData) return [];
+    if (effectiveScope === "currentFile" && filePath) {
+      return remoteData.threads.filter((t) => t.path === filePath);
+    }
+    return remoteData.threads;
+  }, [remoteData, effectiveScope, filePath]);
+
+  const merged = useMemo(
+    () => mergeLocalAndRemote(visible, remoteThreads),
+    [visible, remoteThreads],
+  );
+
+  const unmapped = useMemo(() => {
+    if (!remoteData) return [];
+    if (effectiveScope === "currentFile" && filePath) {
+      return remoteData.unmapped.filter((t) => t.path === filePath);
+    }
+    return remoteData.unmapped;
+  }, [remoteData, effectiveScope, filePath]);
+```
+
+4. Where the JSX renders the existing thread list, branch on entry kind. The simplest path: render the existing `<ThreadList>` only with `local`-kind entries' comments (extract them with `merged.filter(e => e.kind === "local").map(e => e.comment)`), and render `RemoteThreadCard` for each `remote` entry above the list. If your `ThreadList` already does grouping, keep it — but interleaving requires turning the JSX into a flat `merged.map(entry => entry.kind === "remote" ? <RemoteThreadCard …/> : <LocalThreadRow …/>)`. Use the option that produces correct ordering with minimal churn — pick whichever fits the existing keyboard navigation patterns (see the existing `ThreadList.tsx` roving-tabindex implementation).
+
+5. After the main list, render `<UnmappedThreadsSection threads={unmapped} />`.
+
+6. If `prNumber` and `repoPath` are present, pass `remote.refresh` to a `RefreshButton onRefresh={remote.refresh}` instance — likely in the parent `MainLayout`. If `RefreshButton` lives outside `ThreadsPane`, surface a callback prop and let the parent pass it down.
+
+7. Show a banner when `remote.error` is set:
+
+```tsx
+  {remote.error ? (
+    <Alert variant="destructive" className="mx-4 my-2">
+      <AlertTitle>{t("sync.errors.refreshFailedTitle")}</AlertTitle>
+      <AlertDescription>{t("sync.errors.refreshFailedDescription")}</AlertDescription>
+    </Alert>
+  ) : null}
+```
+
+- [ ] **Step 2: Typecheck + lint**
+
+Run: `bun run typecheck && bun run check`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/main/components/ThreadsPane.tsx
+git commit -m "$(cat <<'EOF'
+feat(phase-6 #31 #32 #34): integrate remote threads into ThreadsPane
+
+Renders remote threads inline with local ones, with an Unmapped
+section at the bottom and a refresh-failure banner.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: Hook MainLayout's RefreshButton to remote refresh
+
+**Files:**
+- Modify: `src/features/main/screens/MainLayout.tsx` (or wherever `RefreshButton` is rendered alongside the `ThreadsPane`)
+
+- [ ] **Step 1: Locate the RefreshButton mount and wire `onRefresh`**
+
+Run: `grep -rn "<RefreshButton" src/features`
+Expected: 1–2 hits. For each occurrence inside `MainLayout` (or equivalent), call `useRemoteThreads(...)` in the same component and pass `onRefresh={remote.refresh}` to `<RefreshButton>`.
+
+If `useRemoteThreads` is already mounted inside `ThreadsPane`, lift it into `MainLayout` (single source of truth) and pass `remote.data` down via prop or via a small context. Choose lifting — duplicate hook instances with the same query key would still share React Query cache, but lifting keeps the code obvious.
+
+- [ ] **Step 2: Build the frontend and run the app to smoke-test**
+
+Run: `bun run dev` (Tauri will spawn Vite). Open a repo with a known PR that already has review threads. Click Refresh. Threads should appear; clicking reply / edit / resolve should round-trip.
+
+If the dev server can't reach `gh` (`gh auth status` fails), the existing `GhNotAuthenticated` error already surfaces — confirm the new sync flows reuse the same error mapping (no extra UI work needed).
+
+- [ ] **Step 3: Commit any wiring fixes**
+
+```bash
+git add src/features/main/screens/MainLayout.tsx
+git commit -m "$(cat <<'EOF'
+feat(phase-6): wire RefreshButton onRefresh to useRemoteThreads.refresh
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+# Phase 6 — Verification
+
+## Task 20: Full verification + fixups
+
+**Files:**
+- Any files needed to clear lint / type / test failures.
+
+- [ ] **Step 1: Format**
+
+Run: `cargo fmt --all` then `bun run check:fix`.
+
+- [ ] **Step 2: Rust lint**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: clean. Fix inline.
+
+- [ ] **Step 3: Rust tests**
+
+Run: `cargo test --workspace`
+Expected: green.
+
+- [ ] **Step 4: TS type + lint + build**
+
+Run: `bun run typecheck && bun run check && bun run build:web`
+Expected: green.
+
+- [ ] **Step 5: Bun unit tests**
+
+Run: `bun test`
+Expected: green.
+
+- [ ] **Step 6: Manual smoke (spec checklist)**
+
+Open the dev app via `bun run dev` and walk through the manual checklist in `docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md` ("Verification checklist (manual)"). Mark each item off in this plan as you go:
+
+  - [ ] PR with open / resolved / outdated threads → refresh → correct buckets.
+  - [ ] Single-line and multi-line anchors render correctly.
+  - [ ] Force an unmapped thread (rename a file locally) → appears under "Unmapped".
+  - [ ] Reply persists after refresh.
+  - [ ] Edit own comment in place; edit button hidden on others'.
+  - [ ] Delete own comment.
+  - [ ] Resolve / reopen toggles badge.
+  - [ ] Restart app → cache hydrates before refresh click.
+  - [ ] Switch PR and back → cache still there.
+  - [ ] No raw English in the new UI (everything reads via `t(...)`).
+
+- [ ] **Step 7: Commit fixups**
+
+If any of the above produced fixes, commit them:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+chore(phase-6): verification fixes
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 8: Open the PR**
+
+Run:
+
+```bash
+git push -u origin feat/phase-6-github-sync
+gh pr create --title "feat(phase-6): GitHub sync — refresh, mutations, cache, unmapped" --body "$(cat <<'EOF'
+## Summary
+- Refresh remote review threads via GraphQL and anchor them to the current head (#31).
+- Reply / edit / delete / resolve / reopen remote threads where GitHub allows; read-only otherwise (#32).
+- Per-PR SQLite cache with explicit invalidation; cache hydrates at boot (#33).
+- Surface unmappable threads under a dedicated "Unmapped" section in the threads pane (#34).
+
+Spec: `docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md`
+Plan: `docs/superpowers/plans/2026-05-24-phase-6-github-sync.md`
+
+## Test plan
+- [ ] `cargo test --workspace`
+- [ ] `bun run typecheck && bun run check && bun run build:web`
+- [ ] `bun test`
+- [ ] Manual smoke (verification checklist in the spec)
+
+Closes #31, #32, #33, #34.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+(Performed at plan-write time; documented for the executor.)
+
+- Every Phase 6 issue has at least one task: #31 → Tasks 5/6/8/10; #32 → Tasks 9/10/14/15/17/18; #33 → Tasks 4/7/10/11/14; #34 → Tasks 5/6/16/18.
+- No `TBD` or `add appropriate error handling` placeholders — each task carries the exact code or a precise pointer to an existing pattern (with the file path) when the snippet would be too long to inline.
+- Type/method names stay consistent: `RemoteThread`, `RemoteComment`, `RefreshResult`, `MappingStatus`, `Sync`, `RemoteThreadsStore`, `FileResolver`, `mergeLocalAndRemote`, `remoteThreadsKey` are introduced once and referenced under the same names everywhere.
+- Commits are granular (one per task) and ride on the `feat/phase-6-github-sync` branch already created with the spec commit.

--- a/docs/superpowers/specs/2026-05-08-long-range-comments-design.md
+++ b/docs/superpowers/specs/2026-05-08-long-range-comments-design.md
@@ -1,0 +1,291 @@
+# Long-range comments (10–15+ lines) — design spec
+
+**Issue:** [#24 — Long range comments (10–15+ lines)](https://github.com/jaovito/markdown-reviewer/issues/24)
+**Milestone:** Phase 4 — Advanced Comments
+**Status:** Design approved 2026-05-08; ready for implementation plan.
+
+---
+
+## Goal
+
+Make multi-line review comments (especially 10+ line anchors) feel calm and traceable in the rendered Markdown preview, and let reviewers identify each thread in the threads pane without having to open the file. Closes the last open Phase 4 issue.
+
+The mechanical anchor model already supports arbitrary range lengths (`lineRange` and `codeBlock` anchors carry `startLine` / `endLine`). This spec is purely UX polish on top of that model:
+
+1. Replace the per-line full-background wash on multi-line ranges with a thin left rail plus a sticky header chip pinned to the start of the range.
+2. Add a source-snippet preview to every row in the threads pane.
+
+No Rust changes. No DB migration. No new IPC commands.
+
+---
+
+## Non-goals
+
+- Capping range length. There is no hard upper bound; the visual treatment scales gracefully.
+- Cross-file source diffing — the snippet shows raw Markdown source, not a rendered or diff-aware preview.
+- Syntax highlighting in the threads-pane snippet (code-block anchors render as plain mono text).
+- Pre-fetching every Markdown file in the PR up front.
+
+---
+
+## 1. Inline long-range layout (`features/comments`)
+
+### Visual
+
+| Anchor kind                   | Visual treatment                                                                                                                                                                       |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `singleLine`                  | Unchanged — full background wash + 3px brand left bar + 6px rounded corners (current `[data-source-line][data-has-comment="true"]` rule).                                              |
+| `lineRange` / `codeBlock` (multi-line) | Drop the wash. Render a continuous **3px brand left rail** spanning every covered line (rounded top on the start line, rounded bottom on the end line, straight middle). Add a **sticky range header chip** above the start line: `"L{start}–L{end} · {count} comment"` + a "Jump" affordance. |
+| Resolved / hidden / minimized (multi-line) | Same rail, muted via the existing `data-comment-minimized` / `data-comment-resolved` attributes already stamped on each line. The wash-specific minimized/resolved CSS rules go away for ranges. |
+
+### DOM contract
+
+`syncSlots` in `InlineThreads.tsx` already walks every covered line. Extend it to:
+
+1. Stamp a new attribute alongside `data-has-comment` on each line in the range:
+   - `data-comment-range="head"` on `startLine`
+   - `data-comment-range="tail"` on `endLine`
+   - `data-comment-range="body"` on every line strictly between
+   - `data-comment-range="single"` on a single-line anchor (lets the existing wash rule key off the same attribute uniformly)
+2. Allocate a new slot type alongside the existing card / badge slots:
+
+```ts
+interface SlotMap {
+  threads: Map<SlotKey, HTMLDivElement>;     // existing — card slot AFTER endLine
+  badges: Map<SlotKey, HTMLSpanElement>;     // existing — collapsed-state badge
+  headers: Map<SlotKey, HTMLDivElement>;     // NEW — range header BEFORE startLine
+  composerSlot: HTMLDivElement | null;       // existing
+}
+```
+
+`headers` slot is created only when `startLine !== endLine` and the group is not collapsed (a fully hidden / fully resolved-collapsed range shows no header — the gutter marker already handles those cases). Mounted as `data-thread-slot="header"` so the existing mutation observer's `mutationIsSignificant` check ignores it.
+
+The header slot is inserted **before** the start-line node (`anchor.parentNode.insertBefore(slot, anchor)`), as a block-level sibling. The chip itself uses `position: sticky; top: 0; z-index: 1` inside the preview's scroll container.
+
+### `RangeHeaderChip` component
+
+New component at `src/features/comments/components/RangeHeaderChip.tsx`. Portaled into the header slot from `InlineThreads`.
+
+Props:
+
+```ts
+interface RangeHeaderChipProps {
+  startLine: number;
+  endLine: number;
+  count: number;
+  /** Used to mute the rail color when the thread is resolved. */
+  state: CommentState;
+  onJump: () => void;
+}
+```
+
+Behavior:
+- Renders `t("comments.range.headerLabel", { start, end, count })` + a small ghost button labeled `t("comments.range.jump")` with `aria-label={t("comments.range.jumpAria")}`.
+- `onJump` is wired up in `InlineThreads` to (a) `select(headComment.id)` and (b) call `scrollIntoView({ block: "center", behavior: "smooth" })` on the corresponding card slot DOM node looked up via `slotsRef.current.threads.get(slotKey)`.
+
+### CSS changes
+
+In `src/shared/styles/index.css`:
+- Drop the `[data-source-line][data-has-comment="true"]` wash for multi-line ranges by guarding it with `[data-comment-range="single"]`.
+- Add a new rail rule keyed off `[data-comment-range="head"|"body"|"tail"]` — 3px solid brand-color left border, rounded top on `head`, rounded bottom on `tail`, no rounding on `body`. Per-line `padding-left` matches the existing wash rule so vertical alignment stays consistent.
+- Mirror the same in the `pre [data-code-line]` family for code-block anchors.
+- Add a `[data-thread-slot="header"]` rule that gives the header slot `margin: 0 0 4px`, removes default block flow padding, and sets `position: sticky; top: 0` with the preview's background as the chip backdrop so text behind doesn't bleed through.
+- Keep the resolved/hidden minimized rules but reduce them to opacity + rail color desaturation.
+
+### Single-line behavior
+
+`singleLine` anchors keep the wash. They get `data-comment-range="single"` so any future styling can branch off it; today's CSS keys off the new attribute but uses the legacy wash visual.
+
+---
+
+## 2. Threads-pane snippet preview (`features/main/components/threads`)
+
+### `ThreadSnippet` component
+
+New component at `src/features/main/components/threads/ThreadSnippet.tsx`. Mounted by `ThreadCard` between the anchor label row and the comment body, for every visible row regardless of anchor kind.
+
+Props:
+
+```ts
+interface ThreadSnippetProps {
+  prNumber: number;
+  filePath: string;
+  headSha: string;
+  startLine: number;
+  endLine: number;
+}
+```
+
+Layout:
+- Outer wrapper: `font-mono text-[11px] leading-snug rounded border-l-[1.5px] border-[hsl(var(--comment-marker-fg))] pl-2 py-1 my-1 bg-[hsl(var(--muted))]/30`.
+- Inner: a list of up to **3 source lines** (`MAX_VISIBLE = 3`), trailing line ellipsised via `text-overflow: ellipsis` on the last child. `white-space: pre`.
+- If the range is longer than `MAX_VISIBLE`, a muted row beneath: `t("threads.snippet.moreLines", { count })` (with `_one` / `_other` plurals).
+- While loading, render a `Skeleton` block with the same height (~3 lines × line-height).
+- On error, render `null` — the rest of the card still works.
+
+Slicing rule (single source of truth in a helper):
+
+```ts
+function sliceSnippet(
+  lines: string[],
+  startLine: number,
+  endLine: number,
+  maxVisible = 3,
+): { visible: string[]; more: number } {
+  const total = endLine - startLine + 1;
+  const stop = startLine - 1 + Math.min(total, maxVisible);
+  const visible = lines.slice(startLine - 1, stop);
+  const more = Math.max(0, total - visible.length);
+  return { visible, more };
+}
+```
+
+### `useFileSource` hook
+
+New hook at `src/features/comments/hooks/useFileSource.ts` (lives under `comments` because both inline and pane consumers belong to comment surfaces; the hook itself is feature-agnostic at runtime).
+
+```ts
+export function useFileSource(
+  repoPath: string | undefined,
+  sha: string | undefined,
+  filePath: string,
+): { lines: string[] | null; isLoading: boolean; error: AppError | null };
+```
+
+Implementation:
+- Wraps `useQuery` with key `["file-source", repoPath, sha, filePath]`.
+- `queryFn` calls `ipc.files.readMarkdown(repoPath, sha, filePath)` (the existing Phase 2 command at `read_markdown_file`). On `Result.ok === false`, throws so React Query surfaces the error.
+- `enabled: Boolean(repoPath && sha && filePath)` — when any input is missing, the query stays idle and the hook returns `{ lines: null, isLoading: false, error: null }`.
+- `staleTime: Infinity`, `gcTime: 5 * 60_000`. Markdown source is content-addressable for a given `(repoPath, sha)`; the `sha` segment of the key auto-invalidates when the PR is refreshed.
+- Returns `{ lines: data.split("\n"), isLoading, error }`. The `split` is memoized inside the hook via a `useMemo` keyed on `data` so multiple `ThreadSnippet` instances reading the same file share the same `string[]` reference.
+
+### `ThreadCard` integration
+
+`ThreadCard.tsx` mounts `<ThreadSnippet />` between the anchor label row and the comment-body row, passing the head comment's `(startLine, endLine)`. `ThreadCard` already receives `filePath` (via the `ThreadGroup`); `repoPath` and `sha` are not in the threads-pane subtree today — they live in `PullRequestScreen` (`repoPath.data` and `detail.data?.headSha`). Plumbing chain to add:
+
+```
+PullRequestScreen (has repoPath + headSha)
+  → ThreadsPane (add repoPath + headSha props)
+    → ThreadList (add repoPath + headSha props)
+      → ThreadCard (consume + pass to ThreadSnippet)
+        → ThreadSnippet → useFileSource(repoPath, sha, filePath)
+```
+
+`ThreadFileGroup` and `ThreadAnchorGroup` don't need the new props — they only render headers and forward `children`. The chain skips them. Each remaining layer adds a couple of optional props (typed as `string | undefined`). No new context or store.
+
+When `head.anchor.kind === "singleLine"`, both `startLine` and `endLine` equal the same line number — the snippet renders a single line with no "more" suffix.
+
+---
+
+## 3. Backend / IPC
+
+No new commands. No DTO additions. No SQLite migration.
+
+`src/shared/ipc/contract.ts` — unchanged.
+
+The frontend side reuses `read_markdown_file(path)` which returns `string` (already typed). All processing happens in `useFileSource`.
+
+---
+
+## 4. State, stores, i18n
+
+### Stores
+
+No new stores. Existing `useSelectedThread`, `useMinimizedThreads`, `useThreadsFilter` are unchanged.
+
+### i18n keys (`src/shared/i18n/locales/en.json`)
+
+Repo is currently English-only; add keys in English. New keys, grouped by feature:
+
+```jsonc
+{
+  "comments": {
+    "range": {
+      "headerLabel_one": "L{{start}}–L{{end}} · {{count}} comment",
+      "headerLabel_other": "L{{start}}–L{{end}} · {{count}} comments",
+      "jump": "Jump",
+      "jumpAria": "Jump to comment thread"
+    }
+  },
+  "threads": {
+    "snippet": {
+      "moreLines_one": "… +{{count}} more line",
+      "moreLines_other": "… +{{count}} more lines"
+    }
+  }
+}
+```
+
+(Spec presented to the user in pt-BR for review; ship strings remain English.)
+
+### Tokens
+
+Add nothing new today — the rail reuses `--comment-marker-fg`, the snippet background reuses `--muted`. If dark-mode contrast on the rail proves insufficient during smoke testing, add `--comment-rail-fg` token in a follow-up commit.
+
+---
+
+## 5. Tests
+
+### Unit (Bun)
+
+- `src/features/main/components/threads/ThreadSnippet.test.ts` — pure-function test for `sliceSnippet`:
+  - 15-line range with `maxVisible = 3` → 3 visible, 12 more.
+  - 2-line range with `maxVisible = 3` → 2 visible, 0 more.
+  - single-line (`startLine === endLine`) → 1 visible, 0 more.
+
+### Component (Bun + happy-dom)
+
+- `RangeHeaderChip.test.tsx`
+  - Renders the localized label with start/end/count.
+  - Clicking "Jump" calls `onJump` exactly once.
+  - `aria-label` resolves through i18n.
+- `ThreadSnippet.test.tsx`
+  - Mocks `useFileSource` to return canned lines + headSha.
+  - 3-line range renders three `<pre>`-style rows and no "more" row.
+  - 15-line range renders three rows + the "+12 more lines" row.
+  - Loading state renders `Skeleton`.
+  - Error state renders `null`.
+
+### Manual smoke (Tauri dev)
+
+Run `bun run dev` against the local fixture PR:
+
+1. Drag-select a 15-line range across paragraphs and code blocks. Expect:
+   - Continuous left rail across all 15 covered lines (rounded top/bottom).
+   - Header chip pinned at the top with `L{start}–L{end} · 1 comment · Jump`.
+   - Card slot below the last covered line.
+2. Scroll past the chip into the middle of the range. The chip should stick to the top of the preview while the rail keeps highlighting the surrounding lines.
+3. Click "Jump" on the chip. Smooth-scroll lands on the card with the head comment selected.
+4. Open the threads pane. Expect:
+   - Each row shows a 3-line monospace snippet from the source.
+   - Threads in unloaded files show a brief Skeleton flash, then snap to content.
+   - Range threads longer than 3 lines show "… +N more lines".
+5. Resolve a long-range thread. Expect:
+   - Inline rail desaturates; the gutter marker takes over (existing behavior).
+   - Pane snippet stays visible for traceability.
+
+---
+
+## 6. Files touched (estimate)
+
+```
+src/features/comments/components/InlineThreads.tsx          ~+80 lines (header slot, range data attrs)
+src/features/comments/components/RangeHeaderChip.tsx        new (~60 lines)
+src/features/comments/hooks/useFileSource.ts                new (~40 lines)
+src/features/main/components/threads/ThreadCard.tsx         ~+15 lines (mount ThreadSnippet, accept repoPath/sha props)
+src/features/main/components/threads/ThreadList.tsx         ~+5 lines (accept + forward repoPath/sha)
+src/features/main/components/ThreadsPane.tsx                ~+5 lines (accept repoPath/sha props)
+src/features/file-explorer/screens/PullRequestScreen/index.tsx  ~+2 lines (pass repoPath + headSha to ThreadsPane)
+src/features/main/components/threads/ThreadSnippet.tsx      new (~80 lines)
+src/shared/styles/index.css                                 ~+30 lines (rail variants, sticky header)
+src/shared/i18n/locales/en.json                             ~+6 keys
++ 3 test files
+```
+
+No Rust changes. No new shadcn primitives. No DB migration.
+
+---
+
+## Open questions
+
+None at design time. If dark-mode contrast on the rail proves insufficient during smoke testing, introduce `--comment-rail-fg` as a follow-up.

--- a/docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md
+++ b/docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md
@@ -1,0 +1,368 @@
+# Phase 6 — GitHub Sync (Design)
+
+**Status:** Draft · **Date:** 2026-05-24 · **Branch:** `feat/phase-6-github-sync` · **Milestone:** [Phase 6 — GitHub Sync](https://github.com/jaovito/markdown-reviewer/milestone/6)
+
+Implements the four Phase 6 issues:
+
+- [#31](https://github.com/jaovito/markdown-reviewer/issues/31) — `refresh_remote_comments` + anchor mapping
+- [#32](https://github.com/jaovito/markdown-reviewer/issues/32) — Reply / edit / delete / resolve / reopen remote threads
+- [#33](https://github.com/jaovito/markdown-reviewer/issues/33) — Per-PR cache with explicit invalidation
+- [#34](https://github.com/jaovito/markdown-reviewer/issues/34) — Report unmappable remote threads
+
+All four ship on a single branch with one PR. The product principles from `CLAUDE.md` apply: local-first, explicit refresh, no polling, `gh` preferred over raw REST, no secrets in logs.
+
+---
+
+## Goals
+
+1. The user can pull existing review threads from GitHub into the app with a single click and see them anchored to their Markdown lines next to local drafts.
+2. The user can reply to, edit, delete, and resolve/reopen review threads from inside the app, with read-only state shown clearly when the GitHub API denies the action.
+3. The threads pane visually distinguishes local drafts, locally-submitted comments, and remote threads, and surfaces threads we couldn't safely anchor under a dedicated "Unmapped" section.
+4. Remote data persists per (repo, PR) so the app boots into the last known good state without re-hitting GitHub. Cache is invalidated on PR switch, branch switch, or explicit refresh — never on a timer.
+
+## Non-goals
+
+- Real-time sync, websockets, or polling.
+- Pull-request review *event* state ("Approve", "Request changes"). Phase 6 only covers comment threads; we already submit reviews as `COMMENT` event in Phase 3.
+- Conflict resolution when the same comment is edited locally and remotely between refreshes — we always treat the remote payload as the source of truth on refresh.
+- Cross-PR navigation from an unmapped thread.
+
+---
+
+## Architecture
+
+### Layer summary
+
+```
+core/
+  domain/remote_thread.rs        (new) RemoteThread, RemoteComment, ThreadState, MappingStatus, UnmappedThread
+  ports/gh.rs                    (extend) list_review_threads, reply/edit/delete review-comment, resolve/unresolve thread
+  ports/remote_threads_store.rs  (new) cache trait
+  application/sync/              (new) refresh.rs, mutations.rs, mapping.rs
+  error.rs                       (extend) ReadOnlyRemote variant if needed
+infra/
+  gh/gh_cli.rs                   (extend) implement new GhClient methods (REST + GraphQL)
+  sqlite/
+    migrations/0004_remote_threads_cache.sql  (new)
+    remote_threads_store.rs                   (new)
+ipc/
+  commands/sync.rs               (new) 7 new commands
+  state.rs                       (extend) Sync use-case bundle
+src-tauri/
+  bootstrap.rs                   (extend) wire SqliteRemoteThreadsStore into AppState
+
+src/
+  features/sync/                 (extend the placeholder)
+    hooks/                       useRemoteThreads, useReply*, useEdit*, useDelete*, useResolve*, useReopen*
+    components/                  RemoteThreadCard, RemoteReplyComposer, UnmappedThreadsSection
+    lib/                         mergeLocalAndRemote.ts (ordering rules)
+    index.ts
+  features/main/components/
+    ThreadsPane.tsx              (extend) consume remote threads + unmapped
+    RefreshButton.tsx            (extend) invalidate ["remote-threads"]
+  shared/ipc/contract.ts         (extend) new types + commands
+  shared/i18n/locales/en.json    (extend) sync.* namespace
+```
+
+Rule of thumb stays the same: `core` knows nothing about HTTP/SQLite; `infra` implements ports; `ipc` is a 5-line adapter per command.
+
+### Domain types
+
+```rust
+// core/domain/remote_thread.rs
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteThread {
+    /// GraphQL node id of the PullRequestReviewThread. Used for resolve/unresolve mutations.
+    pub thread_id: String,
+    /// PR-level path the thread is anchored to, as GitHub reports it.
+    pub path: String,
+    /// Original commit SHA the thread was first posted against.
+    pub original_commit_id: String,
+    /// `null` when GitHub marks the thread as outdated (line moved past the diff).
+    pub line: Option<u32>,
+    pub start_line: Option<u32>,
+    pub original_line: u32,
+    pub original_start_line: Option<u32>,
+    pub state: ThreadState,
+    pub is_outdated: bool,
+    pub viewer_can_resolve: bool,
+    pub viewer_can_unresolve: bool,
+    pub comments: Vec<RemoteComment>,
+    /// Resolved during anchor mapping. `None` when unmappable.
+    pub anchor: Option<CommentAnchor>,
+    pub mapping_status: MappingStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteComment {
+    /// REST review-comment id. Used for edit/delete (`/pulls/comments/{id}`).
+    pub comment_id: i64,
+    pub author: String,
+    pub author_avatar_url: Option<String>,
+    pub body: String,
+    pub created_at: String, // RFC3339
+    pub updated_at: String,
+    pub viewer_can_update: bool,
+    pub viewer_can_delete: bool,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThreadState { Open, Resolved }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum MappingStatus {
+    Mapped,
+    Outdated { reason: String },
+    FileMissing,
+    LineMoved,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RefreshResult {
+    pub threads: Vec<RemoteThread>, // Mapped threads only (anchor != None)
+    pub unmapped: Vec<RemoteThread>, // mapping_status != Mapped, kept for #34 panel
+    pub refreshed_at_ms: i64,
+}
+```
+
+The `RemoteThread` always lives on the same surface whether mapped or not; the `RefreshResult` partitions for ergonomic frontend consumption. Cache stores the full set.
+
+### Anchor mapping algorithm (#31)
+
+Pure function `core::application::sync::mapping::map_anchor(thread, head_sha, file_resolver) -> (Option<CommentAnchor>, MappingStatus)`.
+
+Algorithm:
+
+1. **Outdated short-circuit.** If GitHub says `is_outdated` or `line == None`, return `(None, Outdated { reason: "github_outdated" })`. The thread is preserved as unmapped.
+2. **Same commit.** If `original_commit_id == head_sha` and `line.is_some()`, build a `LineRange` (or `SingleLine` when `start_line == line`) and return `Mapped`.
+3. **Different commit, same path.** If the file exists at `head_sha` and the snippet at `original_line..original_line+span` *as it appeared on `original_commit_id`* is found exactly once at a new position in `head_sha`, anchor to that position. Return `Mapped`.
+4. **Not found / multiple matches.** Return `(None, LineMoved)` (single absence) or `(None, Ambiguous)` (multiple matches). Both go to the unmapped section.
+5. **File missing.** Return `(None, FileMissing)`.
+
+The snippet comparison uses byte-identity on the original lines fetched via `GhClient::get_file_content(original_commit_id, path)`. Rename detection is out of scope for v1 — a renamed file falls through as `FileMissing`. We accept this as a known limitation and add a follow-up issue.
+
+`file_resolver` is a trait so the mapping function stays IO-free in unit tests:
+
+```rust
+#[async_trait]
+pub trait FileResolver: Send + Sync {
+    async fn read(&self, sha: &str, path: &str) -> AppResult<String>;
+}
+```
+
+Production impl delegates to `GitClient::show` with a `GhClient::get_file_content` fallback (same pattern as Phase 5 file loading).
+
+### Cache (#33)
+
+```sql
+-- migrations/0004_remote_threads_cache.sql
+CREATE TABLE IF NOT EXISTS remote_threads_cache (
+    repo_path TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    refreshed_at_ms INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    PRIMARY KEY (repo_path, pr_number)
+);
+```
+
+- One row per (repo, pr). `head_sha` is stored alongside `refreshed_at_ms` so the UI can warn when the cache predates the current head.
+- `payload_json` holds the serialized `Vec<RemoteThread>` (including unmapped ones). We deliberately do not normalize threads into a relational schema — they are read-mostly, written atomically per refresh, and never queried by field.
+- Invalidation:
+  - `refresh_remote_comments` always hits the network and overwrites the row.
+  - The frontend invalidates the React Query key `["remote-threads", repoPath, prNumber]` on PR change and refresh-button click (same as Phase 2 caches).
+  - No timer, no polling.
+
+### Mutations (#32)
+
+`GhClient` gets six new methods (all via `gh api`, the project's standard for hitting GitHub):
+
+| Method | Endpoint | Notes |
+|---|---|---|
+| `list_review_threads(repo, pr)` | GraphQL `repository.pullRequest.reviewThreads(first: 100)` | One round-trip brings threads + comments + `viewerCan*` + `isResolved` + `isOutdated`. Truncation past 100 threads is logged and surfaced via a banner; pagination is a follow-up. |
+| `reply_review_comment(repo, pr, in_reply_to_rest_id, body)` | REST `POST /repos/{o}/{r}/pulls/{pr}/comments` with `in_reply_to` | REST endpoint; GraphQL has no reply mutation that takes only an id. |
+| `edit_review_comment(repo, comment_rest_id, body)` | REST `PATCH /repos/{o}/{r}/pulls/comments/{id}` | |
+| `delete_review_comment(repo, comment_rest_id)` | REST `DELETE /repos/{o}/{r}/pulls/comments/{id}` | 204 on success. |
+| `resolve_review_thread(thread_node_id)` | GraphQL `resolveReviewThread` mutation | Thread node id, not comment id. |
+| `unresolve_review_thread(thread_node_id)` | GraphQL `unresolveReviewThread` mutation | |
+
+Error mapping:
+- HTTP `403` / GraphQL `viewerCannotUpdate` → `AppError::Validation { message: "read-only on GitHub" }` — UI hides the action.
+- HTTP `404` after we successfully fetched the thread → `AppError::Validation { message: "thread no longer exists upstream" }` — UI shows a banner and prompts a refresh.
+- Network/process errors flow through the existing `AppError::Process` channel.
+
+Mutations return the *updated* `RemoteComment` or `RemoteThread` whenever possible so the frontend can update React Query cache without a full refresh. Resolve/unresolve fetch the single thread back via GraphQL after mutation. Delete returns `null`.
+
+### IPC contract
+
+Seven new commands added to `crates/ipc/src/commands/sync.rs`:
+
+```ts
+// shared/ipc/contract.ts additions
+refresh_remote_comments: {
+  args: { repoPath: string; prNumber: number; headSha: string };
+  result: RefreshResult;
+};
+get_cached_remote_threads: {
+  args: { repoPath: string; prNumber: number };
+  result: RefreshResult | null;
+};
+reply_remote_thread: {
+  args: { repoPath: string; prNumber: number; inReplyToCommentId: number; body: string };
+  result: RemoteComment;
+};
+edit_remote_comment: {
+  args: { repoPath: string; commentId: number; body: string };
+  result: RemoteComment;
+};
+delete_remote_comment: {
+  args: { repoPath: string; commentId: number };
+  result: null;
+};
+resolve_remote_thread: {
+  args: { repoPath: string; threadId: string };
+  result: RemoteThread;
+};
+reopen_remote_thread: {
+  args: { repoPath: string; threadId: string };
+  result: RemoteThread;
+};
+```
+
+`headSha` is passed into `refresh_remote_comments` so the backend can map without a separate query — the frontend already has it from `load_pull_request`.
+
+### Frontend integration
+
+**`src/features/sync/` (was placeholder).** Becomes a real feature:
+
+- `hooks/useRemoteThreads.ts` — React Query that reads from `get_cached_remote_threads` on mount, then surfaces a `refresh()` that calls `refresh_remote_comments`. Query key: `["remote-threads", repoPath, prNumber]`.
+- `hooks/useReplyRemoteThread.ts`, `useEditRemoteComment.ts`, `useDeleteRemoteComment.ts`, `useResolveRemoteThread.ts`, `useReopenRemoteThread.ts` — mutations that optimistically patch the cached payload.
+- `components/RemoteThreadCard.tsx` — extends the existing `ThreadCard` props with `RemoteThread`-specific affordances (avatar, GitHub badge, action menu). Lives in sync to keep the comments feature free of remote-state concerns.
+- `components/RemoteReplyComposer.tsx` — single-line composer scoped to a thread; reuses `CommentComposer` primitives where possible.
+- `components/UnmappedThreadsSection.tsx` — collapsible section rendered at the bottom of `ThreadsPane` with each unmapped thread (author, path:line snippet, "Open on GitHub" link, mapping reason).
+- `lib/mergeLocalAndRemote.ts` — merges `ReviewComment[]` and `RemoteThread[]` into a stable ordered list keyed by `(filePath, startLine)`. Dedupes: any local comment whose `githubId` matches a `RemoteComment.commentId` is dropped — the remote thread carries the richer data (replies, `viewerCan*`, resolved state).
+
+**`features/main/components/ThreadsPane.tsx`** — extended to consume the merged stream and to render the unmapped section. The pane keeps its existing roving-tabindex tree.
+
+**`RefreshButton`** — adds `"remote-threads"` to the default invalidation keys so the one refresh button covers Phase 6 too.
+
+**No raw strings.** Every new label goes through `i18next` under the `sync.*` namespace (`sync.thread.replyPlaceholder`, `sync.actions.resolve`, `sync.unmapped.heading`, `sync.unmapped.reason.fileMissing`, etc.). Error mapping additions go through `errors.*`.
+
+---
+
+## Data flow
+
+```
+[user opens PR]
+        │
+        ▼
+  hydrate cache  ──►  get_cached_remote_threads  ──►  threads pane shows last-known state
+        │
+        ▼
+[user clicks refresh]
+        │
+        ▼
+  refresh_remote_comments  ──►  GhCli.list_review_threads (GraphQL)
+        │                              │
+        │                              ▼
+        │                       fetch each thread's anchor file at original_commit_id
+        │                       (cached per (sha, path) inside the call)
+        │                              │
+        │                              ▼
+        │                       map_anchor  ──►  (anchor?, mapping_status)
+        │                              │
+        │                              ▼
+        │                       partition into mapped / unmapped
+        │
+        ▼
+  write remote_threads_cache row  ──►  return RefreshResult
+        │
+        ▼
+  React Query patches ["remote-threads", repo, pr]  ──►  pane re-renders
+
+[user replies / edits / deletes / resolves / reopens]
+        │
+        ▼
+  command → GhCli mutation → updated RemoteThread/RemoteComment → optimistic cache patch
+```
+
+---
+
+## Error handling
+
+| Scenario | Where | Behavior |
+|---|---|---|
+| `gh` missing / unauthenticated | All sync commands | Existing `MissingTool` / `GhNotAuthenticated` errors — UI already maps these. |
+| Network failure during refresh | `refresh_remote_comments` | `AppError::Process`; UI keeps cached state and shows an inline "refresh failed" banner. |
+| Anchor file missing at `original_commit_id` | mapping | Thread goes to unmapped with `FileMissing`. No error to the caller. |
+| Mutation denied by viewer permissions | mutation commands | `AppError::Validation` mapped to UI tooltip ("Only the comment author can edit"). |
+| Mutation succeeds but refetch fails | resolve/unresolve | Return cached thread with state toggled locally; mark `stale = true` so the next refresh corrects it. |
+| Stale cache (head_sha differs from current head) | hydration | Cache is rendered with a small "data is from commit XYZ" tag; refresh button is highlighted. |
+| Concurrent refresh from two windows | cache | Last write wins. No locking. We accept this. |
+
+---
+
+## Security / hardening
+
+- All `gh` invocations stay inside `infra::process` with token redaction; bodies are user content and are *not* redacted (we never log user comment bodies).
+- GraphQL queries are static `&str`; user data only flows through variables, never string-concatenated into the query.
+- HTML in comment bodies is sanitized at render-time using the existing Phase 5 allowlist sanitizer.
+- No new file-system permissions or shell capabilities. Tauri `capabilities/default.json` only gets the seven new command names appended.
+
+---
+
+## Testing
+
+- `crates/core/tests/sync_mapping.rs` — exhaustive `map_anchor` cases with in-memory `FileResolver`: outdated, exact commit match, snippet found once at new position, snippet found multiple times, snippet not found, file missing.
+- `crates/core/tests/sync_refresh.rs` — end-to-end `refresh::run` with fake `GhClient` + fake `RemoteThreadsStore`: confirms partitioning into mapped/unmapped, cache write, deterministic ordering.
+- `crates/core/tests/sync_mutations.rs` — each mutation use case verified against a fake `GhClient` (success, viewer-denied, 404 paths).
+- `crates/infra/tests/gh_review_threads.rs` (`#[ignore]`) — parses recorded JSON fixtures (`threads-multi-line.json`, `threads-outdated.json`, `threads-resolved.json`) to guarantee the deserializer survives real shapes.
+- Frontend: `bun test` for `mergeLocalAndRemote.ts` (ordering, dedupe by `(filePath, startLine)`). React Query hooks are not unit-tested; manual smoke is part of the verification checklist.
+
+---
+
+## Verification checklist (manual)
+
+To be run after the branch is green on automated tests and before merge:
+
+- [ ] Open a PR with at least one open thread, one resolved thread, and one outdated thread → refresh → all three appear in the right buckets.
+- [ ] Map a thread to a single-line anchor; map a thread to a multi-line range — both render in the threads pane.
+- [ ] Force an unmapped thread (rename the file locally) → it appears in the "Unmapped threads" section with the right reason.
+- [ ] Reply to a remote thread → reply appears immediately, persists after refresh.
+- [ ] Edit your own remote comment → body updates in place; edit button is hidden on someone else's comment.
+- [ ] Delete your own remote comment → comment disappears; thread is removed if it was the only comment.
+- [ ] Resolve a thread → state badge flips to `resolved`; reopen flips it back.
+- [ ] Quit app, reopen the same PR → threads pane shows the cached state before clicking refresh.
+- [ ] Switch PR, then come back → cache for the original PR is still there; no extra network call.
+- [ ] Smoke i18n: every string visible during the above flows lives in `en.json` (no raw English in JSX).
+
+---
+
+## Out of scope (followups to file as issues)
+
+- Rename detection during anchor mapping (`git diff --follow`).
+- Editing or deleting one's own draft *and* the submitted GitHub copy in a single action.
+- Hide-from-view for resolved remote threads (currently rendered with a `resolved` badge but still visible).
+- Background refresh.
+- GraphQL pagination beyond the first 100 threads — we cap at 100 and log when truncated. A follow-up will paginate via cursors when needed.
+
+---
+
+## Execution order (one branch, granular commits)
+
+1. **Foundation.** Domain types, errors, contract.ts additions, migration `0004_remote_threads_cache.sql`, port traits, empty use-case modules, IPC command stubs returning `unimplemented!()`. Commit: `feat(phase-6): scaffold remote-thread domain + IPC surface`.
+2. **#31 + #34 backend.** Implement `GhClient::list_review_threads`, `map_anchor`, `application::sync::refresh::run`. Wire `refresh_remote_comments` + `get_cached_remote_threads`. Commit: `feat(phase-6 #31 #34): refresh + anchor mapping with unmapped classification`.
+3. **#33 backend.** `SqliteRemoteThreadsStore`, hydration query, cache invalidation in refresh. Commit: `feat(phase-6 #33): per-PR cache with explicit invalidation`.
+4. **#32 backend.** Mutation methods on `GhClient` + use cases + IPC commands. Commit: `feat(phase-6 #32): reply/edit/delete/resolve remote threads`.
+5. **Frontend foundation.** Hooks, merge helper, `sync.*` i18n keys. Commit: `feat(phase-6): sync feature hooks and merge helper`.
+6. **Frontend UI.** `RemoteThreadCard`, `RemoteReplyComposer`, `UnmappedThreadsSection`, `ThreadsPane` integration, `RefreshButton` extension. Commit: `feat(phase-6 #31 #32 #34): integrate remote threads into ThreadsPane`.
+7. **Verification.** `cargo fmt`, `cargo clippy -D warnings`, `cargo test --workspace`, `bun run check`, `bun run typecheck`, `bun run build:web`, manual smoke. Commit fixes as needed; final commit `chore(phase-6): verification fixes`.
+8. Open PR titled `feat(phase-6): GitHub sync — refresh, mutations, cache, unmapped` referencing all four issues.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-reviewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/src/bootstrap.rs
+++ b/src-tauri/src/bootstrap.rs
@@ -4,10 +4,11 @@ use markdown_reviewer_core::application::comments::Comments;
 use markdown_reviewer_core::application::files::Files;
 use markdown_reviewer_core::application::pull_requests::PullRequests;
 use markdown_reviewer_core::application::repo_selection::RepoSelection;
+use markdown_reviewer_core::application::sync::Sync;
 use markdown_reviewer_infra::{
     logging,
-    sqlite::{open_and_migrate, SqliteCommentsStore, SqliteRecentsStore},
-    GhCli, GitCli, Paths, SystemClock,
+    sqlite::{open_and_migrate, SqliteCommentsStore, SqliteRecentsStore, SqliteRemoteThreadsStore},
+    GhCli, GitCli, GitWithGhFallback, Paths, SystemClock,
 };
 use markdown_reviewer_ipc::AppState;
 use tauri::Manager;
@@ -42,6 +43,11 @@ pub(crate) fn run() {
             let gh = Arc::new(GhCli);
             let clock = Arc::new(SystemClock);
             let comments_store = Arc::new(SqliteCommentsStore::new(db.clone()));
+            let remote_store = Arc::new(SqliteRemoteThreadsStore::new(db.clone()));
+            let file_resolver = Arc::new(GitWithGhFallback {
+                git: git.clone(),
+                gh: gh.clone(),
+            });
             let state = AppState {
                 repo_selection: RepoSelection {
                     git: git.clone(),
@@ -59,8 +65,14 @@ pub(crate) fn run() {
                 },
                 comments: Comments {
                     store: comments_store,
-                    clock,
+                    clock: clock.clone(),
                     gh: gh.clone(),
+                },
+                sync: Sync {
+                    gh: gh.clone(),
+                    store: remote_store,
+                    files: file_resolver,
+                    clock,
                 },
             };
             app.manage(state);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markdown Reviewer",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "com.weqora.markdown-reviewer",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,4 +1,9 @@
-import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
+import type {
+  CommentAnchor,
+  CommentState,
+  RemoteComment,
+  ReviewComment,
+} from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
 import { Textarea } from "@/shared/ui/textarea";
@@ -29,6 +34,13 @@ interface InlineThreadCardProps {
   onDelete?: (comment: ReviewComment) => void;
   /** Click on the count badge — opens the stacked view in the threads panel. */
   onShowStack?: (head: ReviewComment) => void;
+  /**
+   * Remote-only replies that belong to the same GitHub thread as the head
+   * comment (matched via `head.githubId`). Rendered after the local comment
+   * list so the inline conversation mirrors what shows up in the right-rail
+   * GitHub-threads card.
+   */
+  remoteReplies?: RemoteComment[];
 }
 
 function isRange(anchor: CommentAnchor): boolean {
@@ -107,6 +119,7 @@ export function InlineThreadCard({
   replyPending = false,
   onDelete,
   onShowStack,
+  remoteReplies,
 }: InlineThreadCardProps) {
   const { t } = useTranslation();
   const ghUser = useGhUser();
@@ -118,6 +131,14 @@ export function InlineThreadCard({
   if (!head) return null;
   const isResolved = head.state === "resolved";
   const isHidden = head.state === "hidden";
+  // Drop any remote reply that is already represented by a local row — we
+  // mirror Phase 6's pane-side dedupe (githubId ↔ commentId) so a reply the
+  // user just made via this card doesn't render twice.
+  const localGithubIds = new Set<number>();
+  for (const c of comments) {
+    if (c.githubId !== null) localGithubIds.add(c.githubId);
+  }
+  const replies = (remoteReplies ?? []).filter((r) => !localGithubIds.has(r.commentId));
   // Reply is meaningful only when there's a real GitHub thread to attach the
   // reply to. Drafts don't qualify yet — they'll get a remote thread on the
   // next "Finish review".
@@ -227,6 +248,22 @@ export function InlineThreadCard({
                 <Trash2Icon className="h-3.5 w-3.5" aria-hidden="true" />
               </button>
             ) : null}
+          </div>
+        </div>
+      ))}
+
+      {replies.map((r) => (
+        <div
+          key={`remote-${r.commentId}`}
+          className="mt-1 border-[hsl(var(--border))] border-t px-1 pt-2 text-[12px] leading-snug text-[hsl(var(--foreground))]/85"
+        >
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">
+              <p className="mb-1 text-[11px] font-semibold text-[hsl(var(--foreground))]">
+                {r.author}
+              </p>
+              <p className="whitespace-pre-wrap">{r.body}</p>
+            </div>
           </div>
         </div>
       ))}

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -1,7 +1,9 @@
 import type { CommentAnchor, CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
 import { Button } from "@/shared/ui/button";
+import { Textarea } from "@/shared/ui/textarea";
 import { CheckIcon, EyeIcon, MessageSquareIcon, RotateCcwIcon, Trash2Icon } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useGhUser } from "../hooks/useGhUser";
 
@@ -14,7 +16,16 @@ interface InlineThreadCardProps {
   onHide?: (comment: ReviewComment) => void;
   /** Restores a hidden comment back to `submitted`/`draft` via the parent. */
   onUnhide?: (comment: ReviewComment) => void;
-  onReply?: (head: ReviewComment) => void;
+  /**
+   * Posts a reply to the remote thread that owns `head`. When omitted (or
+   * when `head` has no `githubId`), the Reply button is hidden — drafts
+   * don't have a remote thread yet, and replying without a sync handler
+   * would just create another local-only draft with no anchor to the
+   * conversation.
+   */
+  onReplySubmit?: (head: ReviewComment, body: string) => Promise<void> | void;
+  /** Disables the reply composer while the parent's mutation is in flight. */
+  replyPending?: boolean;
   onDelete?: (comment: ReviewComment) => void;
   /** Click on the count badge — opens the stacked view in the threads panel. */
   onShowStack?: (head: ReviewComment) => void;
@@ -92,7 +103,8 @@ export function InlineThreadCard({
   onReopen,
   onHide,
   onUnhide,
-  onReply,
+  onReplySubmit,
+  replyPending = false,
   onDelete,
   onShowStack,
 }: InlineThreadCardProps) {
@@ -101,9 +113,15 @@ export function InlineThreadCard({
   const currentUser = ghUser.data ?? null;
   const isOwn = (c: ReviewComment) => Boolean(currentUser && c.author === currentUser);
   const head = comments[0];
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [replyBody, setReplyBody] = useState("");
   if (!head) return null;
   const isResolved = head.state === "resolved";
   const isHidden = head.state === "hidden";
+  // Reply is meaningful only when there's a real GitHub thread to attach the
+  // reply to. Drafts don't qualify yet — they'll get a remote thread on the
+  // next "Finish review".
+  const canReply = Boolean(onReplySubmit) && head.githubId !== null && !isHidden;
   const range = isRange(head.anchor);
   const avatarBgVar = range ? "--comment-avatar-range-bg" : "--comment-avatar-bg";
   const cardBorderClass = range
@@ -214,13 +232,20 @@ export function InlineThreadCard({
       ))}
 
       <div className="flex items-center justify-between gap-2 pt-1">
-        <button
-          type="button"
-          onClick={() => onReply?.(head)}
-          className="text-[12px] text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
-        >
-          {t("comments.thread.reply")}
-        </button>
+        {canReply ? (
+          <button
+            type="button"
+            onClick={() => {
+              setReplyOpen((v) => !v);
+              if (replyOpen) setReplyBody("");
+            }}
+            className="text-[12px] text-[hsl(var(--muted-foreground))] hover:text-[hsl(var(--foreground))]"
+          >
+            {replyOpen ? t("sync.actions.cancel") : t("comments.thread.reply")}
+          </button>
+        ) : (
+          <span />
+        )}
         <div className="flex items-center gap-2">
           {isResolved ? (
             <Button
@@ -278,6 +303,46 @@ export function InlineThreadCard({
           )}
         </div>
       </div>
+
+      {replyOpen && canReply ? (
+        <form
+          className="flex flex-col gap-2 border-t border-[hsl(var(--border))] pt-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const trimmed = replyBody.trim();
+            if (!trimmed) return;
+            const result = onReplySubmit?.(head, trimmed);
+            const close = () => {
+              setReplyBody("");
+              setReplyOpen(false);
+            };
+            if (result && typeof (result as Promise<unknown>).then === "function") {
+              (result as Promise<unknown>).then(close).catch(() => {
+                /* error surfaced upstream; keep composer open so user can retry */
+              });
+            } else {
+              close();
+            }
+          }}
+        >
+          <Textarea
+            value={replyBody}
+            onChange={(e) => setReplyBody(e.target.value)}
+            placeholder={t("sync.thread.replyPlaceholder")}
+            rows={2}
+            disabled={replyPending}
+          />
+          <div className="flex justify-end">
+            <Button
+              type="submit"
+              size="sm"
+              disabled={replyPending || replyBody.trim().length === 0}
+            >
+              {t("sync.actions.send")}
+            </Button>
+          </div>
+        </form>
+      ) : null}
     </div>
   );
 }

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -18,6 +18,7 @@ import { type FilterableState, useThreadsFilter } from "@/shared/stores/useThrea
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import {
   type CommentGroup,
   anchorEndLine,
@@ -81,6 +82,7 @@ export function InlineThreads({
   composerAnchor,
   onComposerClose,
 }: InlineThreadsProps) {
+  const { t } = useTranslation();
   const select = useSelectedThread((s) => s.select);
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
   // `useMinimizedThreads` still drives the multi-comment "expand stack" badge
@@ -135,10 +137,10 @@ export function InlineThreads({
   const replyOnRemoteThread = useMutation({
     mutationFn: async ({ head, body }: { head: ReviewComment; body: string }) => {
       if (head.githubId === null) {
-        throw new Error("Cannot reply to a draft on GitHub — submit the review first.");
+        throw new Error(t("sync.errors.replyDraftBlocked"));
       }
       if (!repoPath || prNumber === undefined) {
-        throw new Error("Missing repo context for reply.");
+        throw new Error(t("sync.errors.missingRepoContext"));
       }
       let cache = queryClient.getQueryData<RefreshResult | null>(
         remoteThreadsKey(repoPath, prNumber),
@@ -150,9 +152,7 @@ export function InlineThreads({
         cache = refreshed;
       }
       if (!thread) {
-        throw new Error(
-          "Couldn't find the GitHub thread for this comment. Try clicking Refresh and try again.",
-        );
+        throw new Error(t("sync.errors.threadNotFoundOnReply"));
       }
       const lastTarget = thread.comments.at(-1)?.commentId ?? head.githubId;
       const result = await ipc.sync.reply(repoPath, prNumber, lastTarget, body);
@@ -199,11 +199,7 @@ export function InlineThreads({
           cache = refreshed;
         }
         if (!thread) {
-          showMutationError(
-            new Error(
-              "Couldn't find the GitHub thread for this comment. Try clicking Refresh and resolve again.",
-            ),
-          );
+          showMutationError(new Error(t("sync.errors.threadNotFoundOnResolve")));
           return;
         }
         const result =
@@ -229,7 +225,7 @@ export function InlineThreads({
         showMutationError(err);
       }
     },
-    [queryClient, remote, repoPath, prNumber],
+    [queryClient, remote, repoPath, prNumber, t],
   );
 
   // Lookup table from a comment's `github_id` to the remote thread's comment

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -10,8 +10,10 @@ import type {
   CommentUpdate,
   RefreshResult,
   RemoteComment,
+  RemoteThread,
   ReviewComment,
 } from "@/shared/ipc/contract";
+import { describeError, isAppError } from "@/shared/ipc/errors";
 import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { type FilterableState, useThreadsFilter } from "@/shared/stores/useThreadsFilter";
@@ -198,26 +200,42 @@ export function InlineThreads({
           thread = findThreadByCommentId(refreshed, comment.githubId);
           cache = refreshed;
         }
+        const localState = next === "resolved" ? "resolved" : "submitted";
         if (!thread) {
-          showMutationError(new Error(t("sync.errors.threadNotFoundOnResolve")));
+          showMutationError(
+            new Error(
+              `${t("sync.errors.threadNotFoundOnResolve")}\n\n${t("sync.errors.localOnlyHint", { state: localState })}`,
+            ),
+          );
           return;
         }
         const result =
           next === "resolved"
             ? await ipc.sync.resolve(repoPath, thread.threadId)
             : await ipc.sync.reopen(repoPath, thread.threadId);
-        if (!result.ok) throw result.error;
-        // Patch the cached remote thread so the right-pane GitHub-threads
-        // card reflects the new state without a second round-trip.
+        if (!result.ok) {
+          // Surface the local/remote divergence explicitly. `update.mutate`
+          // already flipped the inline card's badge, so a plain "failed"
+          // alert without context would confuse the user.
+          const description = isAppError(result.error)
+            ? describeError(result.error).description
+            : String(result.error);
+          throw new Error(
+            `${description}\n\n${t("sync.errors.localOnlyHint", { state: localState })}`,
+          );
+        }
+        // Patch the cached remote thread (in either bucket) so the right-pane
+        // GitHub-threads card reflects the new state without a second round-trip.
         queryClient.setQueryData<RefreshResult | null>(
           remoteThreadsKey(repoPath, prNumber),
           (prev) => {
             if (!prev) return prev;
+            const replace = (t2: RemoteThread) =>
+              t2.threadId === result.value.threadId ? result.value : t2;
             return {
               ...prev,
-              threads: prev.threads.map((t) =>
-                t.threadId === result.value.threadId ? result.value : t,
-              ),
+              threads: prev.threads.map(replace),
+              unmapped: prev.unmapped.map(replace),
             };
           },
         );

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -1,5 +1,16 @@
+import {
+  findThreadByCommentId,
+  remoteThreadsKey,
+  showMutationError,
+  useRemoteThreads,
+} from "@/features/sync";
 import { ipc } from "@/shared/ipc/client";
-import type { CommentAnchor, CommentUpdate, ReviewComment } from "@/shared/ipc/contract";
+import type {
+  CommentAnchor,
+  CommentUpdate,
+  RefreshResult,
+  ReviewComment,
+} from "@/shared/ipc/contract";
 import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
 import { useSelectedThread } from "@/shared/stores/useSelectedThread";
 import { type FilterableState, useThreadsFilter } from "@/shared/stores/useThreadsFilter";
@@ -20,6 +31,11 @@ import { RangeHeaderChip } from "./RangeHeaderChip";
 import { ResolvedThreadMarker } from "./ResolvedThreadMarker";
 
 interface InlineThreadsProps {
+  /**
+   * Absolute repo path — only required for syncing resolve / reopen with
+   * GitHub on `submitted` comments. When absent, those actions stay local.
+   */
+  repoPath?: string;
   prNumber: number;
   filePath: string;
   headSha: string;
@@ -55,6 +71,7 @@ interface SlotMap {
  * content down — matching the design's "Comment under the line" layout.
  */
 export function InlineThreads({
+  repoPath,
   prNumber,
   filePath,
   headSha,
@@ -97,6 +114,66 @@ export function InlineThreads({
       queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber, filePath] });
     },
   });
+
+  // Mounted with the same key as `AppHeader`/`ThreadsPane`, so React Query
+  // dedupes and we read whatever the most recent refresh stored. `refresh()`
+  // is only called as a fallback when a submitted comment has no remote twin
+  // in cache yet (e.g. the user just clicked "Finish review" and the cache
+  // hasn't been warmed since).
+  const remote = useRemoteThreads({ repoPath, prNumber, headSha });
+
+  // When the user resolves or reopens a `submitted` comment from the inline
+  // card, propagate the action to GitHub. The local state is always written
+  // first (the existing `update.mutate` call) so the UI feedback is instant;
+  // any GitHub failure surfaces via `showMutationError` without rolling the
+  // local state back — the next refresh will reconcile.
+  const syncStateToRemote = useCallback(
+    async (comment: ReviewComment, next: "resolved" | "reopen") => {
+      if (comment.githubId === null) return;
+      if (!repoPath || prNumber === undefined) return;
+      try {
+        let cache = queryClient.getQueryData<RefreshResult | null>(
+          remoteThreadsKey(repoPath, prNumber),
+        );
+        let thread = findThreadByCommentId(cache ?? null, comment.githubId);
+        if (!thread) {
+          const refreshed = await remote.refresh();
+          thread = findThreadByCommentId(refreshed, comment.githubId);
+          cache = refreshed;
+        }
+        if (!thread) {
+          showMutationError(
+            new Error(
+              "Couldn't find the GitHub thread for this comment. Try clicking Refresh and resolve again.",
+            ),
+          );
+          return;
+        }
+        const result =
+          next === "resolved"
+            ? await ipc.sync.resolve(repoPath, thread.threadId)
+            : await ipc.sync.reopen(repoPath, thread.threadId);
+        if (!result.ok) throw result.error;
+        // Patch the cached remote thread so the right-pane GitHub-threads
+        // card reflects the new state without a second round-trip.
+        queryClient.setQueryData<RefreshResult | null>(
+          remoteThreadsKey(repoPath, prNumber),
+          (prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              threads: prev.threads.map((t) =>
+                t.threadId === result.value.threadId ? result.value : t,
+              ),
+            };
+          },
+        );
+      } catch (err) {
+        showMutationError(err);
+      }
+    },
+    [queryClient, remote, repoPath, prNumber],
+  );
 
   // Memoize groups directly from `comments` — the previous fingerprint missed
   // anchor end-line / kind changes, which left portals pointing at stale
@@ -408,10 +485,12 @@ export function InlineThreads({
                   onResolve={(c) => {
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: "resolved" } });
+                    void syncStateToRemote(c, "resolved");
                   }}
                   onReopen={(c) => {
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: "submitted" } });
+                    void syncStateToRemote(c, "reopen");
                   }}
                   // `Hide` persists `state = hidden` via IPC so the choice survives
                   // restart and a remote refresh. The session-only `minimize` store

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -127,6 +127,62 @@ export function InlineThreads({
   // first (the existing `update.mutate` call) so the UI feedback is instant;
   // any GitHub failure surfaces via `showMutationError` without rolling the
   // local state back — the next refresh will reconcile.
+  // Reply on a `submitted` inline card posts to the matching GitHub thread.
+  // Same lookup pattern as `syncStateToRemote`: prefer cache, refresh if
+  // the thread isn't loaded yet. The result is appended to the cached
+  // thread so the reply shows up immediately in the right-pane card too.
+  const replyOnRemoteThread = useMutation({
+    mutationFn: async ({ head, body }: { head: ReviewComment; body: string }) => {
+      if (head.githubId === null) {
+        throw new Error("Cannot reply to a draft on GitHub — submit the review first.");
+      }
+      if (!repoPath || prNumber === undefined) {
+        throw new Error("Missing repo context for reply.");
+      }
+      let cache = queryClient.getQueryData<RefreshResult | null>(
+        remoteThreadsKey(repoPath, prNumber),
+      );
+      let thread = findThreadByCommentId(cache ?? null, head.githubId);
+      if (!thread) {
+        const refreshed = await remote.refresh();
+        thread = findThreadByCommentId(refreshed, head.githubId);
+        cache = refreshed;
+      }
+      if (!thread) {
+        throw new Error(
+          "Couldn't find the GitHub thread for this comment. Try clicking Refresh and try again.",
+        );
+      }
+      const lastTarget = thread.comments.at(-1)?.commentId ?? head.githubId;
+      const result = await ipc.sync.reply(repoPath, prNumber, lastTarget, body);
+      if (!result.ok) throw result.error;
+      return { threadId: thread.threadId, added: result.value };
+    },
+    onSuccess: ({ threadId, added }) => {
+      if (!repoPath || prNumber === undefined) return;
+      queryClient.setQueryData<RefreshResult | null>(
+        remoteThreadsKey(repoPath, prNumber),
+        (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            threads: prev.threads.map((t) =>
+              t.threadId === threadId ? { ...t, comments: [...t.comments, added] } : t,
+            ),
+          };
+        },
+      );
+    },
+    onError: showMutationError,
+  });
+
+  const handleReplySubmit = useCallback(
+    async (head: ReviewComment, body: string) => {
+      await replyOnRemoteThread.mutateAsync({ head, body });
+    },
+    [replyOnRemoteThread],
+  );
+
   const syncStateToRemote = useCallback(
     async (comment: ReviewComment, next: "resolved" | "reopen") => {
       if (comment.githubId === null) return;
@@ -504,7 +560,8 @@ export function InlineThreads({
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
                   }}
-                  onReply={(c) => select(c.id)}
+                  onReplySubmit={handleReplySubmit}
+                  replyPending={replyOnRemoteThread.isPending}
                   onDelete={(c) => remove.mutate(c.id)}
                   onShowStack={(c) => {
                     const target = pickPaneVisibleComment(group.comments, paneFilter, c);

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -9,6 +9,7 @@ import type {
   CommentAnchor,
   CommentUpdate,
   RefreshResult,
+  RemoteComment,
   ReviewComment,
 } from "@/shared/ipc/contract";
 import { minimizedKey, useMinimizedThreads } from "@/shared/stores/useMinimizedThreads";
@@ -230,6 +231,22 @@ export function InlineThreads({
     },
     [queryClient, remote, repoPath, prNumber],
   );
+
+  // Lookup table from a comment's `github_id` to the remote thread's comment
+  // list. Lets the inline card show GitHub-originated replies inline (not
+  // just in the right-rail pane), so the user sees their reply land in the
+  // same conversation they opened the composer from.
+  const remoteRepliesByGithubId = useMemo(() => {
+    const out = new Map<number, RemoteComment[]>();
+    if (!remote.data) return out;
+    const allThreads = [...remote.data.threads, ...remote.data.unmapped];
+    for (const t of allThreads) {
+      for (const c of t.comments) {
+        out.set(c.commentId, t.comments);
+      }
+    }
+    return out;
+  }, [remote.data]);
 
   // Memoize groups directly from `comments` — the previous fingerprint missed
   // anchor end-line / kind changes, which left portals pointing at stale
@@ -538,6 +555,12 @@ export function InlineThreads({
                   key={slotKey}
                   comments={group.comments}
                   selected={isSelected}
+                  remoteReplies={
+                    group.comments[0]?.githubId !== null &&
+                    group.comments[0]?.githubId !== undefined
+                      ? remoteRepliesByGithubId.get(group.comments[0].githubId)
+                      : undefined
+                  }
                   onResolve={(c) => {
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: "resolved" } });

--- a/src/features/file-explorer/screens/PullRequestScreen/PreviewArea.tsx
+++ b/src/features/file-explorer/screens/PullRequestScreen/PreviewArea.tsx
@@ -63,6 +63,7 @@ export function PreviewArea({
     <MarkdownPreview
       source={file.data ?? ""}
       hunks={diff.data?.hunks}
+      repoPath={repoPath}
       prNumber={prNumber}
       filePath={filePath}
       headSha={sha}

--- a/src/features/main/components/AppHeader.tsx
+++ b/src/features/main/components/AppHeader.tsx
@@ -1,13 +1,13 @@
 import { usePullRequestComments } from "@/features/comments/hooks/usePullRequestComments";
+import { usePullRequestDetail } from "@/features/markdown-preview";
 import { useRepoPath } from "@/features/pull-requests/hooks/useRepoPath";
 import { useRemoteThreads } from "@/features/sync";
 import { ipc } from "@/shared/ipc/client";
-import type { AppError, PullRequestDetail } from "@/shared/ipc/contract";
-import { describeError } from "@/shared/ipc/errors";
+import { describeError, isAppError } from "@/shared/ipc/errors";
 import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { Skeleton } from "@/shared/ui/skeleton";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { CheckIcon, GitBranchIcon, Loader2Icon } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,15 +28,9 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
 
   const repoPath = useRepoPath(owner, repo).data ?? undefined;
 
-  const prDetail = useQuery<PullRequestDetail, AppError>({
-    queryKey: ["pull-request", repoPath, prNumber],
-    enabled: Boolean(repoPath && prNumber),
-    queryFn: async () => {
-      const res = await ipc.pullRequests.load(repoPath as string, prNumber as number);
-      if (!res.ok) throw res.error;
-      return res.value;
-    },
-  });
+  // Re-uses the shared hook (same query key as `usePullRequestTitle`), so
+  // we never declare the PR-detail query in two places.
+  const prDetail = usePullRequestDetail(repoPath, prNumber);
   const headSha = prDetail.data?.headSha;
 
   const remote = useRemoteThreads({ repoPath, prNumber, headSha });
@@ -76,7 +70,15 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
       }
     },
     onError: (error) => {
-      const description = describeError(error as unknown as AppError).description;
+      // `mutationFn` can throw an AppError (from IPC) or a plain Error
+      // (the "missing repoPath" guard above). Use the same isAppError
+      // discrimination as `showMutationError` so both paths render a
+      // meaningful description.
+      const description = isAppError(error)
+        ? describeError(error).description
+        : error instanceof Error
+          ? error.message
+          : String(error);
       window.alert(`${t("app.finishReview.failedTitle")}\n\n${description}`);
     },
   });

--- a/src/features/main/components/AppHeader.tsx
+++ b/src/features/main/components/AppHeader.tsx
@@ -1,6 +1,11 @@
+import { useRepoPath } from "@/features/pull-requests/hooks/useRepoPath";
+import { useRemoteThreads } from "@/features/sync";
+import { ipc } from "@/shared/ipc/client";
+import type { AppError, PullRequestDetail } from "@/shared/ipc/contract";
 import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { Skeleton } from "@/shared/ui/skeleton";
+import { useQuery } from "@tanstack/react-query";
 import { CheckIcon, GitBranchIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { usePullRequestTitle } from "../hooks/usePullRequestTitle";
@@ -17,6 +22,21 @@ interface AppHeaderProps {
 export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHeaderProps) {
   const { t } = useTranslation();
   const title = usePullRequestTitle(owner, repo, prNumber);
+
+  const repoPath = useRepoPath(owner, repo).data ?? undefined;
+
+  const prDetail = useQuery<PullRequestDetail, AppError>({
+    queryKey: ["pull-request", repoPath, prNumber],
+    enabled: Boolean(repoPath && prNumber),
+    queryFn: async () => {
+      const res = await ipc.pullRequests.load(repoPath as string, prNumber as number);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+  });
+  const headSha = prDetail.data?.headSha;
+
+  const remote = useRemoteThreads({ repoPath, prNumber, headSha });
 
   return (
     <header className="flex h-14 shrink-0 items-center gap-3 border-b border-[hsl(var(--border))] bg-[hsl(var(--card))] px-5">
@@ -39,7 +59,7 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
       ) : null}
       <div className="ml-auto flex shrink-0 items-center gap-2">
         {rightAction}
-        <RefreshButton />
+        <RefreshButton onRefresh={remote.refresh} />
         {branch ? (
           <span className="flex h-8 items-center gap-1.5 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--muted))]/40 px-2.5 text-xs">
             <GitBranchIcon className="size-3.5 text-[hsl(var(--muted-foreground))]" />

--- a/src/features/main/components/AppHeader.tsx
+++ b/src/features/main/components/AppHeader.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { Skeleton } from "@/shared/ui/skeleton";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckIcon, GitBranchIcon } from "lucide-react";
+import { CheckIcon, GitBranchIcon, Loader2Icon } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { usePullRequestTitle } from "../hooks/usePullRequestTitle";
@@ -124,7 +124,11 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
                 : t("app.finishReview.tooltip", { count: draftIds.length })
             }
           >
-            <CheckIcon className="size-3.5" />
+            {submit.isPending ? (
+              <Loader2Icon className="size-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <CheckIcon className="size-3.5" aria-hidden="true" />
+            )}
             {t("app.actions.finishReview")}
             {draftIds.length > 0 ? (
               <span className="ml-1 rounded-full bg-[hsl(var(--primary-foreground))]/20 px-1.5 text-[10px]">

--- a/src/features/main/components/AppHeader.tsx
+++ b/src/features/main/components/AppHeader.tsx
@@ -1,12 +1,15 @@
+import { usePullRequestComments } from "@/features/comments/hooks/usePullRequestComments";
 import { useRepoPath } from "@/features/pull-requests/hooks/useRepoPath";
 import { useRemoteThreads } from "@/features/sync";
 import { ipc } from "@/shared/ipc/client";
 import type { AppError, PullRequestDetail } from "@/shared/ipc/contract";
+import { describeError } from "@/shared/ipc/errors";
 import { Button } from "@/shared/ui/button";
 import { Separator } from "@/shared/ui/separator";
 import { Skeleton } from "@/shared/ui/skeleton";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckIcon, GitBranchIcon } from "lucide-react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { usePullRequestTitle } from "../hooks/usePullRequestTitle";
 import { RefreshButton } from "./RefreshButton";
@@ -38,6 +41,49 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
 
   const remote = useRemoteThreads({ repoPath, prNumber, headSha });
 
+  const comments = usePullRequestComments(prNumber);
+  const draftIds = useMemo(
+    () => (comments.data ?? []).filter((c) => c.state === "draft").map((c) => c.id),
+    [comments.data],
+  );
+
+  const queryClient = useQueryClient();
+  const submit = useMutation({
+    mutationFn: async () => {
+      if (!repoPath || prNumber === undefined) {
+        throw new Error("missing repoPath or prNumber");
+      }
+      const res = await ipc.comments.submitReview(repoPath, prNumber, draftIds);
+      if (!res.ok) throw res.error;
+      return res.value;
+    },
+    onSettled: () => {
+      if (prNumber !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      }
+    },
+    onSuccess: (result) => {
+      const submitted = result.comments.filter((c) => c.submitted).length;
+      const failed = result.comments.length - submitted;
+      const total = result.comments.length;
+      if (failed === 0) {
+        window.alert(t("app.finishReview.success", { count: submitted, total }));
+      } else if (submitted === 0) {
+        const first = result.comments.find((c) => c.error)?.error ?? "";
+        window.alert(t("app.finishReview.allFailed", { total, error: first }));
+      } else {
+        window.alert(t("app.finishReview.partial", { submitted, total, failed }));
+      }
+    },
+    onError: (error) => {
+      const description = describeError(error as unknown as AppError).description;
+      window.alert(`${t("app.finishReview.failedTitle")}\n\n${description}`);
+    },
+  });
+
+  const canFinish =
+    Boolean(repoPath) && prNumber !== undefined && draftIds.length > 0 && !submit.isPending;
+
   return (
     <header className="flex h-14 shrink-0 items-center gap-3 border-b border-[hsl(var(--border))] bg-[hsl(var(--card))] px-5">
       <div className="flex shrink-0 items-center gap-2.5">
@@ -67,9 +113,24 @@ export function AppHeader({ owner, repo, prNumber, branch, rightAction }: AppHea
           </span>
         ) : null}
         {prNumber ? (
-          <Button size="sm" className="gap-1.5">
+          <Button
+            size="sm"
+            className="gap-1.5"
+            disabled={!canFinish}
+            onClick={() => submit.mutate()}
+            title={
+              draftIds.length === 0
+                ? t("app.finishReview.noDraftsTooltip")
+                : t("app.finishReview.tooltip", { count: draftIds.length })
+            }
+          >
             <CheckIcon className="size-3.5" />
             {t("app.actions.finishReview")}
+            {draftIds.length > 0 ? (
+              <span className="ml-1 rounded-full bg-[hsl(var(--primary-foreground))]/20 px-1.5 text-[10px]">
+                {draftIds.length}
+              </span>
+            ) : null}
           </Button>
         ) : null}
       </div>

--- a/src/features/main/components/RefreshButton.tsx
+++ b/src/features/main/components/RefreshButton.tsx
@@ -12,6 +12,12 @@ interface RefreshButtonProps {
    * Phase 2 surface: PR list/detail, changed files, file content, file diff.
    */
   keys?: string[];
+  /**
+   * Optional async hook the consumer fires alongside the React Query
+   * invalidation — used by ThreadsPane to also call `useRemoteThreads.refresh`
+   * so the user sees the GitHub round-trip when they click Refresh.
+   */
+  onRefresh?: () => Promise<unknown>;
 }
 
 const DEFAULT_KEYS = [
@@ -20,9 +26,10 @@ const DEFAULT_KEYS = [
   "changed-files",
   "file-content",
   "file-diff",
+  "remote-threads",
 ];
 
-export function RefreshButton({ keys = DEFAULT_KEYS }: RefreshButtonProps) {
+export function RefreshButton({ keys = DEFAULT_KEYS, onRefresh }: RefreshButtonProps) {
   const { t } = useTranslation();
   const qc = useQueryClient();
   const [spinning, setSpinning] = useState(false);
@@ -44,7 +51,10 @@ export function RefreshButton({ keys = DEFAULT_KEYS }: RefreshButtonProps) {
     }
     setSpinning(true);
     try {
-      await Promise.all(keys.map((k) => qc.invalidateQueries({ queryKey: [k] })));
+      await Promise.all([
+        ...keys.map((k) => qc.invalidateQueries({ queryKey: [k] })),
+        onRefresh?.(),
+      ]);
     } finally {
       // Keep the spin visible briefly even if the network is fast — gives
       // the user feedback that the click registered.

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -12,6 +12,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { EyeIcon, EyeOffIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useNavigateToComment } from "../lib/navigateToComment";
 import { type FilterableState, ThreadFilterBar } from "./threads/ThreadFilterBar";
 import { ThreadList } from "./threads/ThreadList";
 
@@ -119,6 +120,7 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
   );
 
   const canHideAll = !hideAll.isPending && hideableIds.length > 0;
+  const navigateToComment = useNavigateToComment(prNumber, filePath);
 
   return (
     <aside className="flex h-full w-[336px] shrink-0 flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--muted))]">
@@ -206,6 +208,7 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
                       thread={thread}
                       repoPath={repoPath}
                       prNumber={prNumber}
+                      onNavigate={navigateToComment}
                     />
                   ))}
                 </section>

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -77,15 +77,19 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
 
   // Drop local comments whose githubId matches a remote thread comment — they
   // are already represented by the RemoteThreadCard and would be duplicates.
+  // Includes both mapped and unmapped threads: a local "submitted" comment
+  // whose remote twin lives on an unmapped thread would otherwise show twice
+  // (once in the local list, once under the Unmapped section).
   const dedupedVisible = useMemo(() => {
     const remoteCommentIds = new Set<number>();
-    for (const t of remoteThreads) {
+    const allThreads = remoteData ? [...remoteData.threads, ...remoteData.unmapped] : remoteThreads;
+    for (const t of allThreads) {
       for (const c of t.comments) {
         remoteCommentIds.add(c.commentId);
       }
     }
     return visible.filter((v) => v.githubId === null || !remoteCommentIds.has(v.githubId));
-  }, [visible, remoteThreads]);
+  }, [visible, remoteData, remoteThreads]);
 
   // "Hide all" applies to the threads currently surfaced in the pane (under
   // the active scope + filter). Comments already `hidden`, `resolved`, or

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -172,7 +172,7 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
           </Button>
         </div>
       </header>
-      <ScrollArea className="flex-1">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="px-3 pb-4 pt-1">
           {query.isError && query.error ? (
             <Alert tone="destructive">

--- a/src/features/main/components/ThreadsPane.tsx
+++ b/src/features/main/components/ThreadsPane.tsx
@@ -1,4 +1,5 @@
 import { usePullRequestComments } from "@/features/comments/hooks/usePullRequestComments";
+import { RemoteThreadCard, UnmappedThreadsSection, useRemoteThreads } from "@/features/sync";
 import { ipc } from "@/shared/ipc/client";
 import type { CommentState, ReviewComment } from "@/shared/ipc/contract";
 import { describeError } from "@/shared/ipc/errors";
@@ -35,6 +36,10 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
 
   const allComments = query.data ?? [];
 
+  // Remote threads — only enabled when we have both repoPath and prNumber.
+  const remote = useRemoteThreads({ repoPath, prNumber, headSha: sha });
+  const remoteData = remote.data;
+
   // When no file is selected, force the "all files" view so the user still sees
   // every PR-level thread instead of an empty pane.
   const effectiveScope: Scope = filePath ? scope : "allFiles";
@@ -50,6 +55,36 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
     () => partitionByFilter(scopedComments, filter),
     [scopedComments, filter],
   );
+
+  // Remote threads scoped to the current file (or all files).
+  const remoteThreads = useMemo(() => {
+    if (!remoteData) return [];
+    if (effectiveScope === "currentFile" && filePath) {
+      return remoteData.threads.filter((t) => t.path === filePath);
+    }
+    return remoteData.threads;
+  }, [remoteData, effectiveScope, filePath]);
+
+  // Unmapped threads (no line anchor found in current head), scoped similarly.
+  const unmapped = useMemo(() => {
+    if (!remoteData) return [];
+    if (effectiveScope === "currentFile" && filePath) {
+      return remoteData.unmapped.filter((t) => t.path === filePath);
+    }
+    return remoteData.unmapped;
+  }, [remoteData, effectiveScope, filePath]);
+
+  // Drop local comments whose githubId matches a remote thread comment — they
+  // are already represented by the RemoteThreadCard and would be duplicates.
+  const dedupedVisible = useMemo(() => {
+    const remoteCommentIds = new Set<number>();
+    for (const t of remoteThreads) {
+      for (const c of t.comments) {
+        remoteCommentIds.add(c.commentId);
+      }
+    }
+    return visible.filter((v) => v.githubId === null || !remoteCommentIds.has(v.githubId));
+  }, [visible, remoteThreads]);
 
   // "Hide all" applies to the threads currently surfaced in the pane (under
   // the active scope + filter). Comments already `hidden`, `resolved`, or
@@ -151,16 +186,42 @@ export function ThreadsPane({ prNumber, filePath, repoPath, sha }: ThreadsPanePr
               {t("main.threads.empty")}
             </p>
           ) : (
-            <ThreadList
-              comments={visible}
-              isLoading={query.isLoading}
-              hideFilePath={effectiveScope === "currentFile"}
-              hiddenCount={hiddenCount}
-              prNumber={prNumber}
-              currentFilePath={filePath}
-              repoPath={repoPath}
-              sha={sha}
-            />
+            <>
+              {remote.error ? (
+                <Alert tone="destructive" className="mb-2">
+                  <div className="min-w-0 flex-1">
+                    <AlertTitle>{t("sync.errors.refreshFailedTitle")}</AlertTitle>
+                    <AlertDescription>{t("sync.errors.refreshFailedDescription")}</AlertDescription>
+                  </div>
+                </Alert>
+              ) : null}
+              {repoPath && remoteThreads.length > 0 ? (
+                <section className="mb-3 flex flex-col gap-2">
+                  <h3 className="px-1 text-[11px] font-semibold uppercase tracking-wide text-[hsl(var(--muted-foreground))]">
+                    {t("sync.section.remoteHeading")}
+                  </h3>
+                  {remoteThreads.map((thread) => (
+                    <RemoteThreadCard
+                      key={thread.threadId}
+                      thread={thread}
+                      repoPath={repoPath}
+                      prNumber={prNumber}
+                    />
+                  ))}
+                </section>
+              ) : null}
+              <ThreadList
+                comments={dedupedVisible}
+                isLoading={query.isLoading}
+                hideFilePath={effectiveScope === "currentFile"}
+                hiddenCount={hiddenCount}
+                prNumber={prNumber}
+                currentFilePath={filePath}
+                repoPath={repoPath}
+                sha={sha}
+              />
+              <UnmappedThreadsSection threads={unmapped} />
+            </>
           )}
         </div>
       </ScrollArea>

--- a/src/features/main/components/threads/ThreadList.tsx
+++ b/src/features/main/components/threads/ThreadList.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from "@/shared/ui/skeleton";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { scrollToAnchorLine } from "../../lib/scrollToAnchor";
+import { useNavigateToComment } from "../../lib/navigateToComment";
 import { ThreadAnchorGroup } from "./ThreadAnchorGroup";
 import { ThreadCard, type ThreadGroup } from "./ThreadCard";
 import { ThreadFileGroup } from "./ThreadFileGroup";
@@ -61,6 +61,7 @@ export function ThreadList({
   const selectedId = useSelectedThread((s) => s.selectedCommentId);
   const select = useSelectedThread((s) => s.select);
   const queryClient = useQueryClient();
+  const navigateToComment = useNavigateToComment(prNumber, currentFilePath);
   const anchorGroups = useMemo(() => groupByAnchor(comments), [comments]);
   const fileGroups = useMemo(() => groupByFile(anchorGroups), [anchorGroups]);
 
@@ -358,9 +359,7 @@ export function ThreadList({
             const head = anchor?.comments[0];
             if (head) {
               select(head.id);
-              if (head.filePath === currentFilePath) {
-                scrollToAnchorLine(getAnchorScrollLine(head));
-              }
+              navigateToComment(head.filePath, getAnchorScrollLine(head));
             }
           }
           break;
@@ -383,7 +382,7 @@ export function ThreadList({
       hideFilePath,
       anchorGroups,
       select,
-      currentFilePath,
+      navigateToComment,
     ],
   );
 
@@ -465,9 +464,7 @@ export function ThreadList({
                 onSelect={(comment) => {
                   setActiveId(cId);
                   select(comment.id);
-                  if (comment.filePath === currentFilePath) {
-                    scrollToAnchorLine(getAnchorScrollLine(comment));
-                  }
+                  navigateToComment(comment.filePath, getAnchorScrollLine(comment));
                 }}
                 onReopen={onReopen}
               />

--- a/src/features/main/lib/navigateToComment.ts
+++ b/src/features/main/lib/navigateToComment.ts
@@ -1,0 +1,37 @@
+import { useRepoContext } from "@/features/main/hooks/useRepoContext";
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { scrollToAnchorLine } from "./scrollToAnchor";
+
+function encodeSegments(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+/**
+ * Returns a callback that focuses a comment in the preview: scrolls to its
+ * anchor line when the comment lives in the file currently rendered, or
+ * navigates to that file (with the line in the URL hash) otherwise.
+ *
+ * The hash is read by `MarkdownPreview` once the markdown finishes rendering
+ * so the user lands on the right paragraph instead of the top of the file.
+ */
+export function useNavigateToComment(
+  prNumber: number | undefined,
+  currentFilePath: string | undefined,
+) {
+  const navigate = useNavigate();
+  const { owner, repo } = useRepoContext();
+
+  return useCallback(
+    (filePath: string, line: number) => {
+      if (prNumber === undefined) return;
+      if (filePath === currentFilePath) {
+        scrollToAnchorLine(line);
+        return;
+      }
+      const url = `/repo/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${prNumber}/files/${encodeSegments(filePath)}#L${line}`;
+      navigate(url);
+    },
+    [navigate, owner, repo, prNumber, currentFilePath],
+  );
+}

--- a/src/features/markdown-preview/components/MarkdownPreview.tsx
+++ b/src/features/markdown-preview/components/MarkdownPreview.tsx
@@ -10,6 +10,7 @@ interface MarkdownPreviewProps {
   className?: string;
   hunks?: DiffHunk[];
   /** When prNumber + filePath + headSha are present, mounts the comments UI. */
+  repoPath?: string;
   prNumber?: number;
   filePath?: string;
   headSha?: string;
@@ -19,6 +20,7 @@ export function MarkdownPreview({
   source,
   className,
   hunks,
+  repoPath,
   prNumber,
   filePath,
   headSha,
@@ -42,6 +44,7 @@ export function MarkdownPreview({
       {commentsEnabled ? (
         <>
           <InlineThreads
+            repoPath={repoPath}
             prNumber={prNumber as number}
             filePath={filePath as string}
             headSha={headSha as string}

--- a/src/features/markdown-preview/components/MarkdownPreview.tsx
+++ b/src/features/markdown-preview/components/MarkdownPreview.tsx
@@ -1,7 +1,9 @@
 import { InlineThreads, SelectionCommentOverlay, useFileComments } from "@/features/comments";
+import { scrollToAnchorLine } from "@/features/main/lib/scrollToAnchor";
 import type { CommentAnchor, DiffHunk } from "@/shared/ipc/contract";
 import { cn } from "@/shared/lib/cn";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { renderMarkdown } from "../lib/pipeline";
 import { DiffGutter } from "./DiffGutter";
 
@@ -31,6 +33,22 @@ export function MarkdownPreview({
   const fileComments = useFileComments({ prNumber, filePath });
   const comments = fileComments.data ?? [];
   const [composerAnchor, setComposerAnchor] = useState<CommentAnchor | null>(null);
+
+  // When the user lands on the preview via a thread-pane click, the URL hash
+  // carries the target line (e.g. `#L42`). Scroll once the markdown finishes
+  // rendering — `requestAnimationFrame` waits for the next paint so the
+  // `[data-source-line]` nodes are mounted before we query them. We depend on
+  // `html` + `location.key` (not read) so navigating to the same URL or
+  // landing on a freshly-rendered file both trigger a re-scroll.
+  const location = useLocation();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: html and location.key are intentional re-run triggers; their values aren't read in the body.
+  useEffect(() => {
+    const match = /^#L(\d+)$/.exec(location.hash);
+    if (!match) return;
+    const line = Number(match[1]);
+    if (!Number.isFinite(line) || line <= 0) return;
+    requestAnimationFrame(() => scrollToAnchorLine(line));
+  }, [html, location.hash, location.key]);
 
   return (
     <div className="relative mx-auto w-full max-w-3xl">

--- a/src/features/sync/components/RemoteCommentBody.tsx
+++ b/src/features/sync/components/RemoteCommentBody.tsx
@@ -1,0 +1,71 @@
+import type { RemoteComment } from "@/shared/ipc/contract";
+import { Button } from "@/shared/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { PencilIcon, TrashIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  comment: RemoteComment;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export function RemoteCommentBody({ comment, onEdit, onDelete }: Props) {
+  const { t } = useTranslation();
+  return (
+    <article className="flex flex-col gap-1.5 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--card))] p-3">
+      <header className="flex items-center justify-between gap-2 text-xs">
+        <span className="flex items-center gap-2 font-medium text-[hsl(var(--foreground))]">
+          {comment.authorAvatarUrl ? (
+            <img
+              src={comment.authorAvatarUrl}
+              alt=""
+              className="size-5 rounded-full"
+              loading="lazy"
+            />
+          ) : null}
+          {t("sync.thread.byAuthor", { author: comment.author })}
+        </span>
+        {comment.viewerCanUpdate || comment.viewerCanDelete ? (
+          <div className="flex items-center gap-1">
+            {comment.viewerCanUpdate ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={onEdit}
+                    aria-label={t("sync.actions.edit")}
+                  >
+                    <PencilIcon className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("sync.actions.edit")}</TooltipContent>
+              </Tooltip>
+            ) : null}
+            {comment.viewerCanDelete ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-7"
+                    onClick={onDelete}
+                    aria-label={t("sync.actions.delete")}
+                  >
+                    <TrashIcon className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{t("sync.actions.delete")}</TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+        ) : null}
+      </header>
+      <p className="whitespace-pre-wrap text-sm text-[hsl(var(--foreground))]">{comment.body}</p>
+    </article>
+  );
+}

--- a/src/features/sync/components/RemoteCommentBody.tsx
+++ b/src/features/sync/components/RemoteCommentBody.tsx
@@ -36,7 +36,10 @@ export function RemoteCommentBody({ comment, onEdit, onDelete }: Props) {
                     variant="ghost"
                     size="icon"
                     className="size-7"
-                    onClick={onEdit}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onEdit?.();
+                    }}
                     aria-label={t("sync.actions.edit")}
                   >
                     <PencilIcon className="size-3.5" />
@@ -53,7 +56,10 @@ export function RemoteCommentBody({ comment, onEdit, onDelete }: Props) {
                     variant="ghost"
                     size="icon"
                     className="size-7"
-                    onClick={onDelete}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete?.();
+                    }}
                     aria-label={t("sync.actions.delete")}
                   >
                     <TrashIcon className="size-3.5" />

--- a/src/features/sync/components/RemoteReplyComposer.tsx
+++ b/src/features/sync/components/RemoteReplyComposer.tsx
@@ -1,0 +1,42 @@
+import { Button } from "@/shared/ui/button";
+import { Textarea } from "@/shared/ui/textarea";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  pending: boolean;
+  onSubmit: (body: string) => void;
+}
+
+export function RemoteReplyComposer({ pending, onSubmit }: Props) {
+  const { t } = useTranslation();
+  const [body, setBody] = useState("");
+  const submit = () => {
+    const trimmed = body.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setBody("");
+  };
+  return (
+    <form
+      className="flex flex-col gap-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <Textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder={t("sync.thread.replyPlaceholder")}
+        rows={2}
+        disabled={pending}
+      />
+      <div className="flex justify-end">
+        <Button type="submit" size="sm" disabled={pending || body.trim().length === 0}>
+          {t("sync.actions.send")}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/features/sync/components/RemoteReplyComposer.tsx
+++ b/src/features/sync/components/RemoteReplyComposer.tsx
@@ -13,7 +13,11 @@ export function RemoteReplyComposer({ pending, onSubmit }: Props) {
   const [body, setBody] = useState("");
   const submit = () => {
     const trimmed = body.trim();
-    if (!trimmed) return;
+    console.log("[sync-debug] reply composer submit", { bodyLen: trimmed.length, pending });
+    if (!trimmed) {
+      console.log("[sync-debug] reply: empty body, aborting");
+      return;
+    }
     onSubmit(trimmed);
     setBody("");
   };

--- a/src/features/sync/components/RemoteReplyComposer.tsx
+++ b/src/features/sync/components/RemoteReplyComposer.tsx
@@ -13,11 +13,7 @@ export function RemoteReplyComposer({ pending, onSubmit }: Props) {
   const [body, setBody] = useState("");
   const submit = () => {
     const trimmed = body.trim();
-    console.log("[sync-debug] reply composer submit", { bodyLen: trimmed.length, pending });
-    if (!trimmed) {
-      console.log("[sync-debug] reply: empty body, aborting");
-      return;
-    }
+    if (!trimmed) return;
     onSubmit(trimmed);
     setBody("");
   };

--- a/src/features/sync/components/RemoteThreadCard.tsx
+++ b/src/features/sync/components/RemoteThreadCard.tsx
@@ -1,0 +1,149 @@
+import type { RemoteThread } from "@/shared/ipc/contract";
+import { Badge } from "@/shared/ui/badge";
+import { Button } from "@/shared/ui/button";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDeleteRemoteComment } from "../hooks/useDeleteRemoteComment";
+import { useEditRemoteComment } from "../hooks/useEditRemoteComment";
+import { useReopenRemoteThread } from "../hooks/useReopenRemoteThread";
+import { useReplyRemoteThread } from "../hooks/useReplyRemoteThread";
+import { useResolveRemoteThread } from "../hooks/useResolveRemoteThread";
+import { RemoteCommentBody } from "./RemoteCommentBody";
+import { RemoteReplyComposer } from "./RemoteReplyComposer";
+
+interface Props {
+  thread: RemoteThread;
+  repoPath: string;
+  prNumber: number;
+}
+
+export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
+  const { t } = useTranslation();
+  const reply = useReplyRemoteThread();
+  const edit = useEditRemoteComment();
+  const del = useDeleteRemoteComment();
+  const resolve = useResolveRemoteThread();
+  const reopen = useReopenRemoteThread();
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editingBody, setEditingBody] = useState("");
+
+  const lastReplyTarget = thread.comments.at(-1)?.commentId ?? thread.comments[0]?.commentId;
+
+  return (
+    <section className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3">
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Badge tone={thread.state === "resolved" ? "success" : "default"}>
+            {thread.state === "resolved"
+              ? t("sync.thread.resolvedBadge")
+              : t("sync.thread.openBadge")}
+          </Badge>
+          {thread.isOutdated ? (
+            <Badge tone="warning">{t("sync.thread.outdatedBadge")}</Badge>
+          ) : null}
+        </div>
+        {thread.state === "open" && thread.viewerCanResolve ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => resolve.mutate({ repoPath, prNumber, threadId: thread.threadId })}
+            disabled={resolve.isPending}
+          >
+            {t("sync.actions.resolve")}
+          </Button>
+        ) : null}
+        {thread.state === "resolved" && thread.viewerCanUnresolve ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => reopen.mutate({ repoPath, prNumber, threadId: thread.threadId })}
+            disabled={reopen.isPending}
+          >
+            {t("sync.actions.reopen")}
+          </Button>
+        ) : null}
+      </header>
+
+      <ol className="flex flex-col gap-2">
+        {thread.comments.map((c) => (
+          <li key={c.commentId}>
+            {editingId === c.commentId ? (
+              <form
+                className="flex flex-col gap-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const trimmed = editingBody.trim();
+                  if (!trimmed) return;
+                  edit.mutate(
+                    {
+                      repoPath,
+                      prNumber,
+                      threadId: thread.threadId,
+                      commentId: c.commentId,
+                      body: trimmed,
+                    },
+                    { onSuccess: () => setEditingId(null) },
+                  );
+                }}
+              >
+                <textarea
+                  className="min-h-20 rounded border border-[hsl(var(--border))] bg-[hsl(var(--background))] p-2 text-sm"
+                  value={editingBody}
+                  onChange={(e) => setEditingBody(e.target.value)}
+                />
+                <div className="flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEditingId(null)}
+                  >
+                    {t("sync.actions.cancel")}
+                  </Button>
+                  <Button type="submit" size="sm" disabled={edit.isPending}>
+                    {t("sync.actions.save")}
+                  </Button>
+                </div>
+              </form>
+            ) : (
+              <RemoteCommentBody
+                comment={c}
+                onEdit={() => {
+                  setEditingId(c.commentId);
+                  setEditingBody(c.body);
+                }}
+                onDelete={() => {
+                  if (window.confirm(t("sync.actions.deleteConfirm"))) {
+                    del.mutate({
+                      repoPath,
+                      prNumber,
+                      threadId: thread.threadId,
+                      commentId: c.commentId,
+                    });
+                  }
+                }}
+              />
+            )}
+          </li>
+        ))}
+      </ol>
+
+      {thread.state === "open" && lastReplyTarget !== undefined ? (
+        <RemoteReplyComposer
+          pending={reply.isPending}
+          onSubmit={(body) =>
+            reply.mutate({
+              repoPath,
+              prNumber,
+              threadId: thread.threadId,
+              inReplyToCommentId: lastReplyTarget,
+              body,
+            })
+          }
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/sync/components/RemoteThreadCard.tsx
+++ b/src/features/sync/components/RemoteThreadCard.tsx
@@ -16,12 +16,17 @@ interface Props {
   repoPath: string;
   prNumber: number;
   /**
-   * When set, the file:line breadcrumb at the top of the card becomes a
-   * button that calls back with the thread's anchor — used by the threads
-   * pane to jump from the right rail into the rendered markdown.
+   * When set, the card becomes clickable as a whole — anywhere outside the
+   * action buttons (Resolve / Reply / edit / delete / composer) calls back
+   * with the thread's anchor so the right rail can jump into the rendered
+   * markdown. Buttons inside the card stop propagation so they don't
+   * also trigger navigation.
    */
   onNavigate?: (filePath: string, line: number) => void;
 }
+
+/** Stops a synthetic event from bubbling up to the card's clickable wrapper. */
+const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
 
 export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Props) {
   const { t } = useTranslation();
@@ -39,19 +44,40 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
       ? thread.anchor.line
       : (thread.anchor?.startLine ?? thread.line ?? thread.originalLine);
 
+  const navigate = onNavigate ? () => onNavigate(thread.path, anchorLine) : undefined;
+  // The whole card is wrapped in a div with onClick + role="button" so keyboard
+  // users can also fire it via Space/Enter. The action buttons inside call
+  // `stop()` on their click handlers so they don't also trigger navigation.
+  const wrapperProps = navigate
+    ? {
+        onClick: navigate,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            navigate();
+          }
+        },
+        role: "button" as const,
+        tabIndex: 0,
+        "aria-label": t("sync.actions.openInPreview", {
+          path: thread.path,
+          line: anchorLine,
+        }),
+        className:
+          "flex cursor-pointer flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3 transition-colors hover:border-[hsl(var(--foreground))]/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]",
+      }
+    : {
+        className:
+          "flex flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3",
+      };
+
   return (
-    <section className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3">
-      {onNavigate ? (
-        <button
-          type="button"
-          onClick={() => onNavigate(thread.path, anchorLine)}
-          className="flex items-baseline gap-1.5 self-start rounded px-1 py-0.5 text-left text-[11px] text-[hsl(var(--muted-foreground))] transition-colors hover:bg-[hsl(var(--accent))]/40 hover:text-[hsl(var(--foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
-        >
+    <div {...wrapperProps}>
+      <header className="flex items-center justify-between gap-2">
+        <span className="flex items-baseline gap-1.5 text-[11px] text-[hsl(var(--muted-foreground))]">
           <span className="truncate font-medium">{thread.path}</span>
           <span className="font-mono">L{anchorLine}</span>
-        </button>
-      ) : null}
-      <header className="flex items-center justify-between gap-2">
+        </span>
         <div className="flex items-center gap-2">
           <Badge tone={thread.state === "resolved" ? "success" : "default"}>
             {thread.state === "resolved"
@@ -62,16 +88,16 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
             <Badge tone="warning">{t("sync.thread.outdatedBadge")}</Badge>
           ) : null}
         </div>
+      </header>
+
+      <div className="flex items-center justify-end gap-2">
         {thread.state === "open" && thread.viewerCanResolve ? (
           <Button
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => {
-              console.log("[sync-debug] resolve click", {
-                threadId: thread.threadId,
-                viewerCanResolve: thread.viewerCanResolve,
-              });
+            onClick={(e) => {
+              stop(e);
               resolve.mutate({ repoPath, prNumber, threadId: thread.threadId });
             }}
             disabled={resolve.isPending}
@@ -84,13 +110,16 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => reopen.mutate({ repoPath, prNumber, threadId: thread.threadId })}
+            onClick={(e) => {
+              stop(e);
+              reopen.mutate({ repoPath, prNumber, threadId: thread.threadId });
+            }}
             disabled={reopen.isPending}
           >
             {t("sync.actions.reopen")}
           </Button>
         ) : null}
-      </header>
+      </div>
 
       <ol className="flex flex-col gap-2">
         {thread.comments.map((c) => (
@@ -98,8 +127,11 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
             {editingId === c.commentId ? (
               <form
                 className="flex flex-col gap-2"
+                onClick={stop}
+                onKeyDown={stop}
                 onSubmit={(e) => {
                   e.preventDefault();
+                  e.stopPropagation();
                   const trimmed = editingBody.trim();
                   if (!trimmed) return;
                   edit.mutate(
@@ -124,7 +156,10 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
                     type="button"
                     variant="ghost"
                     size="sm"
-                    onClick={() => setEditingId(null)}
+                    onClick={(e) => {
+                      stop(e);
+                      setEditingId(null);
+                    }}
                   >
                     {t("sync.actions.cancel")}
                   </Button>
@@ -157,24 +192,21 @@ export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Pro
       </ol>
 
       {thread.state === "open" && lastReplyTarget !== undefined ? (
-        <RemoteReplyComposer
-          pending={reply.isPending}
-          onSubmit={(body) => {
-            console.log("[sync-debug] reply mutate", {
-              threadId: thread.threadId,
-              inReplyToCommentId: lastReplyTarget,
-              bodyLen: body.length,
-            });
-            reply.mutate({
-              repoPath,
-              prNumber,
-              threadId: thread.threadId,
-              inReplyToCommentId: lastReplyTarget,
-              body,
-            });
-          }}
-        />
+        <div onClick={stop} onKeyDown={stop}>
+          <RemoteReplyComposer
+            pending={reply.isPending}
+            onSubmit={(body) =>
+              reply.mutate({
+                repoPath,
+                prNumber,
+                threadId: thread.threadId,
+                inReplyToCommentId: lastReplyTarget,
+                body,
+              })
+            }
+          />
+        </div>
       ) : null}
-    </section>
+    </div>
   );
 }

--- a/src/features/sync/components/RemoteThreadCard.tsx
+++ b/src/features/sync/components/RemoteThreadCard.tsx
@@ -15,9 +15,15 @@ interface Props {
   thread: RemoteThread;
   repoPath: string;
   prNumber: number;
+  /**
+   * When set, the file:line breadcrumb at the top of the card becomes a
+   * button that calls back with the thread's anchor — used by the threads
+   * pane to jump from the right rail into the rendered markdown.
+   */
+  onNavigate?: (filePath: string, line: number) => void;
 }
 
-export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
+export function RemoteThreadCard({ thread, repoPath, prNumber, onNavigate }: Props) {
   const { t } = useTranslation();
   const reply = useReplyRemoteThread();
   const edit = useEditRemoteComment();
@@ -28,9 +34,23 @@ export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
   const [editingBody, setEditingBody] = useState("");
 
   const lastReplyTarget = thread.comments.at(-1)?.commentId ?? thread.comments[0]?.commentId;
+  const anchorLine =
+    thread.anchor?.kind === "singleLine"
+      ? thread.anchor.line
+      : (thread.anchor?.startLine ?? thread.line ?? thread.originalLine);
 
   return (
     <section className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--muted))] p-3">
+      {onNavigate ? (
+        <button
+          type="button"
+          onClick={() => onNavigate(thread.path, anchorLine)}
+          className="flex items-baseline gap-1.5 self-start rounded px-1 py-0.5 text-left text-[11px] text-[hsl(var(--muted-foreground))] transition-colors hover:bg-[hsl(var(--accent))]/40 hover:text-[hsl(var(--foreground))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))]"
+        >
+          <span className="truncate font-medium">{thread.path}</span>
+          <span className="font-mono">L{anchorLine}</span>
+        </button>
+      ) : null}
       <header className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Badge tone={thread.state === "resolved" ? "success" : "default"}>

--- a/src/features/sync/components/RemoteThreadCard.tsx
+++ b/src/features/sync/components/RemoteThreadCard.tsx
@@ -47,7 +47,13 @@ export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => resolve.mutate({ repoPath, prNumber, threadId: thread.threadId })}
+            onClick={() => {
+              console.log("[sync-debug] resolve click", {
+                threadId: thread.threadId,
+                viewerCanResolve: thread.viewerCanResolve,
+              });
+              resolve.mutate({ repoPath, prNumber, threadId: thread.threadId });
+            }}
             disabled={resolve.isPending}
           >
             {t("sync.actions.resolve")}
@@ -133,15 +139,20 @@ export function RemoteThreadCard({ thread, repoPath, prNumber }: Props) {
       {thread.state === "open" && lastReplyTarget !== undefined ? (
         <RemoteReplyComposer
           pending={reply.isPending}
-          onSubmit={(body) =>
+          onSubmit={(body) => {
+            console.log("[sync-debug] reply mutate", {
+              threadId: thread.threadId,
+              inReplyToCommentId: lastReplyTarget,
+              bodyLen: body.length,
+            });
             reply.mutate({
               repoPath,
               prNumber,
               threadId: thread.threadId,
               inReplyToCommentId: lastReplyTarget,
               body,
-            })
-          }
+            });
+          }}
         />
       ) : null}
     </section>

--- a/src/features/sync/components/UnmappedThreadsSection.tsx
+++ b/src/features/sync/components/UnmappedThreadsSection.tsx
@@ -1,0 +1,71 @@
+import type { RemoteThread } from "@/shared/ipc/contract";
+import { Button } from "@/shared/ui/button";
+import { ChevronDownIcon, ChevronRightIcon, ExternalLinkIcon } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { describeUnmappedReason } from "../lib/unmappedReason";
+
+interface Props {
+  threads: RemoteThread[];
+}
+
+export function UnmappedThreadsSection({ threads }: Props) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  if (threads.length === 0) return null;
+  const Chevron = open ? ChevronDownIcon : ChevronRightIcon;
+  return (
+    <section className="border-t border-[hsl(var(--border))] px-4 py-3">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 text-left text-xs font-semibold text-[hsl(var(--foreground))]"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Chevron className="size-3.5" />
+        {t("sync.section.unmappedHeading")} ({threads.length})
+      </button>
+      {open ? (
+        <div className="mt-2 flex flex-col gap-2">
+          <p className="text-[11px] text-[hsl(var(--muted-foreground))]">
+            {t("sync.section.unmappedSubtitle")}
+          </p>
+          <ul className="flex flex-col gap-2">
+            {threads.map((thread) => {
+              const firstComment = thread.comments[0];
+              return (
+                <li
+                  key={thread.threadId}
+                  className="flex flex-col gap-1 rounded-md border border-dashed border-[hsl(var(--border))] p-2"
+                >
+                  <span className="text-xs font-medium text-[hsl(var(--foreground))]">
+                    {describeUnmappedReason(thread, t)}
+                  </span>
+                  {firstComment ? (
+                    <span className="line-clamp-2 text-[11px] text-[hsl(var(--muted-foreground))]">
+                      {t("sync.thread.byAuthor", { author: firstComment.author })}:{" "}
+                      {firstComment.body}
+                    </span>
+                  ) : null}
+                  {firstComment ? (
+                    <Button
+                      asChild
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 w-fit gap-1 px-2 text-[11px]"
+                    >
+                      <a href={firstComment.htmlUrl} target="_blank" rel="noreferrer">
+                        <ExternalLinkIcon className="size-3" />
+                        {t("sync.section.openOnGithub")}
+                      </a>
+                    </Button>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/features/sync/hooks/index.ts
+++ b/src/features/sync/hooks/index.ts
@@ -1,0 +1,6 @@
+export { useRemoteThreads, remoteThreadsKey } from "./useRemoteThreads";
+export { useReplyRemoteThread } from "./useReplyRemoteThread";
+export { useEditRemoteComment } from "./useEditRemoteComment";
+export { useDeleteRemoteComment } from "./useDeleteRemoteComment";
+export { useResolveRemoteThread } from "./useResolveRemoteThread";
+export { useReopenRemoteThread } from "./useReopenRemoteThread";

--- a/src/features/sync/hooks/useDeleteRemoteComment.ts
+++ b/src/features/sync/hooks/useDeleteRemoteComment.ts
@@ -19,19 +19,20 @@ export function useDeleteRemoteComment() {
       if (!result.ok) throw result.error;
     },
     onSuccess: (_void, { repoPath, prNumber, threadId, commentId }) => {
+      // Walk both buckets so a delete on a thread whose anchor went
+      // unmapped also drops the comment from the cache.
+      const dropComment = (t: import("@/shared/ipc/contract").RemoteThread) =>
+        t.threadId === threadId
+          ? { ...t, comments: t.comments.filter((c) => c.commentId !== commentId) }
+          : t;
       qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
         if (!prev) return prev;
         return {
           ...prev,
-          threads: prev.threads
-            .map((t) =>
-              t.threadId === threadId
-                ? { ...t, comments: t.comments.filter((c) => c.commentId !== commentId) }
-                : t,
-            )
-            // Drop the thread when its last comment is gone — matches what
-            // GitHub does on the web.
-            .filter((t) => t.comments.length > 0),
+          // Drop the thread when its last comment is gone — matches what
+          // GitHub does on the web.
+          threads: prev.threads.map(dropComment).filter((t) => t.comments.length > 0),
+          unmapped: prev.unmapped.map(dropComment).filter((t) => t.comments.length > 0),
         };
       });
     },

--- a/src/features/sync/hooks/useDeleteRemoteComment.ts
+++ b/src/features/sync/hooks/useDeleteRemoteComment.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/shared/ipc/client";
 import type { RefreshResult } from "@/shared/ipc/contract";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showMutationError } from "../lib/showError";
 import { remoteThreadsKey } from "./useRemoteThreads";
 
 interface Vars {
@@ -34,5 +35,6 @@ export function useDeleteRemoteComment() {
         };
       });
     },
+    onError: showMutationError,
   });
 }

--- a/src/features/sync/hooks/useDeleteRemoteComment.ts
+++ b/src/features/sync/hooks/useDeleteRemoteComment.ts
@@ -1,0 +1,38 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  commentId: number;
+}
+
+export function useDeleteRemoteComment() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, Vars>({
+    mutationFn: async ({ repoPath, commentId }) => {
+      const result = await ipc.sync.delete(repoPath, commentId);
+      if (!result.ok) throw result.error;
+    },
+    onSuccess: (_void, { repoPath, prNumber, threadId, commentId }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads
+            .map((t) =>
+              t.threadId === threadId
+                ? { ...t, comments: t.comments.filter((c) => c.commentId !== commentId) }
+                : t,
+            )
+            // Drop the thread when its last comment is gone — matches what
+            // GitHub does on the web.
+            .filter((t) => t.comments.length > 0),
+        };
+      });
+    },
+  });
+}

--- a/src/features/sync/hooks/useEditRemoteComment.ts
+++ b/src/features/sync/hooks/useEditRemoteComment.ts
@@ -1,0 +1,39 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteComment } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  commentId: number;
+  body: string;
+}
+
+export function useEditRemoteComment() {
+  const qc = useQueryClient();
+  return useMutation<RemoteComment, Error, Vars>({
+    mutationFn: async ({ repoPath, commentId, body }) => {
+      const result = await ipc.sync.edit(repoPath, commentId, body);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber, threadId, commentId }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) =>
+            t.threadId === threadId
+              ? {
+                  ...t,
+                  comments: t.comments.map((c) => (c.commentId === commentId ? updated : c)),
+                }
+              : t,
+          ),
+        };
+      });
+    },
+  });
+}

--- a/src/features/sync/hooks/useEditRemoteComment.ts
+++ b/src/features/sync/hooks/useEditRemoteComment.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/shared/ipc/client";
 import type { RefreshResult, RemoteComment } from "@/shared/ipc/contract";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showMutationError } from "../lib/showError";
 import { remoteThreadsKey } from "./useRemoteThreads";
 
 interface Vars {
@@ -35,5 +36,6 @@ export function useEditRemoteComment() {
         };
       });
     },
+    onError: showMutationError,
   });
 }

--- a/src/features/sync/hooks/useEditRemoteComment.ts
+++ b/src/features/sync/hooks/useEditRemoteComment.ts
@@ -21,18 +21,18 @@ export function useEditRemoteComment() {
       return result.value;
     },
     onSuccess: (updated, { repoPath, prNumber, threadId, commentId }) => {
+      // Walk both `threads` and `unmapped` so an edit on a thread whose
+      // anchor went unmapped still patches the cache.
+      const patchComments = (t: import("@/shared/ipc/contract").RemoteThread) =>
+        t.threadId === threadId
+          ? { ...t, comments: t.comments.map((c) => (c.commentId === commentId ? updated : c)) }
+          : t;
       qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
         if (!prev) return prev;
         return {
           ...prev,
-          threads: prev.threads.map((t) =>
-            t.threadId === threadId
-              ? {
-                  ...t,
-                  comments: t.comments.map((c) => (c.commentId === commentId ? updated : c)),
-                }
-              : t,
-          ),
+          threads: prev.threads.map(patchComments),
+          unmapped: prev.unmapped.map(patchComments),
         };
       });
     },

--- a/src/features/sync/hooks/useRemoteThreads.ts
+++ b/src/features/sync/hooks/useRemoteThreads.ts
@@ -1,0 +1,48 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult } from "@/shared/ipc/contract";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+interface Options {
+  repoPath?: string;
+  prNumber?: number;
+  headSha?: string;
+}
+
+export function remoteThreadsKey(repoPath: string, prNumber: number) {
+  return ["remote-threads", repoPath, prNumber] as const;
+}
+
+/**
+ * Loads remote review threads for `(repoPath, prNumber)`. On mount we read
+ * the SQLite cache; the user must click Refresh to hit GitHub. Both the
+ * initial cache read and the manual refresh return the same `RefreshResult`
+ * shape so the consumer doesn't care which path produced it.
+ */
+export function useRemoteThreads({ repoPath, prNumber, headSha }: Options) {
+  const qc = useQueryClient();
+  const enabled = Boolean(repoPath && prNumber !== undefined);
+  const query = useQuery<RefreshResult | null>({
+    queryKey:
+      enabled && repoPath && prNumber !== undefined
+        ? remoteThreadsKey(repoPath, prNumber)
+        : ["remote-threads", "disabled"],
+    enabled,
+    staleTime: Number.POSITIVE_INFINITY, // never auto-refetch — refresh is explicit
+    queryFn: async () => {
+      if (!repoPath || prNumber === undefined) return null;
+      const result = await ipc.sync.getCached(repoPath, prNumber);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+  });
+
+  const refresh = async (): Promise<RefreshResult | null> => {
+    if (!repoPath || prNumber === undefined || !headSha) return null;
+    const result = await ipc.sync.refresh(repoPath, prNumber, headSha);
+    if (!result.ok) throw result.error;
+    qc.setQueryData(remoteThreadsKey(repoPath, prNumber), result.value);
+    return result.value;
+  };
+
+  return { ...query, refresh };
+}

--- a/src/features/sync/hooks/useReopenRemoteThread.ts
+++ b/src/features/sync/hooks/useReopenRemoteThread.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/shared/ipc/client";
 import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showMutationError } from "../lib/showError";
 import { remoteThreadsKey } from "./useRemoteThreads";
 
 interface Vars {
@@ -26,5 +27,6 @@ export function useReopenRemoteThread() {
         };
       });
     },
+    onError: showMutationError,
   });
 }

--- a/src/features/sync/hooks/useReopenRemoteThread.ts
+++ b/src/features/sync/hooks/useReopenRemoteThread.ts
@@ -1,0 +1,30 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+}
+
+export function useReopenRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteThread, Error, Vars>({
+    mutationFn: async ({ repoPath, threadId }) => {
+      const result = await ipc.sync.reopen(repoPath, threadId);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) => (t.threadId === updated.threadId ? updated : t)),
+        };
+      });
+    },
+  });
+}

--- a/src/features/sync/hooks/useReplyRemoteThread.ts
+++ b/src/features/sync/hooks/useReplyRemoteThread.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/shared/ipc/client";
 import type { RefreshResult, RemoteComment, RemoteThread } from "@/shared/ipc/contract";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showMutationError } from "../lib/showError";
 import { remoteThreadsKey } from "./useRemoteThreads";
 
 interface Vars {
@@ -26,6 +27,7 @@ export function useReplyRemoteThread() {
           prev && patchThread(prev, threadId, (t) => ({ ...t, comments: [...t.comments, added] })),
       );
     },
+    onError: showMutationError,
   });
 }
 

--- a/src/features/sync/hooks/useReplyRemoteThread.ts
+++ b/src/features/sync/hooks/useReplyRemoteThread.ts
@@ -1,0 +1,41 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteComment, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+  inReplyToCommentId: number;
+  body: string;
+}
+
+export function useReplyRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteComment, Error, Vars>({
+    mutationFn: async ({ repoPath, prNumber, inReplyToCommentId, body }) => {
+      const result = await ipc.sync.reply(repoPath, prNumber, inReplyToCommentId, body);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (added, { repoPath, prNumber, threadId }) => {
+      qc.setQueryData<RefreshResult | null>(
+        remoteThreadsKey(repoPath, prNumber),
+        (prev) =>
+          prev && patchThread(prev, threadId, (t) => ({ ...t, comments: [...t.comments, added] })),
+      );
+    },
+  });
+}
+
+function patchThread(
+  prev: RefreshResult,
+  threadId: string,
+  patch: (t: RemoteThread) => RemoteThread,
+): RefreshResult {
+  return {
+    ...prev,
+    threads: prev.threads.map((t) => (t.threadId === threadId ? patch(t) : t)),
+  };
+}

--- a/src/features/sync/hooks/useReplyRemoteThread.ts
+++ b/src/features/sync/hooks/useReplyRemoteThread.ts
@@ -36,8 +36,13 @@ function patchThread(
   threadId: string,
   patch: (t: RemoteThread) => RemoteThread,
 ): RefreshResult {
+  // Walk both buckets — a reply to a thread whose anchor became unmapped
+  // (file/line moved) still needs the optimistic cache update, otherwise
+  // the new comment won't appear in the Unmapped section until the next
+  // refresh.
   return {
     ...prev,
     threads: prev.threads.map((t) => (t.threadId === threadId ? patch(t) : t)),
+    unmapped: prev.unmapped.map((t) => (t.threadId === threadId ? patch(t) : t)),
   };
 }

--- a/src/features/sync/hooks/useResolveRemoteThread.ts
+++ b/src/features/sync/hooks/useResolveRemoteThread.ts
@@ -1,0 +1,30 @@
+import { ipc } from "@/shared/ipc/client";
+import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { remoteThreadsKey } from "./useRemoteThreads";
+
+interface Vars {
+  repoPath: string;
+  prNumber: number;
+  threadId: string;
+}
+
+export function useResolveRemoteThread() {
+  const qc = useQueryClient();
+  return useMutation<RemoteThread, Error, Vars>({
+    mutationFn: async ({ repoPath, threadId }) => {
+      const result = await ipc.sync.resolve(repoPath, threadId);
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (updated, { repoPath, prNumber }) => {
+      qc.setQueryData<RefreshResult | null>(remoteThreadsKey(repoPath, prNumber), (prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          threads: prev.threads.map((t) => (t.threadId === updated.threadId ? updated : t)),
+        };
+      });
+    },
+  });
+}

--- a/src/features/sync/hooks/useResolveRemoteThread.ts
+++ b/src/features/sync/hooks/useResolveRemoteThread.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/shared/ipc/client";
 import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { showMutationError } from "../lib/showError";
 import { remoteThreadsKey } from "./useRemoteThreads";
 
 interface Vars {
@@ -26,5 +27,6 @@ export function useResolveRemoteThread() {
         };
       });
     },
+    onError: showMutationError,
   });
 }

--- a/src/features/sync/index.ts
+++ b/src/features/sync/index.ts
@@ -6,5 +6,7 @@ export { useEditRemoteComment } from "./hooks/useEditRemoteComment";
 export { useDeleteRemoteComment } from "./hooks/useDeleteRemoteComment";
 export { useResolveRemoteThread } from "./hooks/useResolveRemoteThread";
 export { useReopenRemoteThread } from "./hooks/useReopenRemoteThread";
+export { findThreadByCommentId } from "./lib/findThreadByCommentId";
 export { mergeLocalAndRemote } from "./lib/mergeLocalAndRemote";
 export type { MergedEntry } from "./lib/mergeLocalAndRemote";
+export { showMutationError } from "./lib/showError";

--- a/src/features/sync/index.ts
+++ b/src/features/sync/index.ts
@@ -1,1 +1,10 @@
-// Placeholder for Phase 2+ — this feature lives here.
+export { RemoteThreadCard } from "./components/RemoteThreadCard";
+export { UnmappedThreadsSection } from "./components/UnmappedThreadsSection";
+export { useRemoteThreads, remoteThreadsKey } from "./hooks/useRemoteThreads";
+export { useReplyRemoteThread } from "./hooks/useReplyRemoteThread";
+export { useEditRemoteComment } from "./hooks/useEditRemoteComment";
+export { useDeleteRemoteComment } from "./hooks/useDeleteRemoteComment";
+export { useResolveRemoteThread } from "./hooks/useResolveRemoteThread";
+export { useReopenRemoteThread } from "./hooks/useReopenRemoteThread";
+export { mergeLocalAndRemote } from "./lib/mergeLocalAndRemote";
+export type { MergedEntry } from "./lib/mergeLocalAndRemote";

--- a/src/features/sync/lib/findThreadByCommentId.ts
+++ b/src/features/sync/lib/findThreadByCommentId.ts
@@ -1,0 +1,21 @@
+import type { RefreshResult, RemoteThread } from "@/shared/ipc/contract";
+
+/**
+ * Locates the remote thread that contains the comment with the given
+ * REST `comment_id`. Used to bridge a local "submitted" comment (which
+ * only knows its `githubId`) to the thread node id required by the
+ * resolve / unresolve / reply mutations.
+ */
+export function findThreadByCommentId(
+  cache: RefreshResult | null | undefined,
+  githubId: number,
+): RemoteThread | undefined {
+  if (!cache) return undefined;
+  for (const thread of cache.threads) {
+    if (thread.comments.some((c) => c.commentId === githubId)) return thread;
+  }
+  for (const thread of cache.unmapped) {
+    if (thread.comments.some((c) => c.commentId === githubId)) return thread;
+  }
+  return undefined;
+}

--- a/src/features/sync/lib/mergeLocalAndRemote.test.ts
+++ b/src/features/sync/lib/mergeLocalAndRemote.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "bun:test";
+import type { RemoteThread, ReviewComment } from "@/shared/ipc/contract";
+import { mergeLocalAndRemote } from "./mergeLocalAndRemote";
+
+function local(id: number, githubId: number | null = null): ReviewComment {
+  return {
+    id,
+    prNumber: 7,
+    filePath: "doc.md",
+    headSha: "abc",
+    body: "local body",
+    author: "me",
+    state: githubId ? "submitted" : "draft",
+    anchor: { kind: "singleLine", line: 4 },
+    createdAt: 0,
+    updatedAt: 0,
+    githubId,
+    submitError: null,
+  };
+}
+
+function remote(id: string, commentId: number, line: number): RemoteThread {
+  return {
+    threadId: id,
+    path: "doc.md",
+    originalCommitId: "abc",
+    line,
+    startLine: null,
+    originalLine: line,
+    originalStartLine: null,
+    state: "open",
+    isOutdated: false,
+    viewerCanResolve: true,
+    viewerCanUnresolve: false,
+    comments: [
+      {
+        commentId,
+        author: "alice",
+        authorAvatarUrl: null,
+        body: "remote body",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+        viewerCanUpdate: false,
+        viewerCanDelete: false,
+        htmlUrl: "https://",
+      },
+    ],
+    anchor: { kind: "singleLine", line },
+    mappingStatus: { kind: "mapped" },
+  };
+}
+
+test("orders entries by file then start line", () => {
+  const merged = mergeLocalAndRemote([local(1)], [remote("T1", 100, 1)]);
+  expect(merged.map((e) => (e.kind === "remote" ? e.thread.threadId : `L${e.comment.id}`))).toEqual(
+    ["T1", "L1"],
+  );
+});
+
+test("drops local submitted comment when its githubId matches a remote one", () => {
+  const merged = mergeLocalAndRemote([local(1, 100)], [remote("T1", 100, 4)]);
+  expect(merged.length).toBe(1);
+  expect(merged[0].kind).toBe("remote");
+});
+
+test("keeps local drafts even at the same anchor", () => {
+  const merged = mergeLocalAndRemote([local(1, null)], [remote("T1", 100, 4)]);
+  expect(merged.length).toBe(2);
+});

--- a/src/features/sync/lib/mergeLocalAndRemote.test.ts
+++ b/src/features/sync/lib/mergeLocalAndRemote.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import type { RemoteThread, ReviewComment } from "@/shared/ipc/contract";
 import { mergeLocalAndRemote } from "./mergeLocalAndRemote";
 
@@ -60,7 +60,7 @@ test("orders entries by file then start line", () => {
 test("drops local submitted comment when its githubId matches a remote one", () => {
   const merged = mergeLocalAndRemote([local(1, 100)], [remote("T1", 100, 4)]);
   expect(merged.length).toBe(1);
-  expect(merged[0].kind).toBe("remote");
+  expect(merged[0]?.kind).toBe("remote");
 });
 
 test("keeps local drafts even at the same anchor", () => {

--- a/src/features/sync/lib/mergeLocalAndRemote.ts
+++ b/src/features/sync/lib/mergeLocalAndRemote.ts
@@ -1,0 +1,60 @@
+import type { CommentAnchor, RemoteThread, ReviewComment } from "@/shared/ipc/contract";
+
+export type MergedEntry =
+  | { kind: "remote"; key: string; filePath: string; startLine: number; thread: RemoteThread }
+  | { kind: "local"; key: string; filePath: string; startLine: number; comment: ReviewComment };
+
+function anchorStart(anchor: CommentAnchor): number {
+  return anchor.kind === "singleLine" ? anchor.line : anchor.startLine;
+}
+
+/**
+ * Merges local comments and mapped remote threads into a stable ordered list.
+ * Any local comment whose `githubId` matches a `RemoteComment.commentId` is
+ * dropped — the remote thread carries the richer data (replies, viewerCan*,
+ * resolved state), so showing both would be a confusing duplicate.
+ *
+ * Sort key: filePath, then anchor start line, then a stable tiebreaker
+ * (`threadId` for remote, `id` for local).
+ */
+export function mergeLocalAndRemote(
+  local: ReviewComment[],
+  remote: RemoteThread[],
+): MergedEntry[] {
+  const remoteCommentIds = new Set<number>();
+  for (const thread of remote) {
+    for (const c of thread.comments) remoteCommentIds.add(c.commentId);
+  }
+
+  const entries: MergedEntry[] = [];
+
+  for (const thread of remote) {
+    if (!thread.anchor) continue; // unmapped goes elsewhere
+    entries.push({
+      kind: "remote",
+      key: `remote:${thread.threadId}`,
+      filePath: thread.path,
+      startLine: anchorStart(thread.anchor),
+      thread,
+    });
+  }
+
+  for (const comment of local) {
+    if (comment.githubId !== null && remoteCommentIds.has(comment.githubId)) continue;
+    entries.push({
+      kind: "local",
+      key: `local:${comment.id}`,
+      filePath: comment.filePath,
+      startLine: anchorStart(comment.anchor),
+      comment,
+    });
+  }
+
+  entries.sort((a, b) => {
+    if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+    if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+    return a.key.localeCompare(b.key);
+  });
+
+  return entries;
+}

--- a/src/features/sync/lib/mergeLocalAndRemote.ts
+++ b/src/features/sync/lib/mergeLocalAndRemote.ts
@@ -17,10 +17,7 @@ function anchorStart(anchor: CommentAnchor): number {
  * Sort key: filePath, then anchor start line, then a stable tiebreaker
  * (`threadId` for remote, `id` for local).
  */
-export function mergeLocalAndRemote(
-  local: ReviewComment[],
-  remote: RemoteThread[],
-): MergedEntry[] {
+export function mergeLocalAndRemote(local: ReviewComment[], remote: RemoteThread[]): MergedEntry[] {
   const remoteCommentIds = new Set<number>();
   for (const thread of remote) {
     for (const c of thread.comments) remoteCommentIds.add(c.commentId);

--- a/src/features/sync/lib/showError.ts
+++ b/src/features/sync/lib/showError.ts
@@ -1,0 +1,21 @@
+import { describeError, isAppError } from "@/shared/ipc/errors";
+import { createLogger } from "@/shared/lib/logger";
+
+const log = createLogger("sync");
+
+/**
+ * Default `onError` handler for sync mutations. Without it, React Query
+ * stores the failure on the mutation object and nothing reaches the user —
+ * so a click on "Resolve" looks like it did nothing.
+ *
+ * For Phase 6 we surface the failure via `window.alert`; a toast component
+ * is a follow-up. The error is also logged so it shows up in the dev
+ * console for debugging.
+ */
+export function showMutationError(error: unknown) {
+  log.error("sync mutation failed", error);
+  const view = isAppError(error)
+    ? describeError(error)
+    : { title: "Something went wrong", description: String(error) };
+  window.alert(`${view.title}\n\n${view.description}`);
+}

--- a/src/features/sync/lib/showError.ts
+++ b/src/features/sync/lib/showError.ts
@@ -1,3 +1,4 @@
+import { i18next } from "@/shared/i18n";
 import { describeError, isAppError } from "@/shared/ipc/errors";
 import { createLogger } from "@/shared/lib/logger";
 
@@ -14,8 +15,12 @@ const log = createLogger("sync");
  */
 export function showMutationError(error: unknown) {
   log.error("sync mutation failed", error);
+  const t = i18next.t.bind(i18next);
   const view = isAppError(error)
     ? describeError(error)
-    : { title: "Something went wrong", description: String(error) };
+    : {
+        title: t("errors.generic.title"),
+        description: error instanceof Error ? error.message : String(error),
+      };
   window.alert(`${view.title}\n\n${view.description}`);
 }

--- a/src/features/sync/lib/unmappedReason.ts
+++ b/src/features/sync/lib/unmappedReason.ts
@@ -1,0 +1,24 @@
+import type { RemoteThread } from "@/shared/ipc/contract";
+import type { TFunction } from "i18next";
+
+export function describeUnmappedReason(thread: RemoteThread, t: TFunction): string {
+  const status = thread.mappingStatus;
+  switch (status.kind) {
+    case "fileMissing":
+      return t("sync.unmapped.fileMissing", { path: thread.path });
+    case "lineMoved":
+      return t("sync.unmapped.lineMoved", {
+        path: thread.path,
+        line: thread.originalLine,
+      });
+    case "ambiguous":
+      return t("sync.unmapped.ambiguous", { path: thread.path });
+    case "outdated":
+      return t("sync.unmapped.outdated");
+    case "mapped":
+      // Defensive: an unmapped thread should never report Mapped, but
+      // returning a sensible message keeps the UI from crashing on stale
+      // payloads.
+      return t("sync.unmapped.outdated");
+  }
+}

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -228,7 +228,8 @@
       "cancel": "Cancel",
       "save": "Save",
       "send": "Send reply",
-      "deleteConfirm": "Delete this comment? This cannot be undone."
+      "deleteConfirm": "Delete this comment? This cannot be undone.",
+      "openInPreview": "Open {{path}} at line {{line}}"
     },
     "thread": {
       "replyPlaceholder": "Write a reply…",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -200,6 +200,50 @@
       "jumpAria": "Jump to comment thread"
     }
   },
+  "sync": {
+    "section": {
+      "remoteHeading": "GitHub threads",
+      "unmappedHeading": "Unmapped threads",
+      "unmappedSubtitle": "These remote threads couldn't be anchored to a line in the current head.",
+      "truncatedWarning": "Showing the first 100 review threads. Older threads will sync once pagination is implemented.",
+      "emptyMapped": "No remote review threads on this pull request yet.",
+      "openOnGithub": "Open on GitHub"
+    },
+    "actions": {
+      "reply": "Reply",
+      "edit": "Edit",
+      "delete": "Delete",
+      "resolve": "Mark as resolved",
+      "reopen": "Reopen thread",
+      "cancel": "Cancel",
+      "save": "Save",
+      "send": "Send reply",
+      "deleteConfirm": "Delete this comment? This cannot be undone."
+    },
+    "thread": {
+      "replyPlaceholder": "Write a reply…",
+      "editPlaceholder": "Edit your comment…",
+      "byAuthor": "by {{author}}",
+      "edited": "edited",
+      "resolvedBadge": "Resolved",
+      "openBadge": "Open",
+      "outdatedBadge": "Outdated",
+      "readOnlyTooltip": "You can only edit or delete your own comments."
+    },
+    "unmapped": {
+      "fileMissing": "File no longer in this PR head ({{path}})",
+      "lineMoved": "Original snippet no longer found at {{path}}:{{line}}",
+      "ambiguous": "Snippet matches multiple positions in {{path}}",
+      "outdated": "GitHub marked this thread as outdated"
+    },
+    "errors": {
+      "refreshFailedTitle": "Couldn't refresh remote threads",
+      "refreshFailedDescription": "We kept the cached threads. Try refreshing again.",
+      "mutationFailedTitle": "Action failed",
+      "readOnlyTitle": "Read-only on GitHub",
+      "readOnlyDescription": "GitHub didn't allow this action — you may need write access on the repository."
+    }
+  },
   "errors": {
     "invalidPath": {
       "title": "Invalid folder",

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -252,7 +252,11 @@
       "refreshFailedDescription": "We kept the cached threads. Try refreshing again.",
       "mutationFailedTitle": "Action failed",
       "readOnlyTitle": "Read-only on GitHub",
-      "readOnlyDescription": "GitHub didn't allow this action — you may need write access on the repository."
+      "readOnlyDescription": "GitHub didn't allow this action — you may need write access on the repository.",
+      "replyDraftBlocked": "Submit the review before replying — drafts don't have a GitHub thread yet.",
+      "missingRepoContext": "Reload the pull request and try again.",
+      "threadNotFoundOnReply": "Couldn't find this comment's GitHub thread. Click Refresh and try again.",
+      "threadNotFoundOnResolve": "Couldn't find this comment's GitHub thread. Click Refresh and resolve again."
     }
   },
   "errors": {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -256,7 +256,8 @@
       "replyDraftBlocked": "Submit the review before replying — drafts don't have a GitHub thread yet.",
       "missingRepoContext": "Reload the pull request and try again.",
       "threadNotFoundOnReply": "Couldn't find this comment's GitHub thread. Click Refresh and try again.",
-      "threadNotFoundOnResolve": "Couldn't find this comment's GitHub thread. Click Refresh and resolve again."
+      "threadNotFoundOnResolve": "Couldn't find this comment's GitHub thread. Click Refresh and resolve again.",
+      "localOnlyHint": "The comment is marked as {{state}} locally, but the GitHub thread didn't sync. The next refresh will reconcile."
     }
   },
   "errors": {

--- a/src/shared/i18n/locales/en.json
+++ b/src/shared/i18n/locales/en.json
@@ -12,6 +12,16 @@
       "somethingWrong": "Something went wrong",
       "notFoundTitle": "Not found",
       "notFoundDescription": "The screen you tried to open doesn't exist."
+    },
+    "finishReview": {
+      "noDraftsTooltip": "Write at least one draft comment before finishing the review.",
+      "tooltip_one": "Submit {{count}} draft comment to GitHub.",
+      "tooltip_other": "Submit {{count}} draft comments to GitHub.",
+      "success_one": "Sent {{count}} comment to GitHub.",
+      "success_other": "Sent {{count}} comments to GitHub.",
+      "partial": "Sent {{submitted}} of {{total}} comments. {{failed}} failed — check the threads pane for details.",
+      "allFailed": "None of the {{total}} comments could be sent.\n\n{{error}}",
+      "failedTitle": "Couldn't submit the review"
     }
   },
   "rail": {

--- a/src/shared/ipc/client.ts
+++ b/src/shared/ipc/client.ts
@@ -73,4 +73,27 @@ export const ipc = {
     submitReview: (repoPath: string, prNumber: number, commentIds: number[]) =>
       call("submit_review", { repoPath, prNumber, commentIds }),
   },
+  sync: {
+    refresh(repoPath: string, prNumber: number, headSha: string) {
+      return call("refresh_remote_comments", { repoPath, prNumber, headSha });
+    },
+    getCached(repoPath: string, prNumber: number) {
+      return call("get_cached_remote_threads", { repoPath, prNumber });
+    },
+    reply(repoPath: string, prNumber: number, inReplyToCommentId: number, body: string) {
+      return call("reply_remote_thread", { repoPath, prNumber, inReplyToCommentId, body });
+    },
+    edit(repoPath: string, commentId: number, body: string) {
+      return call("edit_remote_comment", { repoPath, commentId, body });
+    },
+    delete(repoPath: string, commentId: number) {
+      return call("delete_remote_comment", { repoPath, commentId });
+    },
+    resolve(repoPath: string, threadId: string) {
+      return call("resolve_remote_thread", { repoPath, threadId });
+    },
+    reopen(repoPath: string, threadId: string) {
+      return call("reopen_remote_thread", { repoPath, threadId });
+    },
+  },
 };

--- a/src/shared/ipc/contract.ts
+++ b/src/shared/ipc/contract.ts
@@ -136,6 +136,50 @@ export interface ReviewSubmissionResult {
   allSubmitted: boolean;
 }
 
+export type ThreadState = "open" | "resolved";
+
+export type MappingStatus =
+  | { kind: "mapped" }
+  | { kind: "outdated"; reason: string }
+  | { kind: "fileMissing" }
+  | { kind: "lineMoved" }
+  | { kind: "ambiguous" };
+
+export interface RemoteComment {
+  commentId: number;
+  author: string;
+  authorAvatarUrl: string | null;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  viewerCanUpdate: boolean;
+  viewerCanDelete: boolean;
+  htmlUrl: string;
+}
+
+export interface RemoteThread {
+  threadId: string;
+  path: string;
+  originalCommitId: string;
+  line: number | null;
+  startLine: number | null;
+  originalLine: number;
+  originalStartLine: number | null;
+  state: ThreadState;
+  isOutdated: boolean;
+  viewerCanResolve: boolean;
+  viewerCanUnresolve: boolean;
+  comments: RemoteComment[];
+  anchor: CommentAnchor | null;
+  mappingStatus: MappingStatus;
+}
+
+export interface RefreshResult {
+  threads: RemoteThread[];
+  unmapped: RemoteThread[];
+  refreshedAtMs: number;
+}
+
 export type AppError =
   | { kind: "invalidPath"; data: { path: string } }
   | { kind: "notAGitRepo"; data: { path: string } }
@@ -205,6 +249,34 @@ export interface Commands {
   submit_review: {
     args: { repoPath: string; prNumber: number; commentIds: number[] };
     result: ReviewSubmissionResult;
+  };
+  refresh_remote_comments: {
+    args: { repoPath: string; prNumber: number; headSha: string };
+    result: RefreshResult;
+  };
+  get_cached_remote_threads: {
+    args: { repoPath: string; prNumber: number };
+    result: RefreshResult | null;
+  };
+  reply_remote_thread: {
+    args: { repoPath: string; prNumber: number; inReplyToCommentId: number; body: string };
+    result: RemoteComment;
+  };
+  edit_remote_comment: {
+    args: { repoPath: string; commentId: number; body: string };
+    result: RemoteComment;
+  };
+  delete_remote_comment: {
+    args: { repoPath: string; commentId: number };
+    result: null;
+  };
+  resolve_remote_thread: {
+    args: { repoPath: string; threadId: string };
+    result: RemoteThread;
+  };
+  reopen_remote_thread: {
+    args: { repoPath: string; threadId: string };
+    result: RemoteThread;
   };
 }
 


### PR DESCRIPTION
## Summary

Implements the four Phase 6 milestone issues in a single branch:

- **#31 — `refresh_remote_comments` + anchor mapping.** Fetches review threads via GraphQL (`gh api graphql reviewThreads`) and maps each to a local anchor (same-commit fast path, snippet relocation across commits, or `MappingStatus::{Outdated, LineMoved, Ambiguous, FileMissing}` when it can't).
- **#32 — Reply / edit / delete / resolve / reopen remote threads.** New `GhClient` methods cover the GitHub REST + GraphQL mutation surface. Viewer-denied (`403`) responses surface as `AppError::Validation` so the UI can render a read-only tooltip.
- **#33 — Per-PR cache with explicit invalidation.** New SQLite table `remote_threads_cache` keyed by `(repo_path, pr_number)`. Cache hydrates on boot; refresh is always explicit (no polling).
- **#34 — Report unmappable remote threads.** Threads that can't be safely anchored land in `RefreshResult.unmapped` and render in a collapsible "Unmapped threads" footer in the threads pane, with the original GitHub URL.

Frontend adds the `src/features/sync/` feature: `useRemoteThreads` hook + 5 mutation hooks, `RemoteThreadCard` / `RemoteReplyComposer` / `UnmappedThreadsSection` components, and a `mergeLocalAndRemote` helper that dedupes local submitted comments against remote ones (so a comment we just submitted doesn't show twice).

The Refresh button in `AppHeader` now triggers `useRemoteThreads.refresh()` alongside the React Query invalidations — one click, one GitHub round-trip.

Spec: `docs/superpowers/specs/2026-05-24-phase-6-github-sync-design.md`
Plan: `docs/superpowers/plans/2026-05-24-phase-6-github-sync.md`

## Test plan

- [x] `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — green (49 unit / integration tests across core + infra)
- [x] `bun run typecheck && bun run check`
- [x] `bun test` — 17 pass (mergeLocalAndRemote + existing comments tests)
- [x] `bun run build:web`
- [ ] Manual smoke on a real PR (per spec verification checklist) — open a PR with one open / one resolved / one outdated thread, refresh, then exercise reply / edit / delete / resolve / reopen.

Closes #31, #32, #33, #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)