### PR TITLE
fix(phase-6): inline rendering + group actions + reply on hidden (v0.2.2)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(python3 -c \"print\\(open\\('/Users/jaovito/.claude/projects/-Users-jaovito-www-markdown-reviewer/9532a2b4-151a-4ccd-97b7-68b0f55faa68/tool-results/mcp-pencil-batch_get-1777062148652.txt'\\).read\\(\\)[0:80000]\\)\")",
       "Bash(python3 -c ' *)",
-      "Bash(python3)"
+      "Bash(python3)",
+      "Bash(gh issue *)"
     ]
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-reviewer-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "fix-path-env",
  "markdown-reviewer-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-infra"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-trait",
  "markdown-reviewer-core",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-ipc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "markdown-reviewer-core",
  "markdown-reviewer-infra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,7 +1862,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markdown-reviewer-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fix-path-env",
  "markdown-reviewer-core",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-infra"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "markdown-reviewer-core",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-reviewer-ipc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "markdown-reviewer-core",
  "markdown-reviewer-infra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/core", "crates/infra", "crates/ipc"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.81"
 license = "UNLICENSED"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["src-tauri", "crates/core", "crates/infra", "crates/ipc"]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.81"
 license = "UNLICENSED"

--- a/design.pen
+++ b/design.pen
@@ -4356,6 +4356,47 @@
                                     },
                                     {
                                       "type": "frame",
+                                      "id": "1pgIx",
+                                      "name": "Delete",
+                                      "height": 28,
+                                      "fill": "#fef2f2",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#fecaca"
+                                      },
+                                      "gap": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon_font",
+                                          "id": "QTndI",
+                                          "name": "deleteIcon",
+                                          "width": 12,
+                                          "height": 12,
+                                          "iconFontName": "trash-2",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#b91c1c"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "1Ln4o",
+                                          "name": "deleteText",
+                                          "fill": "#b91c1c",
+                                          "content": "Delete",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "frame",
                                       "id": "mrexCommentAResolve",
                                       "name": "Resolve",
                                       "height": 28,
@@ -16082,6 +16123,47 @@
                                       "name": "Spacer",
                                       "width": "fill_container",
                                       "height": 1
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "EmyCk",
+                                      "name": "Delete",
+                                      "height": 28,
+                                      "fill": "#fef2f2",
+                                      "cornerRadius": 6,
+                                      "stroke": {
+                                        "align": "inside",
+                                        "thickness": 1,
+                                        "fill": "#fecaca"
+                                      },
+                                      "gap": 6,
+                                      "padding": [
+                                        4,
+                                        10
+                                      ],
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "icon_font",
+                                          "id": "BLbqd",
+                                          "name": "deleteIcon",
+                                          "width": 12,
+                                          "height": 12,
+                                          "iconFontName": "trash-2",
+                                          "iconFontFamily": "lucide",
+                                          "fill": "#b91c1c"
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "INT3J",
+                                          "name": "deleteLabel",
+                                          "fill": "#b91c1c",
+                                          "content": "Delete",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
                                     },
                                     {
                                       "type": "frame",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-reviewer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-reviewer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markdown Reviewer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.weqora.markdown-reviewer",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Markdown Reviewer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.weqora.markdown-reviewer",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -146,8 +146,10 @@ export function InlineThreadCard({
   //   - Submitted/synced head (has githubId) → posts to GitHub.
   //   - Draft head (no githubId)             → stacks another local draft.
   // The card stays out of that decision; it just enables the composer
-  // whenever the parent provides a handler and the head is reachable.
-  const canReply = Boolean(onReplySubmit) && !isHidden;
+  // whenever the parent provides a handler. Hidden groups still allow
+  // reply: the new draft surfaces the conversation again because it
+  // isn't itself hidden, so the "all hidden" group collapse drops.
+  const canReply = Boolean(onReplySubmit);
   const range = isRange(head.anchor);
   const avatarBgVar = range ? "--comment-avatar-range-bg" : "--comment-avatar-bg";
   const cardBorderClass = range

--- a/src/features/comments/components/InlineThreadCard.tsx
+++ b/src/features/comments/components/InlineThreadCard.tsx
@@ -142,7 +142,12 @@ export function InlineThreadCard({
   // Reply is meaningful only when there's a real GitHub thread to attach the
   // reply to. Drafts don't qualify yet — they'll get a remote thread on the
   // next "Finish review".
-  const canReply = Boolean(onReplySubmit) && head.githubId !== null && !isHidden;
+  // Reply works in two modes — the parent's `onReplySubmit` decides which:
+  //   - Submitted/synced head (has githubId) → posts to GitHub.
+  //   - Draft head (no githubId)             → stacks another local draft.
+  // The card stays out of that decision; it just enables the composer
+  // whenever the parent provides a handler and the head is reachable.
+  const canReply = Boolean(onReplySubmit) && !isHidden;
   const range = isRange(head.anchor);
   const avatarBgVar = range ? "--comment-avatar-range-bg" : "--comment-avatar-bg";
   const cardBorderClass = range

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -262,12 +262,53 @@ export function InlineThreads({
     return out;
   }, [remote.data]);
 
+  // Synthesize a fake "local submitted" ReviewComment for each remote thread
+  // on this file that has no local row representing it (e.g. comments posted
+  // by other reviewers, or comments from a session prior to a DB reset). The
+  // `id` is intentionally negative so it never collides with SQLite's
+  // positive AUTOINCREMENT ids, and the handlers below skip `update.mutate`
+  // for negative ids since there's no local row to write to.
+  const remoteOnlyHeads = useMemo<ReviewComment[]>(() => {
+    if (!remote.data) return [];
+    const localCommentIds = new Set<number>();
+    for (const c of comments) {
+      if (c.githubId !== null) localCommentIds.add(c.githubId);
+    }
+    const out: ReviewComment[] = [];
+    for (const thread of remote.data.threads) {
+      if (thread.path !== filePath) continue;
+      if (!thread.anchor) continue;
+      const head = thread.comments[0];
+      if (!head) continue;
+      // If any of the thread's comments already has a local row, that row
+      // is the head — skip this thread to avoid rendering the card twice.
+      if (thread.comments.some((c) => localCommentIds.has(c.commentId))) continue;
+      out.push({
+        id: -head.commentId, // negative ⇒ "synthetic, no local row"
+        prNumber,
+        filePath,
+        headSha,
+        body: head.body,
+        author: head.author,
+        state: thread.state === "resolved" ? "resolved" : "submitted",
+        anchor: thread.anchor,
+        createdAt: Date.parse(head.createdAt) || 0,
+        updatedAt: Date.parse(head.updatedAt) || 0,
+        githubId: head.commentId,
+        submitError: null,
+      });
+    }
+    return out;
+  }, [comments, remote.data, filePath, prNumber, headSha]);
+
+  const allComments = useMemo(() => [...comments, ...remoteOnlyHeads], [comments, remoteOnlyHeads]);
+
   // Memoize groups directly from `comments` — the previous fingerprint missed
   // anchor end-line / kind changes, which left portals pointing at stale
   // slots when an anchor moved. React Query already returns a stable array
   // identity until the underlying data changes, so this re-runs precisely
   // when needed.
-  const groups = useMemo(() => groupCommentsByStartLine(comments), [comments]);
+  const groups = useMemo(() => groupCommentsByStartLine(allComments), [allComments]);
 
   const composerStart = composerAnchor ? anchorStartLine(composerAnchor) : null;
   const composerEnd = composerAnchor
@@ -577,29 +618,43 @@ export function InlineThreads({
                   }
                   onResolve={(c) => {
                     select(c.id);
-                    update.mutate({ id: c.id, patch: { state: "resolved" } });
+                    // Synthetic remote-only rows (id < 0) have no local DB
+                    // record — skip the local update and go straight to
+                    // GitHub. The remote success path patches the cache
+                    // and a future refresh keeps things in sync.
+                    if (c.id >= 0) {
+                      update.mutate({ id: c.id, patch: { state: "resolved" } });
+                    }
                     void syncStateToRemote(c, "resolved");
                   }}
                   onReopen={(c) => {
                     select(c.id);
-                    update.mutate({ id: c.id, patch: { state: "submitted" } });
+                    if (c.id >= 0) {
+                      update.mutate({ id: c.id, patch: { state: "submitted" } });
+                    }
                     void syncStateToRemote(c, "reopen");
                   }}
                   // `Hide` persists `state = hidden` via IPC so the choice survives
                   // restart and a remote refresh. The session-only `minimize` store
                   // still drives the count-badge expand UX (see #21) but it is no
-                  // longer wired to this button.
+                  // longer wired to this button. Hide/Unhide/Delete are local-only
+                  // operations, so we no-op them for remote-only synthetic rows.
                   onHide={(c) => {
+                    if (c.id < 0) return;
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: "hidden" } });
                   }}
                   onUnhide={(c) => {
+                    if (c.id < 0) return;
                     select(c.id);
                     update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
                   }}
                   onReplySubmit={handleReplySubmit}
                   replyPending={replyOnRemoteThread.isPending}
-                  onDelete={(c) => remove.mutate(c.id)}
+                  onDelete={(c) => {
+                    if (c.id < 0) return;
+                    remove.mutate(c.id);
+                  }}
                   onShowStack={(c) => {
                     const target = pickPaneVisibleComment(group.comments, paneFilter, c);
                     // If every comment in the group is filtered out of the pane,

--- a/src/features/comments/components/InlineThreads.tsx
+++ b/src/features/comments/components/InlineThreads.tsx
@@ -179,11 +179,42 @@ export function InlineThreads({
     onError: showMutationError,
   });
 
+  // Reply on a fully-local thread (head is a draft, no GitHub thread yet)
+  // creates another draft anchored to the same line/range. The user can
+  // submit them all in one "Finish review" later. We re-fetch the
+  // local-comments query so the inline grouping picks the new row up
+  // alongside the existing draft.
+  const createDraftReply = useMutation({
+    mutationFn: async ({ head, body }: { head: ReviewComment; body: string }) => {
+      const result = await ipc.comments.create({
+        prNumber: head.prNumber,
+        filePath: head.filePath,
+        headSha: head.headSha,
+        body,
+        author: head.author,
+        anchor: head.anchor,
+      });
+      if (!result.ok) throw result.error;
+      return result.value;
+    },
+    onSuccess: (created) => {
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber] });
+      queryClient.invalidateQueries({ queryKey: ["local-comments", prNumber, filePath] });
+      select(created.id);
+    },
+    onError: showMutationError,
+  });
+
   const handleReplySubmit = useCallback(
     async (head: ReviewComment, body: string) => {
+      if (head.githubId === null) {
+        // Draft head — just stack another local draft at the same anchor.
+        await createDraftReply.mutateAsync({ head, body });
+        return;
+      }
       await replyOnRemoteThread.mutateAsync({ head, body });
     },
-    [replyOnRemoteThread],
+    [createDraftReply, replyOnRemoteThread],
   );
 
   const syncStateToRemote = useCallback(
@@ -618,39 +649,52 @@ export function InlineThreads({
                   }
                   onResolve={(c) => {
                     select(c.id);
-                    // Synthetic remote-only rows (id < 0) have no local DB
-                    // record — skip the local update and go straight to
-                    // GitHub. The remote success path patches the cache
-                    // and a future refresh keeps things in sync.
-                    if (c.id >= 0) {
-                      update.mutate({ id: c.id, patch: { state: "resolved" } });
+                    // Apply the transition to every non-deleted/non-synthetic
+                    // comment in the group — otherwise the second comment on
+                    // the same anchor stays "submitted" and the group never
+                    // reaches the `all resolved` state that collapses it.
+                    for (const target of group.comments) {
+                      if (target.id < 0 || target.state === "deleted") continue;
+                      if (target.state === "resolved") continue;
+                      update.mutate({ id: target.id, patch: { state: "resolved" } });
                     }
                     void syncStateToRemote(c, "resolved");
                   }}
                   onReopen={(c) => {
                     select(c.id);
-                    if (c.id >= 0) {
-                      update.mutate({ id: c.id, patch: { state: "submitted" } });
+                    for (const target of group.comments) {
+                      if (target.id < 0 || target.state === "deleted") continue;
+                      if (target.state === "submitted") continue;
+                      update.mutate({ id: target.id, patch: { state: "submitted" } });
                     }
                     void syncStateToRemote(c, "reopen");
                   }}
-                  // `Hide` persists `state = hidden` via IPC so the choice survives
-                  // restart and a remote refresh. The session-only `minimize` store
-                  // still drives the count-badge expand UX (see #21) but it is no
-                  // longer wired to this button. Hide/Unhide/Delete are local-only
-                  // operations, so we no-op them for remote-only synthetic rows.
+                  // Hide / Unhide / Delete are local-only operations. We
+                  // walk the whole group so the inline marker can collapse
+                  // (HiddenThreadMarker shows up only when EVERY comment in
+                  // the group is hidden). Synthetic remote-only rows are
+                  // skipped — they have no local DB record.
                   onHide={(c) => {
-                    if (c.id < 0) return;
                     select(c.id);
-                    update.mutate({ id: c.id, patch: { state: "hidden" } });
+                    for (const target of group.comments) {
+                      if (target.id < 0) continue;
+                      if (target.state === "hidden" || target.state === "deleted") continue;
+                      update.mutate({ id: target.id, patch: { state: "hidden" } });
+                    }
                   }}
                   onUnhide={(c) => {
-                    if (c.id < 0) return;
                     select(c.id);
-                    update.mutate({ id: c.id, patch: { state: targetUnhideState(c) } });
+                    for (const target of group.comments) {
+                      if (target.id < 0) continue;
+                      if (target.state !== "hidden") continue;
+                      update.mutate({
+                        id: target.id,
+                        patch: { state: targetUnhideState(target) },
+                      });
+                    }
                   }}
                   onReplySubmit={handleReplySubmit}
-                  replyPending={replyOnRemoteThread.isPending}
+                  replyPending={replyOnRemoteThread.isPending || createDraftReply.isPending}
                   onDelete={(c) => {
                     if (c.id < 0) return;
                     remove.mutate(c.id);


### PR DESCRIPTION
## Summary

Patch release follow-up to #57. Two issues:

### 1. GitHub-only threads now render inline

Inline thread cards rendered only when a local comment row existed for the anchor. Threads created by other reviewers on GitHub — or that survived a local DB reset — had no matching local row, so they appeared in the right-rail pane but vanished from the markdown preview itself.

`InlineThreads` now synthesizes a "submitted" `ReviewComment` for each remote thread on the current file that has no local twin. The synthetic row uses a negative `id` (never collides with SQLite `AUTOINCREMENT`) so the resolve/reopen/hide/delete handlers can tell them apart from real rows:

- `onResolve` / `onReopen` skip the local `update.mutate` (no DB row) and go straight to `ipc.sync.*`.
- `onHide` / `onUnhide` / `onDelete` no-op on synthetic rows (those are local-only operations).
- `onReplySubmit` routes through `githubId`, so replies on GitHub-only threads work end-to-end.

### 2. Multi-comment anchor groups: hide / resolve / reply all work now

When two comments shared the same anchor (drafts stacked on a single line), the inline group's behavior was off:

- **Hide / Resolve / Reopen** mutated only the head row, so the group never reached the "all hidden" / "all resolved" condition that triggers `HiddenThreadMarker` / `ResolvedThreadMarker` collapse. Now the handlers walk `group.comments` and transition every non-deleted row.
- **Reply** was hidden when the head was a draft (no `githubId`), leaving the user with no way to add to the group from inside the card. The composer now opens regardless, and the parent routes the submit to either:
  - `ipc.sync.reply` when the head has a `githubId` (real GitHub thread), or
  - `ipc.comments.create` with the head's anchor when it doesn't (stack another local draft).

## Version
`Cargo.toml`, `package.json`, `src-tauri/tauri.conf.json` → `0.2.2` so the release workflow publishes `app-v0.2.2` on merge.

## Test plan
- [ ] PR with a thread you didn't author → refresh → thread shows inline next to the markdown.
- [ ] Resolve / Reply on that inline thread work end-to-end.
- [ ] Two drafts on the same line → click Hide → both collapse to the discreet HiddenThreadMarker.
- [ ] Two drafts on the same line → click Reply → composer opens → another draft stacks at the same anchor.
- [ ] Two submitted comments at same anchor → Resolve → group collapses to ResolvedThreadMarker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)